### PR TITLE
VULN-328 - Redesign shouldPenalizePegoutLP

### DIFF
--- a/contracts/BridgeMock.sol
+++ b/contracts/BridgeMock.sol
@@ -7,6 +7,7 @@ contract BridgeMock is Bridge {
 
     mapping(bytes32 => uint256) private amounts;
     mapping(uint256 => bytes) private headers;
+    mapping (bytes32 => bytes) private headersByHash;
 
     receive() external payable override {}
     function registerFastBridgeBtcTransaction(
@@ -36,6 +37,10 @@ contract BridgeMock is Bridge {
 
     function setHeader(uint256 height, bytes memory header) public {
         headers[height] = header;
+    }
+
+    function setHeaderByHash(bytes32 blockHash, bytes memory header) public {
+        headersByHash[blockHash] = header;
     }  
 
     function getBtcBlockchainBestChainHeight (  ) external pure override returns (int) {return 0;}
@@ -91,7 +96,13 @@ contract BridgeMock is Bridge {
     function hasBtcBlockCoinbaseTransactionInformation ( bytes32  ) external pure override returns (bool) {return false;}
     function getActiveFederationCreationBlockHeight (  ) external pure override returns (uint256) {return uint256(0);}
     function getBtcBlockchainBestBlockHeader (  ) external pure override returns (bytes memory) {bytes memory b; return b;}
-    function getBtcBlockchainBlockHeaderByHash ( bytes32  ) external pure override returns (bytes memory) {bytes memory b; return b;}
+
+    function getBtcBlockchainBlockHeaderByHash(
+        bytes32 blockHash
+    ) external view override returns (bytes memory) {
+        return headersByHash[blockHash];
+    }
+
     function getBtcBlockchainParentBlockHeaderByHash ( bytes32) external pure override returns (bytes memory) {bytes memory b; return b;}
    
 }

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -27,6 +27,7 @@ const REWARD_PERCENTAGE = 10;
 const RESIGN_DELAY_BLOCKS = 1;
 const DUST_THRESHOLD = 2300 * 65164000;
 const MAX_QUOTE_VALUE = web3.utils.toBN("1000000000000000000"); // amount in wei
+const BTC_BLOCK_TIME = 5400; // the 5400 addition is to give 1.5h to the tx to be mined
 const { deploy, read } = require("../config");
 
 module.exports = async function (deployer, network) {
@@ -85,6 +86,7 @@ module.exports = async function (deployer, network) {
         RESIGN_DELAY_BLOCKS,
         DUST_THRESHOLD,
         MAX_QUOTE_VALUE,
+        BTC_BLOCK_TIME,
       ],
       {
         deployer,

--- a/test/basic.tests.js
+++ b/test/basic.tests.js
@@ -769,26 +769,14 @@ contract("LiquidityBridgeContract", async (accounts) => {
     quote.transferConfirmations = 0;
 
     // configure mocked block on mockBridge
-    const block = await web3.eth.getBlock("latest");
     const firstConfirmationTime = utils.reverseHexBytes(
       web3.utils.toHex(quote.agreementTimestamp + 300).substring(2)
-    );
-    const nConfirmationTime = utils.reverseHexBytes(
-      web3.utils.toHex(quote.agreementTimestamp + 600).substring(2)
     );
     const firstHeader =
       "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
       firstConfirmationTime +
       "0000000000000000";
-    const nHeader =
-      "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
-      nConfirmationTime +
-      "0000000000000000";
-    await bridgeMockInstance.setHeader(block.timestamp, firstHeader);
-    await bridgeMockInstance.setHeader(
-      block.timestamp + quote.depositConfirmations - 1,
-      nHeader
-    );
+    await bridgeMockInstance.setHeaderByHash(blockHeaderHash, firstHeader);
 
     const msgValue = quote.value.add(quote.callFee);
     const pegOut = await instance.depositPegout(quote, {
@@ -849,26 +837,14 @@ contract("LiquidityBridgeContract", async (accounts) => {
     quote.agreementTimestamp = Math.round(new Date().getTime() / 1000)
 
     // configure mocked block on mockBridge
-    const block = await web3.eth.getBlock("latest");
     const firstConfirmationTime = utils.reverseHexBytes(
       web3.utils.toHex(quote.agreementTimestamp + 300).substring(2)
-    );
-    const nConfirmationTime = utils.reverseHexBytes(
-      web3.utils.toHex(quote.agreementTimestamp + 600).substring(2)
     );
     const firstHeader =
       "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
       firstConfirmationTime +
       "0000000000000000";
-    const nHeader =
-      "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
-      nConfirmationTime +
-      "0000000000000000";
-    await bridgeMockInstance.setHeader(block.timestamp, firstHeader);
-    await bridgeMockInstance.setHeader(
-      block.timestamp + quote.depositConfirmations - 1,
-      nHeader
-    );
+    await bridgeMockInstance.setHeaderByHash(blockHeaderHash, firstHeader);
 
     const msgValue = quote.value.add(quote.callFee);
     const pegOut = await instance.depositPegout(quote, { value: msgValue.toNumber() });
@@ -1225,7 +1201,7 @@ contract("LiquidityBridgeContract", async (accounts) => {
       amount: depositAmount,
     });
     // this is to wait for the quote to expire
-    await utils.timeout(2000);
+    await utils.timeout(2500);
     await instance.addPegoutCollateral({
       value: web3.utils.toWei("30000", "wei"),
       from: liquidityProviderRskAddress,

--- a/test/miscellaneous.tests.js
+++ b/test/miscellaneous.tests.js
@@ -379,21 +379,21 @@ contract("LiquidityBridgeContract", async (accounts) => {
   it("should validate reward percentage arg in initialize", async () => {
     let instance = await LiquidityBridgeContract.new();
     const MAX_QUOTE_VALUE = web3.utils.toBN("1000000000000000000")
-    await instance.initialize(bridgeMockInstance.address, 1, 1, 0, 1, 1, MAX_QUOTE_VALUE);
+    await instance.initialize(bridgeMockInstance.address, 1, 1, 0, 1, 1, MAX_QUOTE_VALUE, 1);
     instance = await LiquidityBridgeContract.new();
-    await instance.initialize(bridgeMockInstance.address, 1, 1, 0, 1, 1, MAX_QUOTE_VALUE);
+    await instance.initialize(bridgeMockInstance.address, 1, 1, 0, 1, 1, MAX_QUOTE_VALUE, 1);
     instance = await LiquidityBridgeContract.new();
-    await instance.initialize(bridgeMockInstance.address, 1, 1, 1, 1, 1, MAX_QUOTE_VALUE);
+    await instance.initialize(bridgeMockInstance.address, 1, 1, 1, 1, 1, MAX_QUOTE_VALUE, 1);
     instance = await LiquidityBridgeContract.new();
-    await instance.initialize(bridgeMockInstance.address, 1, 1, 99, 1, 1, MAX_QUOTE_VALUE);
+    await instance.initialize(bridgeMockInstance.address, 1, 1, 99, 1, 1, MAX_QUOTE_VALUE, 1);
     instance = await LiquidityBridgeContract.new();
-    await instance.initialize(bridgeMockInstance.address, 1, 1, 100, 1, 1, MAX_QUOTE_VALUE);
+    await instance.initialize(bridgeMockInstance.address, 1, 1, 100, 1, 1, MAX_QUOTE_VALUE, 1);
     await truffleAssert.fails(
-      instance.initialize(bridgeMockInstance.address, 1, 1, 100, 1, 1, MAX_QUOTE_VALUE)
+      instance.initialize(bridgeMockInstance.address, 1, 1, 100, 1, 1, MAX_QUOTE_VALUE, 1)
     );
     instance = await LiquidityBridgeContract.new();
     await truffleAssert.fails(
-      instance.initialize(bridgeMockInstance.address, 1, 1, 101, 1, 1, MAX_QUOTE_VALUE)
+      instance.initialize(bridgeMockInstance.address, 1, 1, 101, 1, 1, MAX_QUOTE_VALUE, 1)
     );
   });
 

--- a/test/penalization.tests.js
+++ b/test/penalization.tests.js
@@ -262,4 +262,106 @@ contract('LiquidityBridgeContract', async accounts => {
         expect(web3.utils.toBN(0)).to.be.a.bignumber.eq(finalLPDeposit);
         expect(lpBal).to.eql(web3.utils.toBN(reward).add(peginAmount));
     });
+
+
+  it("Should not penalize LP on pegout when deposit was not made on time", async () => {
+    await instance.addPegoutCollateral({
+      value: web3.utils.toWei("30000", "wei"),
+      from: liquidityProviderRskAddress,
+    });
+    const btcTxHash =
+      "0xa0cad11b688340cfbb8515d4deb7d37a8c67ea70a938578295f28b6cd8b5aade";
+    const blockHeaderHash =
+      "0x02327049330a25d4d17e53e79f478cbb79c53a509679b1d8a1505c5697afb326";
+    const partialMerkleTree =
+      "0x02327049330a25d4d17e53e79f478cbb79c53a509679b1d8a1505c5697afb426";
+    const merkleBranchHashes = [
+      "0x02327049330a25d4d17e53e79f478cbb79c53a509679b1d8a1505c5697afb326",
+    ];
+
+    let quote = utils.getTestPegOutQuote(
+      instance.address, //lbc address
+      liquidityProviderRskAddress,
+      accounts[2],
+      web3.utils.toBN(25)
+    );
+    quote.transferConfirmations = 0;
+    quote.depositDateLimit = 0;
+    quote.agreementTimestamp = Math.round(new Date().getTime() / 1000) - 1
+
+    // configure mocked block on mockBridge
+    const firstConfirmationTime = utils.reverseHexBytes(
+      web3.utils.toHex(quote.agreementTimestamp + 300).substring(2)
+    );
+    const firstHeader =
+      "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
+      firstConfirmationTime +
+      "0000000000000000";
+    await bridgeMockInstance.setHeaderByHash(blockHeaderHash, firstHeader);
+
+    const msgValue = quote.value.add(quote.callFee);
+    const pegOut = await instance.depositPegout(quote, { value: msgValue.toNumber() });
+    truffleAssert.eventEmitted(pegOut, "PegOutDeposit");
+
+    const refund = await instance.refundPegOut(
+      quote,
+      btcTxHash,
+      blockHeaderHash,
+      partialMerkleTree,
+      merkleBranchHashes
+    );
+    truffleAssert.eventEmitted(refund, "PegOutRefunded");
+    truffleAssert.eventNotEmitted(refund, "Penalized");
+  });
+
+  it("Should penalize LP on pegout if the transfer was not made on time", async () => {
+    await instance.addPegoutCollateral({
+      value: web3.utils.toWei("30000", "wei"),
+      from: liquidityProviderRskAddress,
+    });
+    const btcTxHash =
+      "0xa0cad11b688340cfbb8515d4deb7d37a8c67ea70a938578295f28b6cd8b5aade";
+    const blockHeaderHash =
+      "0x02327049330a25d4d17e53e79f478cbb79c53a509679b1d8a1505c5697afb326";
+    const partialMerkleTree =
+      "0x02327049330a25d4d17e53e79f478cbb79c53a509679b1d8a1505c5697afb426";
+    const merkleBranchHashes = [
+      "0x02327049330a25d4d17e53e79f478cbb79c53a509679b1d8a1505c5697afb326",
+    ];
+
+    let quote = utils.getTestPegOutQuote(
+      instance.address, //lbc address
+      liquidityProviderRskAddress,
+      accounts[2],
+      web3.utils.toBN(25)
+    );
+    quote.transferConfirmations = 0;
+    quote.agreementTimestamp = Math.round(new Date().getTime() / 1000)
+
+    const msgValue = quote.value.add(quote.callFee);
+    const pegOut = await instance.depositPegout(quote, { value: msgValue.toNumber() });
+    truffleAssert.eventEmitted(pegOut, "PegOutDeposit");
+
+    const block = await web3.eth.getBlock("latest");
+    const BTC_BLOCK_TIME = 5400; // 1.5h
+    // configure mocked block on mockBridge
+    const firstConfirmationTime = utils.reverseHexBytes(
+      web3.utils.toHex(block.timestamp + quote.transferTime + BTC_BLOCK_TIME + 1).substring(2)
+    );
+    const firstHeader =
+      "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
+      firstConfirmationTime +
+      "0000000000000000";
+    await bridgeMockInstance.setHeaderByHash(blockHeaderHash, firstHeader);
+
+    const refund = await instance.refundPegOut(
+      quote,
+      btcTxHash,
+      blockHeaderHash,
+      partialMerkleTree,
+      merkleBranchHashes
+    );
+    truffleAssert.eventEmitted(refund, "PegOutRefunded");
+    truffleAssert.eventEmitted(refund, "Penalized");
+  });
 });


### PR DESCRIPTION
Explanation of the new penalization conditions:

- "do not penalize if deposit amount is insufficient": this one was removed because amount is validated on depositPegout
- "do not penalize if deposit was not made on time": this one was changed because now we can store the deposit time during deposit pegout
- "penalize if call was not made": this one was removed because like in the security document says, there isn't really a call on pegout, also, in order to call refundPegout LP will be required to send proof of btc tx which means that transfer is always done
- "penalize if the transfer was not made on time": this one was changed because we can't know the exact time of the btc tx, but we can know the time when btc block was mined so we check if that time is above the deposit time plus the transfer time plus a btcBlockTime (a time that we give the tx to be mined, should be the average mining time of bitcoin)