### PR TITLE
Feature/GBI-1652 - Update BtcUtils

### DIFF
--- a/contracts/LiquidityBridgeContractV2.sol
+++ b/contracts/LiquidityBridgeContractV2.sol
@@ -702,7 +702,12 @@ contract LiquidityBridgeContractV2 is Initializable, OwnableUpgradeable, Reentra
         QuotesV2.PegOutQuote storage quote = registeredPegoutQuotes[quoteHash];
         require(quote.lbcAddress != address(0), "LBC042");
         BtcUtils.TxRawOutput[] memory outputs = BtcUtils.getOutputs(btcTx);
-        bytes32 txQuoteHash = abi.decode(BtcUtils.parseNullDataScript(outputs[QUOTE_HASH_OUTPUT].pkScript), (bytes32));
+        bytes memory scriptContent = BtcUtils.parseNullDataScript(outputs[QUOTE_HASH_OUTPUT].pkScript);
+        // shift the array to remove the first byte (the size)
+        for (uint8 i = 0 ; i < scriptContent.length - 1; i++) {
+            scriptContent[i] = scriptContent[i + 1];
+        }
+        bytes32 txQuoteHash = abi.decode(scriptContent, (bytes32));
         require(quoteHash == txQuoteHash, "LBC069");
         require(msg.sender == quote.lpRskAddress, "LBC048");
         require(

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@openzeppelin/contracts": "^4.8.0",
         "@openzeppelin/contracts-upgradeable": "^4.8.2",
-        "@rsksmart/btc-transaction-solidity-helper": "^0.0.2",
+        "@rsksmart/btc-transaction-solidity-helper": "^0.0.3",
         "@truffle/hdwallet-provider": "^2.1.3",
         "chai": "^4.3.4",
         "chai-bn": "^0.3.0",
@@ -3072,9 +3072,9 @@
       "peer": true
     },
     "node_modules/@rsksmart/btc-transaction-solidity-helper": {
-      "version": "0.0.2",
-      "resolved": "https://npm.pkg.github.com/download/@rsksmart/btc-transaction-solidity-helper/0.0.2/41ad88620297f4fc061c14972a80d78a84527108",
-      "integrity": "sha512-1hpw6YSwEDE+9wSLBrkQDPdVcaIAmI+MRHtj4PVWHq9W45phSiDP6mO8bO8V2hpk4FaTq/2nHGX+m/RG1fyN/A==",
+      "version": "0.0.3",
+      "resolved": "https://npm.pkg.github.com/download/@rsksmart/btc-transaction-solidity-helper/0.0.3/3016563d1170bb6a4efbd8d56ee9994434527cff",
+      "integrity": "sha512-x4SzwxhyMWZGwj6ycUZvM/2uVcIQ4hhWZ3DJeJ1LHcza1nA9ghPH7dDGQYeuWAmJwgz9P4mW+f/9Wahe0KQ3Ew==",
       "license": "ISC"
     },
     "node_modules/@rsksmart/pmt-builder": {
@@ -21757,9 +21757,9 @@
       "peer": true
     },
     "@rsksmart/btc-transaction-solidity-helper": {
-      "version": "0.0.2",
-      "resolved": "https://npm.pkg.github.com/download/@rsksmart/btc-transaction-solidity-helper/0.0.2/41ad88620297f4fc061c14972a80d78a84527108",
-      "integrity": "sha512-1hpw6YSwEDE+9wSLBrkQDPdVcaIAmI+MRHtj4PVWHq9W45phSiDP6mO8bO8V2hpk4FaTq/2nHGX+m/RG1fyN/A=="
+      "version": "0.0.3",
+      "resolved": "https://npm.pkg.github.com/download/@rsksmart/btc-transaction-solidity-helper/0.0.3/3016563d1170bb6a4efbd8d56ee9994434527cff",
+      "integrity": "sha512-x4SzwxhyMWZGwj6ycUZvM/2uVcIQ4hhWZ3DJeJ1LHcza1nA9ghPH7dDGQYeuWAmJwgz9P4mW+f/9Wahe0KQ3Ew=="
     },
     "@rsksmart/pmt-builder": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@openzeppelin/contracts": "^4.8.0",
     "@openzeppelin/contracts-upgradeable": "^4.8.2",
-    "@rsksmart/btc-transaction-solidity-helper": "^0.0.2",
+    "@rsksmart/btc-transaction-solidity-helper": "^0.0.3",
     "@truffle/hdwallet-provider": "^2.1.3",
     "chai": "^4.3.4",
     "chai-bn": "^0.3.0",

