### PR TITLE
Feature/GBI-1578 - Add gas fee

### DIFF
--- a/contracts/LiquidityBridgeContractV2.sol
+++ b/contracts/LiquidityBridgeContractV2.sol
@@ -562,10 +562,10 @@ contract LiquidityBridgeContractV2 is Initializable, OwnableUpgradeable, Reentra
             if (callRegistry[quoteHash].success) {
                 refundAmount = min(
                     transferredAmount,
-                    quote.value + quote.callFee
+                    quote.value + quote.callFee + quote.gasFee
                 );
             } else {
-                refundAmount = min(transferredAmount, quote.callFee);
+                refundAmount = min(transferredAmount, quote.callFee + quote.gasFee);
             }
             increaseBalance(quote.liquidityProviderRskAddress, refundAmount);
 
@@ -640,7 +640,7 @@ contract LiquidityBridgeContractV2 is Initializable, OwnableUpgradeable, Reentra
         bytes memory signature
     ) external payable {
         require(isRegisteredForPegout(quote.lpRskAddress), "LBC037");
-        require(quote.value + quote.callFee + quote.productFeeAmount <= msg.value, "LBC063");
+        require(quote.value + quote.callFee + quote.productFeeAmount + quote.gasFee <= msg.value, "LBC063");
         require(block.timestamp <= quote.depositDateLimit, "LBC065");
         require(block.timestamp <= quote.expireDate, "LBC046");
         require(block.number <= quote.expireBlock, "LBC047");
@@ -671,7 +671,7 @@ contract LiquidityBridgeContractV2 is Initializable, OwnableUpgradeable, Reentra
             "LBC041"
         );
 
-        uint valueToTransfer = quote.value + quote.callFee + quote.productFeeAmount;
+        uint valueToTransfer = quote.value + quote.callFee + quote.productFeeAmount + quote.gasFee;
         address addressToTransfer = quote.rskRefundAddress;
 
         uint penalty = min(quote.penaltyFee, pegoutCollateral[quote.lpRskAddress]);
