### PR TITLE
fix: remove initializeV2 function

### DIFF
--- a/contracts/LiquidityBridgeContractV2.sol
+++ b/contracts/LiquidityBridgeContractV2.sol
@@ -125,14 +125,6 @@ contract LiquidityBridgeContractV2 is Initializable, OwnableUpgradeable, Reentra
         _;
     }
 
-    function initializeV2(
-        uint256 _productFeePercentage,
-        address _daoFeeCollectorAddress
-    ) public {
-        productFeePercentage = _productFeePercentage;
-        daoFeeCollectorAddress = _daoFeeCollectorAddress;
-    }
-
     modifier onlyOwnerAndProvider(uint _providerId) {
         require(
             msg.sender == owner() ||

--- a/migrations/3_upgrade_contracts.js
+++ b/migrations/3_upgrade_contracts.js
@@ -39,19 +39,5 @@ module.exports = async function (deployer, network, accounts) {
         { deployer, unsafeAllowLinkedLibraries: true }
     );
 
-    let daoFeeCollectorAddress = '';
-
-    if(network === 'ganache' || network === 'rskRegtest' || network === 'test') {
-        daoFeeCollectorAddress = accounts[8];
-    } else if(network === 'rskTestnet') {
-        daoFeeCollectorAddress = FEE_COLLECTOR_TESTNET_ADDRESS;
-    } else if(network === 'rskMainnet'){
-        daoFeeCollectorAddress = FEE_COLLECTOR_MAINNET_ADDRESS;
-    } else {
-        throw new Error('Unknown network');
-    }
-
-    await response.initializeV2(DAO_FEE_PERCENTAGE, daoFeeCollectorAddress);
-
     console.log("Upgraded", response.address);
 };


### PR DESCRIPTION
## What
Remove initializeV2 function from the contract and deployment scripts

## Why
This function generates a vulnerability because it is not restricted to the owner of the contract, the proper solution would be to restrict it so the owner is the only one who can execute it. However, since we're dealing with contract size issues and we're planning a contract split we decided to just remove it at the moment.

## Task
https://rsklabs.atlassian.net/browse/GBI-1813