### PR TITLE
Pegout complete map

### DIFF
--- a/readme.MD
+++ b/readme.MD
@@ -74,6 +74,7 @@ Note that the call performed by the LP can be a transfer of value to an account 
 - <b>LBC061</b>: invalid header length
 - <b>LBC062</b>: slicing out of range
 - <b>LBC063</b>: Not enough value
+- <b>LBC064</b>: Pegout finalized
 
 ## Quote
 


### PR DESCRIPTION
This PR was created to avoid this vulnerability:
1. user accepts pegout quote
2. user deposits pegout quote
3. LP sends the money and calls refund therefore the quote is deleted from registered quotes mapping
4. user deposits quote again and since the LP is not tracking it anymore it expires, so user calls refund user pegout and penalizes LP