### PR TITLE
fix: pay gasFee on refundPegout

### DIFF
--- a/contracts/LiquidityBridgeContractV2.sol
+++ b/contracts/LiquidityBridgeContractV2.sol
@@ -730,7 +730,7 @@ contract LiquidityBridgeContractV2 is Initializable, OwnableUpgradeable, Reentra
         }
 
         (bool sent,) = quote.lpRskAddress.call{
-                value: quote.value + quote.callFee
+                value: quote.value + quote.callFee + quote.gasFee
             }("");
         require(sent, "LBC050");
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8847,7 +8847,6 @@
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.5.tgz",
       "integrity": "sha512-HTm14iMQKK2FjFLRTM5lAVcyaUzOnqbPtesFIvREgXpJHdQm8bWS+GkQgIkfaBYRHuCnea7w8UVNfwiAQhlr9A==",
       "dev": true,
-      "hasInstallScript": true,
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -9233,7 +9232,6 @@
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.7.tgz",
       "integrity": "sha512-vLt1O5Pp+flcArHGIyKEQq883nBt8nN8tVBcoL0qUXj2XT1n7p70yGIq2VK98I5FdZ1YHc0wk/koOnHjnXWk1Q==",
       "dev": true,
-      "hasInstallScript": true,
       "optional": true,
       "peer": true,
       "dependencies": {

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -75,7 +75,7 @@ function getTestPegOutQuote(lbcAddress, lpRskAddress, rskRefundAddress, value, b
   }
 
   let valueToTransfer = value || web3.utils.toBN(0);
-  let callFee = web3.utils.toBN(1);
+  const callFee = web3.utils.toBN(2);
   let nonce = 0;
   let agreementTimestamp = 1661788988;
   let expireDate = Math.round(new Date().getTime() / 1000) + 3600;
@@ -86,7 +86,7 @@ function getTestPegOutQuote(lbcAddress, lpRskAddress, rskRefundAddress, value, b
   let transferConfirmations = 10;
   let penaltyFee = web3.utils.toBN(0);
   let productFeeAmount = web3.utils.toBN(1);
-  const gasFee = web3.utils.toBN(1);
+  const gasFee = web3.utils.toBN(42);
 
   let quote = {
     lbcAddress,


### PR DESCRIPTION
## What
Include gas fee in the refund amount of the `refundPegout` function

## Why
Because that fee is supposed to go to the LP as well, not to remain in the contract

## Task
https://rsklabs.atlassian.net/browse/GBI-2171