### PR TITLE
Feature/GBI-1258 - Store quote in register pegout

### DIFF
--- a/contracts/LiquidityBridgeContract.sol
+++ b/contracts/LiquidityBridgeContract.sol
@@ -164,6 +164,7 @@ contract LiquidityBridgeContract is Initializable, OwnableUpgradeable {
 
     mapping(bytes32 => uint8) private processedQuotes;
     mapping(bytes32 => PegOutQuoteState) private pegOutQuotesStates;
+    mapping(bytes32 => PegOutQuote) private registeredPegoutQuotes;
 
     modifier onlyRegistered() {
         require(isRegistered(msg.sender), "Not registered");
@@ -268,6 +269,12 @@ contract LiquidityBridgeContract is Initializable, OwnableUpgradeable {
         bytes32 quoteHash
     ) external view returns (PegOutQuoteState memory) {
         return pegOutQuotesStates[quoteHash];
+    }
+
+    function getRegisteredPegOutQuote(
+        bytes32 quoteHash
+    ) external view returns (PegOutQuote memory) {
+        return registeredPegoutQuotes[quoteHash];
     }
 
     /**
@@ -786,6 +793,7 @@ contract LiquidityBridgeContract is Initializable, OwnableUpgradeable {
         );
 
         pegOutQuotesStates[quoteHash].statusCode = PROCESSED_QUOTE_CODE;
+        registeredPegoutQuotes[quoteHash] = quote;
 
         emit PegOut(
             msg.sender,

--- a/contracts/LiquidityBridgeContract.sol
+++ b/contracts/LiquidityBridgeContract.sol
@@ -894,6 +894,7 @@ contract LiquidityBridgeContract is Initializable, OwnableUpgradeable {
         require(sent, "Failed to send refund to LP address");
 
         delete pegOutQuotesStates[quoteHash];
+        delete registeredPegoutQuotes[quoteHash];
         emit PegOutRefunded(quoteHash);
     }
 

--- a/test/basic.tests.js
+++ b/test/basic.tests.js
@@ -800,6 +800,9 @@ contract("LiquidityBridgeContract", async (accounts) => {
       userPegInBalanceAfter.toString()
     );
     expect(+contractBalanceAfter).to.be.eq(+contractBalanceBefore - +msgValue);
+    // check that stores quote
+    const storedQuote = await instance.getRegisteredPegOutQuote(quoteHash)
+    expect(storedQuote.lbcAddress).to.not.be.eq('0x0000000000000000000000000000000000000000')
   });
 
   it("should fail on a false signature", async () => {

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -49,7 +49,7 @@ module.exports = {
         settings: {          // See the solidity docs for advice about optimization and evmVersion
           optimizer: {
             enabled: true,
-            runs: 200
+            runs: 50
           },
           evmVersion: "byzantium"
         }


### PR DESCRIPTION
Now we have a mapping to save pegout quotes during registerPegout operation as requested. One important thing, during development I got this error:
`"LiquidityBridgeContract" -- VM Exception while processing transaction: code size to deposit exceeds maximum code size.`
I changed compiler configuration according to [documentation](https://docs.soliditylang.org/en/latest/using-the-compiler.html#input-description) in order to reduce resulting code size, but if we don't do something to reduce the amount of code in LBC this probably will happen again, so we need to be aware of this issue
