### PR TITLE
[GBI-1151] - add validation for btc address decoded size 33

### DIFF
--- a/contracts/LiquidityBridgeContract.sol
+++ b/contracts/LiquidityBridgeContract.sol
@@ -742,8 +742,9 @@ contract LiquidityBridgeContract is Initializable, OwnableUpgradeable {
             "Bridge is not an accepted contract address"
         );
         require(
-            quote.btcRefundAddress.length == 21,
-            "BTC refund address must be 21 bytes long"
+            quote.btcRefundAddress.length == 21 ||
+            quote.btcRefundAddress.length == 33,
+            "BTC refund address must be 21 OR 33 bytes long"
         );
         require(
             quote.liquidityProviderBtcAddress.length == 21,


### PR DESCRIPTION
When we decode a bech32 address, it's array data is of 33 bytes length. So we need to change it and VERIFY HOW IT WORKS while refunding (very important since some address doesnt support legacy <-> bech32).

**DO NOT MERGE UNTIL VERIFICATION IS DONE**