--- a/test/basic.tests.js
+++ b/test/basic.tests.js
@@ -1466,7 +1466,7 @@ contract("LiquidityBridgeContractV2.sol", async (accounts) => {
     const firstRawTX = "0x0100000001013503c427ba46058d2d8ac9221a2f6fd50734a69f19dae65420191e3ada2d40000000006a47304402205d047dbd8c49aea5bd0400b85a57b2da7e139cec632fb138b7bee1d382fd70ca02201aa529f59b4f66fdf86b0728937a91a40962aedd3f6e30bce5208fec0464d54901210255507b238c6f14735a7abe96a635058da47b05b61737a610bef757f009eea2a4ffffffff0200879303000000001976a9143c5f66fe733e0ad361805b3053f23212e5755c8d88ac0000000000000000426a403938343934346435383039323135366335613139643936356239613735383530326536646263326439353337333135656266343839373336333134656233343700000000";
     const firstTxOutputs = await btcUtils.getOutputs(firstRawTX);
 
-    const firstQuoteHash = web3.utils.hexToAscii(await btcUtils.parseNullDataScript(firstTxOutputs[1].pkScript));
+    const firstNullScript = await btcUtils.parseNullDataScript(firstTxOutputs[1].pkScript);
     const firstDestinationAddress = await btcUtils.parsePayToPubKeyHash(firstTxOutputs[0].pkScript, false);
     const firstValue = firstTxOutputs[0].value;
     const firstHash = await btcUtils.hashBtcTx(firstRawTX);
@@ -1474,17 +1474,17 @@ contract("LiquidityBridgeContractV2.sol", async (accounts) => {
     const secondRawTX = "0x01000000010178a1cf4f2f0cb1607da57dcb02835d6aa8ef9f06be3f74cafea54759a029dc000000006a473044022070a22d8b67050bee57564279328a2f7b6e7f80b2eb4ecb684b879ea51d7d7a31022057fb6ece52c23ecf792e7597448c7d480f89b77a8371dca4700a18088f529f6a012103ef81e9c4c38df173e719863177e57c539bdcf97289638ec6831f07813307974cffffffff02801d2c04000000001976a9143c5f66fe733e0ad361805b3053f23212e5755c8d88ac0000000000000000426a406539346138393731323632396262633966636364316630633034613237386330653130353265623736323666393365396137663130363762343036663035373600000000";
     const secondTxOutputs = await btcUtils.getOutputs(secondRawTX);
 
-    const secondQuoteHash = web3.utils.hexToAscii(await btcUtils.parseNullDataScript(secondTxOutputs[1].pkScript));
+    const secondNullScript = await btcUtils.parseNullDataScript(secondTxOutputs[1].pkScript);
     const secondDestinationAddress = await btcUtils.parsePayToPubKeyHash(secondTxOutputs[0].pkScript, true);
     const secondValue = secondTxOutputs[0].value;
     const secondHash = await btcUtils.hashBtcTx(secondRawTX);
 
-    expect(firstQuoteHash).to.eq("984944d58092156c5a19d965b9a758502e6dbc2d9537315ebf489736314eb347");
+    expect(firstNullScript).to.eq("0x4039383439343464353830393231353663356131396439363562396137353835303265366462633264393533373331356562663438393733363331346562333437");
     expect(firstDestinationAddress).to.eq("0x6f3c5f66fe733e0ad361805b3053f23212e5755c8d");
     expect(firstValue).to.eq("60000000");
     expect(firstHash).to.eq("0x03c4522ef958f724a7d2ffef04bd534d9eca74ffc0b28308797d2853bc323ba6");
 
-    expect(secondQuoteHash).to.eq("e94a89712629bbc9fccd1f0c04a278c0e1052eb7626f93e9a7f1067b406f0576");
+    expect(secondNullScript).to.eq("0x4065393461383937313236323962626339666363643166306330346132373863306531303532656237363236663933653961376631303637623430366630353736");
     expect(secondDestinationAddress).to.eq("0x003c5f66fe733e0ad361805b3053f23212e5755c8d");
     expect(secondValue).to.eq("70000000");
     expect(secondHash).to.eq("0xfd4251485dafe36aaa6766b38cf236b5925f23f12617daf286e0e92f73708aa3");


### PR DESCRIPTION
## What
Update BtcUtils lib

## Why
To adapt to the new changes (now `parseNullScript` doesn't assume 1st byte as the size)

## Task
https://rsklabs.atlassian.net/browse/GBI-1652