### PR TITLE
LBC Deployer docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /home/node
 COPY --chown=node:node package.json \
     package-lock.json \
     deploy.sh \
+    .solhintignore \
     .solhint.json \
     hardhat.config.ts \
     tsconfig.json \

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
-npm config set //npm.pkg.github.com/:_authToken "$GITHUB_TOKEN"
-
 npx hardhat run scripts/deployment/deploy-lbc.ts --network "$NETWORK_NAME"
 npx hardhat run scripts/deployment/upgrade-lbc.ts --network "$NETWORK_NAME"
 
-LBC_ADDRESS=$(jq -r '.rskRegtest.LiquidityBridgeContract.address' ./addresses.json)
+LBC_ADDRESS=$(jq -r '.[env.NETWORK_NAME].LiquidityBridgeContract.address' ./addresses.json)
 echo "LBC_ADDRESS=$LBC_ADDRESS"


### PR DESCRIPTION
## What
Update docker image to publish it in the GH registry

## Why
To pull the image from the LPS scripts and workflows, so we don't need to clone and install this repository every time we need to set up the LPS environment

## Comments
@rafaiovlabs Feel free to propose or push to this branch any change needed to be able to publish this in the GH registry in the proper way

## Task
https://rsklabs.atlassian.net/browse/GBI-2851