### PR TITLE
Provided a meaningful value for mocked Fed address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 build
 .vscode
+.idea
 coverage
 coverage.json

--- a/contracts/BridgeMock.sol
+++ b/contracts/BridgeMock.sol
@@ -43,7 +43,7 @@ contract BridgeMock is Bridge {
     function getBtcBlockchainBlockHashAtDepth ( int256 ) external pure override returns (bytes memory) {bytes memory b; return b;}
     function getBtcTxHashProcessedHeight ( string calldata ) external pure override returns (int64) {return int64(0);}
     function isBtcTxHashAlreadyProcessed ( string calldata ) external pure override returns (bool) {return false;}
-    function getFederationAddress (  ) external pure override returns (string memory) {return "";}
+    function getFederationAddress (  ) external pure override returns (string memory) {return "2N5muMepJizJE1gR7FbHJU6CD18V3BpNF9p";} // regtest genesis fed addr
     function registerBtcTransaction ( bytes calldata atx, int256 height, bytes calldata pmt ) external override {}
     function addSignature ( bytes calldata pubkey, bytes[] calldata signatures, bytes calldata txhash ) external override {}
     function receiveHeaders ( bytes[] calldata blocks ) external override {}

--- a/readme.MD
+++ b/readme.MD
@@ -31,7 +31,7 @@ The quote structure defines the conditions of a service, and acts as a contract 
         uint timeForDeposit;                    // the time (in seconds) that the user has to achieve one confirmation on the BTC deposit
         uint callTime;                          // the time (in seconds) that the LP has to perform the call on behalf of the user after the deposit achieves the number of confirmations
         uint depositConfirmations;              // the number of confirmations that the LP requires before making the call
-	bool callOnRegister:                   // a boolean value indicating whether the callForUser can be called on registerPegIn.
+        bool callOnRegister:                    // a boolean value indicating whether the callForUser can be called on registerPegIn.
     }
 
 ## ABI Signature


### PR DESCRIPTION
This makes `getFederationAddress` to return non-empty federation address