@@ -799,7 +799,7 @@ contract LiquidityBridgeContractV2 is Initializable, OwnableUpgradeable, Reentra
             "LBC054"
         );
         require(
-            quote.value + quote.callFee + quote.productFeeAmount >= minPegIn,
+            quote.value + quote.callFee + quote.productFeeAmount + quote.gasFee >= minPegIn,
             "LBC055"
         );
         require(
@@ -889,7 +889,7 @@ contract LiquidityBridgeContractV2 is Initializable, OwnableUpgradeable, Reentra
         uint256 height
     ) private view returns (bool) {
         // do not penalize if deposit amount is insufficient
-        if (amount > 0 && uint256(amount) < quote.value + quote.callFee + quote.productFeeAmount) {
+        if (amount > 0 && uint256(amount) < quote.value + quote.callFee + quote.productFeeAmount + quote.gasFee) {
             return false;
         }
 

--- a/contracts/QuotesV2.sol
+++ b/contracts/QuotesV2.sol
@@ -22,6 +22,7 @@ library QuotesV2 {
         uint16 depositConfirmations;
         bool callOnRegister;
         uint256 productFeeAmount;
+        uint256 gasFee;
     }
 
     struct PegOutQuote {
@@ -43,6 +44,7 @@ library QuotesV2 {
         uint32 expireDate;
         uint32 expireBlock;
         uint256 productFeeAmount;
+        uint256 gasFee;
     }
 
     function encodeQuote(
@@ -90,7 +92,8 @@ library QuotesV2 {
                 quote.callTime,
                 quote.depositConfirmations,
                 quote.callOnRegister,
-                quote.productFeeAmount
+                quote.productFeeAmount,
+                quote.gasFee
             );
     }
 
@@ -124,7 +127,8 @@ library QuotesV2 {
                 quote.transferTime,
                 quote.expireDate,
                 quote.expireBlock,
-                quote.productFeeAmount
+                quote.productFeeAmount,
+                quote.gasFee
             );
     }
 
@@ -133,7 +137,7 @@ library QuotesV2 {
         uint transferredAmount
     ) external pure {
         uint agreedAmount = 0;
-        agreedAmount = quote.value + quote.callFee + quote.productFeeAmount;
+        agreedAmount = quote.value + quote.callFee + quote.productFeeAmount + quote.gasFee;
 
 
         uint delta = agreedAmount / 10000;

--- a/integration-test/common.js
+++ b/integration-test/common.js
@@ -67,7 +67,7 @@ async function loadConfig() {
     return JSON.parse(buffer.toString())
 }
 async function sendBtc({ toAddress, amountInBtc, rpc, data }) {
-    const outputs = [ { [toAddress]: amountInBtc } ]
+    const outputs = [ { [toAddress]: amountInBtc.toString() } ]
     const fundOptions = { fee_rate: 25 }
     if (data) {
         outputs.push({ data })

--- a/integration-test/test.config.example.json
+++ b/integration-test/test.config.example.json
@@ -9,6 +9,7 @@
     "btc": {
         "url": "http://127.0.0.1:5555/",
         "user": "test",
-        "pass": "test"
+        "pass": "test",
+        "walletPassphrase": "pass"
     }
 }

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -98,7 +98,7 @@ module.exports = async function (deployer, network) {
       state.address = btcUtilsInstance.address;
     });
 
-    minimumPegIn = 2;
+    minimumPegIn = 3;
   }
 
   let config = read();

--- a/test/basic.tests.js
+++ b/test/basic.tests.js
@@ -636,7 +636,7 @@ contract("LiquidityBridgeContractV2.sol", async (accounts) => {
       liquidityProviderRskAddress
     );
     let initialLBCBalance = await web3.eth.getBalance(instance.address);
-    let peginAmount = quote.val.add(quote.callFee).add(quote.productFeeAmount);
+    let peginAmount = quote.val.add(quote.callFee).add(quote.productFeeAmount).add(quote.gasFee);
     let quoteHash = await instance.hashQuote(utils.asArray(quote));
     let signature = await web3.eth.sign(quoteHash, liquidityProviderRskAddress);
     let firstConfirmationTime = utils.reverseHexBytes(
@@ -739,7 +739,7 @@ contract("LiquidityBridgeContractV2.sol", async (accounts) => {
     let btcRawTransaction = "0x101";
     let partialMerkleTree = "0x202";
     let height = 10;
-    let peginAmount = quote.val.add(quote.callFee).add(quote.productFeeAmount);
+    let peginAmount = quote.val.add(quote.callFee).add(quote.productFeeAmount).add(quote.gasFee);
     let quoteHash = await instance.hashQuote(utils.asArray(quote));
     let signature = await web3.eth.sign(quoteHash, liquidityProviderRskAddress);
     let firstConfirmationTime = utils.reverseHexBytes(
@@ -886,7 +886,7 @@ contract("LiquidityBridgeContractV2.sol", async (accounts) => {
 
     const quoteHash = await instance.hashPegoutQuote(utils.asArray(quote));
     const signature = await web3.eth.sign(quoteHash, liquidityProviderRskAddress);
-    const msgValue = quote.value.add(quote.callFee).add(quote.productFeeAmount);
+    const msgValue = quote.value.add(quote.callFee).add(quote.productFeeAmount).add(quote.gasFee);
     const pegOut = await instance.depositPegout(utils.asArray(quote), signature, {
       value: msgValue.toNumber()
     });
@@ -959,7 +959,7 @@ contract("LiquidityBridgeContractV2.sol", async (accounts) => {
 
     const quoteHash = await instance.hashPegoutQuote(utils.asArray(quote));
     const signature = await web3.eth.sign(quoteHash, liquidityProviderRskAddress);
-    const msgValue = quote.value.add(quote.callFee);
+    const msgValue = quote.value.add(quote.callFee).add(quote.gasFee);
     const pegOut = await instance.depositPegout(utils.asArray(quote), signature, {
       value: msgValue.toNumber()
     });
@@ -1012,7 +1012,7 @@ contract("LiquidityBridgeContractV2.sol", async (accounts) => {
 
     const quoteHash = await instance.hashPegoutQuote(utils.asArray(quote));
     const signature = await web3.eth.sign(quoteHash, liquidityProviderRskAddress);
-    const msgValue = quote.value.add(quote.callFee).add(quote.productFeeAmount);
+    const msgValue = quote.value.add(quote.callFee).add(quote.productFeeAmount).add(quote.gasFee);
     const pegOut = await instance.depositPegout(utils.asArray(quote), signature, { value: msgValue.toNumber() });
     await truffleAssertions.eventEmitted(pegOut, "PegOutDeposit");
 
@@ -1148,7 +1148,7 @@ contract("LiquidityBridgeContractV2.sol", async (accounts) => {
 
     const quoteHash = await instance.hashPegoutQuote(utils.asArray(quote));
     const signature = await web3.eth.sign(quoteHash, liquidityProviderRskAddress);
-    const msgValue = quote.value.add(quote.callFee).add(quote.productFeeAmount);
+    const msgValue = quote.value.add(quote.callFee).add(quote.productFeeAmount).add(quote.gasFee);
     const pegOut = await instance.depositPegout(utils.asArray(quote), signature, {
       value: msgValue.toNumber()
     });
@@ -1566,7 +1566,7 @@ contract("LiquidityBridgeContractV2.sol", async (accounts) => {
       "0000000000000000";
     await bridgeMockInstance.setHeaderByHash(blockHeaderHash, firstHeader);
 
-    const msgValue = quote.value.add(quote.callFee).add(quote.productFeeAmount);
+    const msgValue = quote.value.add(quote.callFee).add(quote.productFeeAmount).add(quote.gasFee);
     const quoteHash = await instance.hashPegoutQuote(utils.asArray(quote));
     const signature = await web3.eth.sign(quoteHash, liquidityProviderRskAddress);
     const pegOut = await instance.depositPegout(utils.asArray(quote), signature, { value: msgValue.toNumber() });
@@ -1608,7 +1608,7 @@ contract("LiquidityBridgeContractV2.sol", async (accounts) => {
       "0000000000000000";
     await bridgeMockInstance.setHeaderByHash(blockHeaderHash, firstHeader);
 
-    const msgValue = quote.value.add(quote.callFee).add(quote.productFeeAmount);
+    const msgValue = quote.value.add(quote.callFee).add(quote.productFeeAmount).add(quote.gasFee);
     const quoteHash = await instance.hashPegoutQuote(utils.asArray(quote));
     const signature = await web3.eth.sign(quoteHash, liquidityProviderRskAddress);
     const pegOut = await instance.depositPegout(utils.asArray(quote), signature, {
@@ -1883,9 +1883,10 @@ contract("LiquidityBridgeContractV2.sol", async (accounts) => {
           callTime: 7200,
           depositConfirmations: 10,
           callOnRegister: false,
-          productFeeAmount: BigInt("6000000000000000")
+          productFeeAmount: BigInt("6000000000000000"),
+          gasFee: BigInt("3000000000000000")
         },
-        address: '2NFWum5hWgScV2QPPEfFGF1hWV6EcX5Gicg'
+        address: '2N54HuutZf7Xkmv85wCtBkQg5nCC3k432rf'
       },
       {
         quote: {
@@ -1907,9 +1908,10 @@ contract("LiquidityBridgeContractV2.sol", async (accounts) => {
           callTime: 7200,
           depositConfirmations: 10,
           callOnRegister: false,
-          productFeeAmount: BigInt("7000000000000000")
+          productFeeAmount: BigInt("7000000000000000"),
+          gasFee: BigInt("4000000000000000")
         },
-        address: '2Mwk75Usb1GyQB2AtFLmr3iqrET3ByP9M9j'
+        address: '2NARRvPtz2ch1KozGfZg6FahLSVVaSG2fQr'
       },
       {
         quote: {
@@ -1931,9 +1933,10 @@ contract("LiquidityBridgeContractV2.sol", async (accounts) => {
           callTime: 7200,
           depositConfirmations: 10,
           callOnRegister: false,
-          productFeeAmount: BigInt("8000000000000000")
+          productFeeAmount: BigInt("8000000000000000"),
+          gasFee: BigInt("5000000000000000")
         },
-        address: '2N56hAFac2aULZNw9SQfjdjLhT3qHtSrnFo'
+        address: '2Mwfc2XRxm64dDbNowHUFj2pZ4owePhNFyQ'
       }
     ]
 

--- a/test/miscellaneous.tests.js
+++ b/test/miscellaneous.tests.js
@@ -90,6 +90,7 @@ contract("LiquidityBridgeContractV2.sol", async (accounts) => {
     let penaltyFee = web3.utils.toBN(0);
     let callOnRegister = true;
     let productFeeAmount = web3.utils.toBN(1);
+    const gasFee = web3.utils.toBN(1);
     let quote = [
       fedBtcAddress,
       lbcAddress,
@@ -109,7 +110,8 @@ contract("LiquidityBridgeContractV2.sol", async (accounts) => {
       callTime,
       depositConfirmations,
       callOnRegister,
-      productFeeAmount
+      productFeeAmount,
+      gasFee
     ];
     // Let's now register our quote in the bridge... note that the
     // value is only a hundred wei
@@ -171,17 +173,20 @@ contract("LiquidityBridgeContractV2.sol", async (accounts) => {
     let data = "0x00";
     let callFee = 1;
     const productFeeAmount = 1;
+    const gasFee = 1;
     let gasLimit = 150000;
     let nonce = 0;
     let delta = web3.utils
       .toBN(val)
       .add(web3.utils.toBN(callFee))
       .add(web3.utils.toBN(productFeeAmount))
+      .add(web3.utils.toBN(gasFee))
       .div(web3.utils.toBN(10000));
     let peginAmount = web3.utils
       .toBN(val)
       .add(web3.utils.toBN(callFee))
       .add(web3.utils.toBN(productFeeAmount))
+      .add(web3.utils.toBN(gasFee))
       .sub(delta);
     let lbcAddress = instance.address;
     let agreementTime = 1661788988;
@@ -209,7 +214,8 @@ contract("LiquidityBridgeContractV2.sol", async (accounts) => {
       callTime,
       depositConfirmations,
       callOnRegister,
-      productFeeAmount
+      productFeeAmount,
+      gasFee
     ];
     let quoteHash = await instance.hashQuote(quote);
     let signature = await web3.eth.sign(quoteHash, liquidityProviderRskAddress);
@@ -321,6 +327,7 @@ contract("LiquidityBridgeContractV2.sol", async (accounts) => {
     let penaltyFee = 0;
     let callOnRegister = false;
     let productFeeAmount = web3.utils.toBN(1);
+    const gasFee = web3.utils.toBN(1);
     let quote = [
       fedBtcAddress,
       lbcAddress,
@@ -340,7 +347,8 @@ contract("LiquidityBridgeContractV2.sol", async (accounts) => {
       callTime,
       depositConfirmations,
       callOnRegister,
-      productFeeAmount
+      productFeeAmount,
+      gasFee
     ];
     let quoteHash = await instance.hashQuote(quote);
     let signature = await web3.eth.sign(quoteHash, liquidityProviderRskAddress);

--- a/test/penalization.tests.js
+++ b/test/penalization.tests.js
@@ -141,7 +141,7 @@ contract('LiquidityBridgeContractV2.sol', async accounts => {
             val);
         quote.penaltyFee = web3.utils.toBN(10);
         quote.callTime = 1;
-        let peginAmount = quote.val.add(quote.callFee).add(quote.productFeeAmount);
+        let peginAmount = quote.val.add(quote.callFee).add(quote.productFeeAmount).add(quote.gasFee);
 
         let btcRawTransaction = '0x101';
         let partialMerkleTree = '0x202';
@@ -227,7 +227,7 @@ contract('LiquidityBridgeContractV2.sol', async accounts => {
         let height = 10;
 
         let initialLPBalance = await instance.getBalance(lpAddress, { from: lpAddress });
-        let peginAmount = quote.val.add(quote.callFee).add(quote.productFeeAmount);
+        let peginAmount = quote.val.add(quote.callFee).add(quote.productFeeAmount).add(quote.gasFee);
         let initialLPDeposit = await instance.getCollateral(lpAddress, { from: lpAddress });
         let rewardPercentage = await instance.getRewardPercentage();
         let quoteHash = await instance.hashQuote(utils.asArray(quote));
@@ -299,7 +299,7 @@ contract('LiquidityBridgeContractV2.sol', async accounts => {
 
     const quoteHash = await instance.hashPegoutQuote(utils.asArray(quote));
     const signature = await web3.eth.sign(quoteHash, liquidityProviderRskAddress);
-    const msgValue = quote.value.add(quote.callFee).add(quote.productFeeAmount);
+    const msgValue = quote.value.add(quote.callFee).add(quote.productFeeAmount).add(quote.gasFee);
     const pegOut = await instance.depositPegout(utils.asArray(quote), signature, { value: msgValue.toNumber() });
     truffleAssert.eventEmitted(pegOut, "PegOutDeposit");
 

--- a/test/refund.tests.js
+++ b/test/refund.tests.js
@@ -50,7 +50,7 @@ contract('LiquidityBridgeContractV2.sol', async accounts => {
         let initialLBCBalance = await web3.eth.getBalance(instance.address);
         let initialRefundBalance = await web3.eth.getBalance(rskRefundAddress);
         let additionalFunds = web3.utils.toBN(1000000000000);
-        let peginAmount = val.add(quote.callFee).add(additionalFunds);
+        let peginAmount = val.add(quote.callFee).add(additionalFunds).add(quote.gasFee);
 
         let quoteHash = await instance.hashQuote(utils.asArray(quote));
         let signature = await web3.eth.sign(quoteHash, liquidityProviderRskAddress);
@@ -136,7 +136,7 @@ contract('LiquidityBridgeContractV2.sol', async accounts => {
         let initialLBCBalance = await web3.eth.getBalance(instance.address);
         let initialRefundBalance = await web3.eth.getBalance(rskRefundAddress);
         let additionalFunds = web3.utils.toBN(1000000000000);
-        let peginAmount = val.add(quote.callFee).add(additionalFunds);
+        let peginAmount = val.add(quote.callFee).add(additionalFunds).add(quote.gasFee);
 
         let quoteHash = await instance.hashQuote(utils.asArray(quote));
         let signature = await web3.eth.sign(quoteHash, liquidityProviderRskAddress);
@@ -219,7 +219,7 @@ contract('LiquidityBridgeContractV2.sol', async accounts => {
         let partialMerkleTree = '0x202';
         let height = 10;
         let initialLPBalance = await instance.getBalance(liquidityProviderRskAddress);
-        let peginAmount = quote.val.add(quote.callFee);
+        let peginAmount = quote.val.add(quote.callFee).add(quote.gasFee);
 
         let quoteHash = await instance.hashQuote(utils.asArray(quote));
         let signature = await web3.eth.sign(quoteHash, liquidityProviderRskAddress);
@@ -264,8 +264,8 @@ contract('LiquidityBridgeContractV2.sol', async accounts => {
             amount: quote.val,
             success: true
         });
-        expect(lpBal).to.be.a.bignumber.eq(quote.val.add(quote.callFee));
-        expect(usrBal).to.be.a.bignumber.eq(peginAmount.sub(quote.callFee));
+        expect(lpBal).to.be.a.bignumber.eq(quote.val.add(quote.callFee).add(quote.gasFee));
+        expect(usrBal).to.be.a.bignumber.eq(peginAmount.sub(quote.callFee).sub(quote.gasFee));
         expect(finalLPDeposit).to.be.a.bignumber.eq(initialLPDeposit);
     });
 
@@ -291,7 +291,7 @@ contract('LiquidityBridgeContractV2.sol', async accounts => {
         let initialLPDeposit = await instance.getCollateral(liquidityProviderRskAddress);
         let reward = Math.floor(quote.penaltyFee.div(web3.utils.toBN(10)));
         let initialLbcBalance = await web3.eth.getBalance(instance.address);
-        let peginAmount = quote.val.add(quote.callFee).add(quote.productFeeAmount);
+        let peginAmount = quote.val.add(quote.callFee).add(quote.productFeeAmount).add(quote.gasFee);
 
         let quoteHash = await instance.hashQuote(utils.asArray(quote));
         let signature = await web3.eth.sign(quoteHash, liquidityProviderRskAddress);
@@ -322,7 +322,7 @@ contract('LiquidityBridgeContractV2.sol', async accounts => {
         let lpCol = web3.utils.toBN(initialLPDeposit).sub(web3.utils.toBN(finalLPDeposit));
         truffleAssert.eventEmitted(tx, "Refund", {
             dest: rskRefundAddress,
-            amount: web3.utils.toBN(1000000000002),
+            amount: web3.utils.toBN(1000000000003),
             success: true,
             quoteHash: quoteHash,
         });
@@ -353,7 +353,7 @@ contract('LiquidityBridgeContractV2.sol', async accounts => {
         let btcRawTransaction = '0x101';
         let partialMerkleTree = '0x202';
         let height = 10;
-        let peginAmount = quote.val.add(quote.callFee).add(quote.productFeeAmount);
+        let peginAmount = quote.val.add(quote.callFee).add(quote.productFeeAmount).add(quote.gasFee);
 
         let quoteHash = await instance.hashQuote(utils.asArray(quote));
         let signature = await web3.eth.sign(quoteHash, liquidityProviderRskAddress);
@@ -391,7 +391,7 @@ contract('LiquidityBridgeContractV2.sol', async accounts => {
         let lpCol = web3.utils.toBN(initialLPDeposit).sub(web3.utils.toBN(finalLPDeposit));
         truffleAssert.eventEmitted(tx, "Refund", {
             dest: rskRefundAddress,
-            amount: web3.utils.toBN(1000000000002),
+            amount: web3.utils.toBN(1000000000003),
             success: false,
             quoteHash: quoteHash,
         });

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -22,6 +22,7 @@ function getTestQuote(
   let penaltyFee = web3.utils.toBN(0);
   let callOnRegister = false;
   let productFeeAmount = web3.utils.toBN(1);
+  const gasFee = web3.utils.toBN(1);
   let quote = {
     fedBtcAddress,
     lbcAddress,
@@ -41,7 +42,8 @@ function getTestQuote(
     callTime,
     depositConfirmations,
     callOnRegister,
-    productFeeAmount
+    productFeeAmount,
+    gasFee
   };
 
   return quote;
@@ -60,6 +62,7 @@ function getTestPegOutQuote(lbcAddress, lpRskAddress, rskRefundAddress, value) {
   let transferConfirmations = 10;
   let penaltyFee = web3.utils.toBN(0);
   let productFeeAmount = web3.utils.toBN(1);
+  const gasFee = web3.utils.toBN(1);
 
   let quote = {
     lbcAddress,
@@ -79,7 +82,8 @@ function getTestPegOutQuote(lbcAddress, lpRskAddress, rskRefundAddress, value) {
     transferTime,
     expireDate,
     expireBlock,
-    productFeeAmount
+    productFeeAmount,
+    gasFee
   };
 
   return quote;


### PR DESCRIPTION
## What 
Separate gas fee from call fee in two different fields
## Why
To be able to distinguish between the amount that is the profit for the LP (call fee) and the amount that is used to perform the call on behalf of the user and the call to pay to the fee collector (gas fee)
## Task
https://rsklabs.atlassian.net/browse/GBI-1578