### PR TITLE
Feature/GBI-1961 - Update getProviders

### DIFF
--- a/contracts/LiquidityBridgeContractV2.sol
+++ b/contracts/LiquidityBridgeContractV2.sol
@@ -255,26 +255,37 @@ contract LiquidityBridgeContractV2 is Initializable, OwnableUpgradeable, Reentra
         return (providerId);
     }
 
-    function getProviders(
-        uint[] memory providerIds
-    ) external view returns (LiquidityProvider[] memory) {
-        LiquidityProvider[] memory providersToReturn = new LiquidityProvider[](
-            providerIds.length
-        );
+    function getProviders() external view returns (LiquidityProvider[] memory) {
         uint count = 0;
-
-        for (uint i = 0; i < providerIds.length; i++) {
-            uint id = providerIds[i];
-            if (
-                (isRegistered(liquidityProviders[id].provider) ||
-                    isRegisteredForPegout(liquidityProviders[id].provider)) &&
-                liquidityProviders[id].status
-            ) {
-                providersToReturn[count] = liquidityProviders[id];
+        LiquidityProvider storage lp;
+        for (uint i = 1; i <= providerId; i++) {
+            if (shouldBeListed(liquidityProviders[i])) {
+                count++;
+            }
+        }
+        LiquidityProvider[] memory providersToReturn = new LiquidityProvider[](count);
+        count = 0;
+        for (uint i = 1; i <= providerId; i++) {
+            lp = liquidityProviders[i];
+            if (shouldBeListed(lp)) {
+                providersToReturn[count] = lp;
                 count++;
             }
         }
         return providersToReturn;
+    }
+
+    function getProvider(address providerAddress) public view returns (LiquidityProvider memory) {
+        for (uint i = 1; i <= providerId; i++) {
+            if (liquidityProviders[i].provider == providerAddress) {
+                return liquidityProviders[i];
+            }
+        }
+        revert("LBC001");
+    }
+
+    function shouldBeListed(LiquidityProvider storage lp) private view returns(bool){
+        return (isRegistered(lp.provider) || isRegisteredForPegout(lp.provider)) && lp.status;
     }
 
     /**

--- a/readme.MD
+++ b/readme.MD
@@ -140,12 +140,8 @@ Registers msg.sender as a liquidity provider with msg.value as collateral
     The registered provider ID
 
 ### **getProviders**
-    function getProviders(
-        uint[] memory providerIds
-    ) external view returns (LiquidityProvider[] memory)
+    function getProviders() external view returns (LiquidityProvider[] memory)
 Retrieves the information of a group of liquidity providers
-#### Parametets
-    * providerIds: IDs of the providers to fetch
 #### Return value
     Array with the information of the requested LPs
 

--- a/readme.MD
+++ b/readme.MD
@@ -145,6 +145,14 @@ Retrieves the information of a group of liquidity providers
 #### Return value
     Array with the information of the requested LPs
 
+### **getProvider**
+    function getProvider(address providerAddress) external view returns (LiquidityProvider memory)
+Retrieves the information of a specific liquidity provider, regardless if it has resigned or has been disabled
+#### Parameters
+    * providerAddress: address of the provider to fetch
+#### Return value
+    Information of the requested LP
+
 ### **withdrawCollateral**
     function withdrawCollateral() external
 Used to withdraw the locked collateral. It is only for LPs who have resigned

--- a/test/basic.tests.js
+++ b/test/basic.tests.js
@@ -2117,14 +2117,14 @@ contract("LiquidityBridgeContractV2.sol", async (accounts) => {
       await instance.setProviderStatus(7, false);
       /**
        * Providers statuses per account:
-       * 0 - active
-       * 1 - disabled
+       * 0 - disabled
+       * 1 - active
        * 2 - active
-       * 3 - resigned but active
+       * 3 - resigned and disabled
        * 4 - active
        * 5 - resigned but active
        * 6 - resigned but active
-       * 7 - resigned and disabled
+       * 7 - resigned but active
        * 8 - Not a provider
        * 9 - active
        */
@@ -2141,24 +2141,24 @@ contract("LiquidityBridgeContractV2.sol", async (accounts) => {
       expect(utils.parseLiquidityProvider(result[1])).to.deep.equal({
         id: 3,
         provider: accounts[4],
-        name: "modified name",
-        apiBaseUrl: "https://modified.com",
+        name: "First contract",
+        apiBaseUrl: "http://localhost/api",
         status: true,
         providerType: "both"
       });
       expect(utils.parseLiquidityProvider(result[2])).to.deep.equal({
         id: 4,
-        provider: accounts[2],
-        name: "modified name",
-        apiBaseUrl: "https://modified.com",
+        provider: accounts[1],
+        name: "First contract",
+        apiBaseUrl: "http://localhost/api",
         status: true,
         providerType: "both"
       });
       expect(utils.parseLiquidityProvider(result[3])).to.deep.equal({
         id: 5,
-        provider: accounts[3],
-        name: "modified name",
-        apiBaseUrl: "https://modified.com",
+        provider: accounts[2],
+        name: "Second contract",
+        apiBaseUrl: "http://localhost/api",
         status: true,
         providerType: "both"
       });

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -155,6 +155,17 @@ async function mineBlocks (blocks) {
   }
 };
 
+function parseLiquidityProvider(contractLp) {
+  return {
+    id: parseInt(contractLp.id),
+    provider: contractLp.provider,
+    name: contractLp.name,
+    apiBaseUrl: contractLp.apiBaseUrl,
+    status: contractLp.status,
+    providerType: contractLp.providerType,
+  };
+}
+
 module.exports = {
   getTestQuote,
   getTestPegOutQuote,
@@ -166,5 +177,6 @@ module.exports = {
   reverseHexBytes,
   generateRawTx,
   mineBlocks,
-  RESIGN_DELAY_BLOCKS
+  RESIGN_DELAY_BLOCKS,
+  parseLiquidityProvider
 };


### PR DESCRIPTION
## What
- Update get providers function to remove the id array parameter
- Add getProvider function

## Why
This function had multiple issues when listing disabled or resigned providers, also, it required the caller to know which ids to fetch but the caller was using this function to know the available ids in first place

## Task
https://rsklabs.atlassian.net/browse/GBI-1961