### PR TITLE
Bugfix/GBI-1873 - Merge withdraw collateral functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           node-version: '19.6.0'
 
+      - name: NPM Login
+        run: npm config set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}
+
       - name: Install truffle
         run: npm install -g truffle
       

--- a/contracts/LiquidityBridgeContractV2.sol
+++ b/contracts/LiquidityBridgeContractV2.sol
@@ -708,7 +708,10 @@ contract LiquidityBridgeContractV2 is Initializable, OwnableUpgradeable, Reentra
             "LBC049"
         );
         require(quote.value <= outputs[PAY_TO_ADDRESS_OUTPUT].value * (10**10), "LBC067"); // satoshi to wei
-        bytes memory btcTxDestination = BtcUtils.parsePayToPubKeyHash(outputs[PAY_TO_ADDRESS_OUTPUT].pkScript, mainnet);
+        bytes memory btcTxDestination = BtcUtils.outputScriptToAddress(
+            outputs[PAY_TO_ADDRESS_OUTPUT].pkScript,
+            mainnet
+        );
         require(keccak256(quote.deposityAddress) == keccak256(btcTxDestination), "LBC068");
 
         if (

--- a/contracts/LiquidityBridgeContractV2.sol
+++ b/contracts/LiquidityBridgeContractV2.sol
@@ -58,7 +58,6 @@ contract LiquidityBridgeContractV2 is Initializable, OwnableUpgradeable, Reentra
     event PegoutCollateralIncrease(address from, uint256 amount);
     event Withdrawal(address from, uint256 amount);
     event WithdrawCollateral(address from, uint256 amount);
-    event PegoutWithdrawCollateral(address from, uint256 amount);
     event Resigned(address from);
     event CallForUser(
         address indexed from,
@@ -313,34 +312,20 @@ contract LiquidityBridgeContractV2 is Initializable, OwnableUpgradeable, Reentra
     /**
         @dev Used to withdraw the locked collateral
      */
-    function withdrawCollateral() external {
+    function withdrawCollateral() external nonReentrant {
         require(resignationBlockNum[msg.sender] > 0, "LBC021");
         require(
             block.number - resignationBlockNum[msg.sender] >=
             resignDelayInBlocks,
             "LBC022"
         );
-        uint amount = collateral[msg.sender];
+        uint amount = collateral[msg.sender] + pegoutCollateral[msg.sender];
+        pegoutCollateral[msg.sender] = 0;
         collateral[msg.sender] = 0;
         resignationBlockNum[msg.sender] = 0;
         (bool success,) = msg.sender.call{value: amount}("");
         require(success, "LBC020");
         emit WithdrawCollateral(msg.sender, amount);
-    }
-
-    function withdrawPegoutCollateral() external {
-        require(resignationBlockNum[msg.sender] > 0, "LBC021");
-        require(
-            block.number - resignationBlockNum[msg.sender] >=
-            resignDelayInBlocks,
-            "LBC022"
-        );
-        uint amount = pegoutCollateral[msg.sender];
-        pegoutCollateral[msg.sender] = 0;
-        resignationBlockNum[msg.sender] = 0;
-        (bool success,) = msg.sender.call{value: amount}("");
-        require(success, "LBC020");
-        emit PegoutWithdrawCollateral(msg.sender, amount);
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@openzeppelin/contracts": "^4.8.0",
         "@openzeppelin/contracts-upgradeable": "^4.8.2",
-        "@rsksmart/btc-transaction-solidity-helper": "^0.0.3",
+        "@rsksmart/btc-transaction-solidity-helper": "^0.1.0",
         "@truffle/hdwallet-provider": "^2.1.3",
         "chai": "^4.3.4",
         "chai-bn": "^0.3.0",
@@ -3072,9 +3072,10 @@
       "peer": true
     },
     "node_modules/@rsksmart/btc-transaction-solidity-helper": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@rsksmart/btc-transaction-solidity-helper/-/btc-transaction-solidity-helper-0.0.3.tgz",
-      "integrity": "sha512-x4SzwxhyMWZGwj6ycUZvM/2uVcIQ4hhWZ3DJeJ1LHcza1nA9ghPH7dDGQYeuWAmJwgz9P4mW+f/9Wahe0KQ3Ew=="
+      "version": "0.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@rsksmart/btc-transaction-solidity-helper/0.1.0/1363b91bc24c38f2f45d816c1fa101383d8d3b99",
+      "integrity": "sha512-BplgAZDWdck/BIXCyJjrJMMmzyEtwNkRvHQgRxfrkicHykgdvhifRRSho5jd91uqWSggNNUnMOsgzLwEE4FYWg==",
+      "license": "ISC"
     },
     "node_modules/@rsksmart/pmt-builder": {
       "version": "3.0.0",
@@ -10154,6 +10155,7 @@
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.5.tgz",
       "integrity": "sha512-HTm14iMQKK2FjFLRTM5lAVcyaUzOnqbPtesFIvREgXpJHdQm8bWS+GkQgIkfaBYRHuCnea7w8UVNfwiAQhlr9A==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -10539,6 +10541,7 @@
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.7.tgz",
       "integrity": "sha512-vLt1O5Pp+flcArHGIyKEQq883nBt8nN8tVBcoL0qUXj2XT1n7p70yGIq2VK98I5FdZ1YHc0wk/koOnHjnXWk1Q==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -21756,9 +21759,9 @@
       "peer": true
     },
     "@rsksmart/btc-transaction-solidity-helper": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@rsksmart/btc-transaction-solidity-helper/-/btc-transaction-solidity-helper-0.0.3.tgz",
-      "integrity": "sha512-x4SzwxhyMWZGwj6ycUZvM/2uVcIQ4hhWZ3DJeJ1LHcza1nA9ghPH7dDGQYeuWAmJwgz9P4mW+f/9Wahe0KQ3Ew=="
+      "version": "0.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@rsksmart/btc-transaction-solidity-helper/0.1.0/1363b91bc24c38f2f45d816c1fa101383d8d3b99",
+      "integrity": "sha512-BplgAZDWdck/BIXCyJjrJMMmzyEtwNkRvHQgRxfrkicHykgdvhifRRSho5jd91uqWSggNNUnMOsgzLwEE4FYWg=="
     },
     "@rsksmart/pmt-builder": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@openzeppelin/contracts": "^4.8.0",
     "@openzeppelin/contracts-upgradeable": "^4.8.2",
-    "@rsksmart/btc-transaction-solidity-helper": "^0.0.3",
+    "@rsksmart/btc-transaction-solidity-helper": "^0.1.0",
     "@truffle/hdwallet-provider": "^2.1.3",
     "chai": "^4.3.4",
     "chai-bn": "^0.3.0",


### PR DESCRIPTION
## What
- Merge withdraw collateral functions
- Update `BtcUtils` lib version

## Why
To prevent the bug when a LP resigned, then withdraws the pegin collateral and after that is unable to withdraw the pegout collateral

## Task
https://rsklabs.atlassian.net/browse/GBI-1873