### PR TITLE
remove call to the bridge

### DIFF
--- a/contracts/LiquidityBridgeContract.sol
+++ b/contracts/LiquidityBridgeContract.sol
@@ -389,8 +389,6 @@ contract LiquidityBridgeContract is Initializable, OwnableUpgradeable {
             "Max transaction value must be greater than min transaction value"
         );
         require(_maxTransactionValue <= maxQuoteValue, "Max transaction value can't be higher than maximum quote value");
-        uint256 bridgeMinimun = uint256(bridge.getMinimumLockTxValue());
-        require(_minTransactionValue >= bridgeMinimun, "Min transaction value can't be lower than bridge minimum lock tx value");
         require(
             bytes(_apiBaseUrl).length > 0,
             "API base URL must not be empty"

--- a/test/basic.tests.js
+++ b/test/basic.tests.js
@@ -125,22 +125,6 @@ contract("LiquidityBridgeContract", async (accounts) => {
         10,
         7200,
         3600,
-        1,
-        100,
-        "http://localhost/api",
-        true,
-        "both",
-        { from: accounts[1], value: minCollateral }
-      ),
-      "Min transaction value can't be lower than bridge minimum lock tx value"
-    );
-
-    await truffleAssertions.reverts(
-      instance.register(
-        "First contract",
-        10,
-        7200,
-        3600,
         10,
         web3.utils.toBN("1000000000000000001"),
         "http://localhost/api",


### PR DESCRIPTION
Hey guys, for some reason the call to the bridge during register was causing the transaction to revert. I'm not sure why, but it is not used on another part of the contract so I removed that validation for now and we can rely on the validation done by lps for quotes not to be below bridge limit (pls tell me if there is a problem with this). I'll investigate why this error happens when calling to that function of the bridge