### PR TITLE
feat: add centralized pause registry

### DIFF
--- a/script/ComputeStorageSlot.s.sol
+++ b/script/ComputeStorageSlot.s.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import "forge-std/Script.sol";
+
+contract ComputeStorageSlot is Script {
+    function run() external view {
+        bytes32 slotPauseRegistry = bytes32(
+            uint256(
+                keccak256(
+                    abi.encode(
+                        uint256(keccak256("rsk.flyover.PauseRegistry")) - 1
+                    )
+                )
+            ) & ~uint256(0xff)
+        );
+        bytes32 slotEmergencyPause = bytes32(
+            uint256(
+                keccak256(
+                    abi.encode(
+                        uint256(keccak256("rsk.flyover.EmergencyPause")) - 1
+                    )
+                )
+            ) & ~uint256(0xff)
+        );
+        console.logBytes32(slotPauseRegistry);
+        console.logBytes32(slotEmergencyPause);
+    }
+}

--- a/script/deployment/DeployFlyover.s.sol
+++ b/script/deployment/DeployFlyover.s.sol
@@ -7,6 +7,7 @@ import {HelperConfig} from "../HelperConfig.s.sol";
 
 import {CollateralManagementContract} from "../../src/CollateralManagement.sol";
 import {FlyoverDiscovery} from "../../src/FlyoverDiscovery.sol";
+import {PauseRegistry} from "../../src/PauseRegistry.sol";
 import {PegInContract} from "../../src/PegInContract.sol";
 import {PegOutContract} from "../../src/PegOutContract.sol";
 
@@ -18,6 +19,7 @@ import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.s
 /// @dev Gas optimized: single ProxyAdmin, inlined deployment logic, linked libraries
 contract DeployFlyover is Script {
     struct FlyoverDeployment {
+        address pauseRegistryProxy;
         address collateralManagementImpl;
         address collateralManagementProxy;
         address flyoverDiscoveryImpl;
@@ -54,6 +56,16 @@ contract DeployFlyover is Script {
         // Single ProxyAdmin for all contracts
         d.proxyAdmin = address(new ProxyAdmin(defaultAdmin));
 
+        // 0) PauseRegistry (shared by all)
+        PauseRegistry prImpl = new PauseRegistry();
+        d.pauseRegistryProxy = address(
+            new TransparentUpgradeableProxy(
+                address(prImpl),
+                d.proxyAdmin,
+                abi.encodeCall(prImpl.initialize, (0, defaultAdmin))
+            )
+        );
+
         // 1) CollateralManagement
         d.collateralManagementImpl = address(
             new CollateralManagementContract()
@@ -69,7 +81,8 @@ contract DeployFlyover is Script {
                         cfg.adminDelay,
                         cfg.minimumCollateral,
                         cfg.resignDelayBlocks,
-                        cfg.rewardPercentage
+                        cfg.rewardPercentage,
+                        PauseRegistry(d.pauseRegistryProxy)
                     )
                 )
             )
@@ -83,7 +96,12 @@ contract DeployFlyover is Script {
                 d.proxyAdmin,
                 abi.encodeCall(
                     FlyoverDiscovery.initialize,
-                    (defaultAdmin, cfg.adminDelay, d.collateralManagementProxy)
+                    (
+                        defaultAdmin,
+                        cfg.adminDelay,
+                        d.collateralManagementProxy,
+                        PauseRegistry(d.pauseRegistryProxy)
+                    )
                 )
             )
         );
@@ -102,7 +120,8 @@ contract DeployFlyover is Script {
                         cfg.dustThreshold,
                         cfg.minimumPegIn,
                         d.collateralManagementProxy,
-                        cfg.mainnet
+                        cfg.mainnet,
+                        PauseRegistry(d.pauseRegistryProxy)
                     )
                 )
             )
@@ -122,7 +141,8 @@ contract DeployFlyover is Script {
                         cfg.dustThreshold,
                         d.collateralManagementProxy,
                         cfg.mainnet,
-                        cfg.btcBlockTime
+                        cfg.btcBlockTime,
+                        PauseRegistry(d.pauseRegistryProxy)
                     )
                 )
             )
@@ -144,6 +164,7 @@ contract DeployFlyover is Script {
     function _log(FlyoverDeployment memory d) private pure {
         console.log("=== FLYOVER DEPLOYMENT ===");
         console.log("ProxyAdmin:", d.proxyAdmin);
+        console.log("PauseRegistry proxy:", d.pauseRegistryProxy);
         console.log("CollateralManagement impl:", d.collateralManagementImpl);
         console.log("CollateralManagement proxy:", d.collateralManagementProxy);
         console.log("FlyoverDiscovery impl:", d.flyoverDiscoveryImpl);

--- a/script/deployment/DeployFlyoverDiscovery.s.sol
+++ b/script/deployment/DeployFlyoverDiscovery.s.sol
@@ -4,12 +4,13 @@ pragma solidity 0.8.25;
 import {Script, console} from "lib/forge-std/src/Script.sol";
 import {HelperConfig} from "../HelperConfig.s.sol";
 import {FlyoverDiscovery} from "../../src/FlyoverDiscovery.sol";
+import {PauseRegistry} from "../../src/PauseRegistry.sol";
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 
 /// @title DeployFlyoverDiscovery
 /// @notice Deploys the FlyoverDiscovery contract with proxy pattern
-/// @dev Requires COLLATERAL_MANAGEMENT_PROXY env var
+/// @dev Requires COLLATERAL_MANAGEMENT_PROXY and PAUSE_REGISTRY_PROXY env vars
 contract DeployFlyoverDiscovery is Script {
     struct DeploymentResult {
         address implementation;
@@ -26,13 +27,23 @@ contract DeployFlyoverDiscovery is Script {
         address collateralManagementProxy = vm.envAddress(
             "COLLATERAL_MANAGEMENT_PROXY"
         );
+        address pauseRegistryProxy = vm.envAddress("PAUSE_REGISTRY_PROXY");
         require(
             collateralManagementProxy != address(0),
             "COLLATERAL_MANAGEMENT_PROXY required"
         );
+        require(
+            pauseRegistryProxy != address(0),
+            "PAUSE_REGISTRY_PROXY required"
+        );
 
         vm.startBroadcast(deployerKey);
-        result = _deploy(deployer, cfg, collateralManagementProxy);
+        result = _deploy(
+            deployer,
+            cfg,
+            collateralManagementProxy,
+            pauseRegistryProxy
+        );
         vm.stopBroadcast();
 
         _log(result);
@@ -41,7 +52,8 @@ contract DeployFlyoverDiscovery is Script {
     function _deploy(
         address defaultAdmin,
         HelperConfig.FlyoverConfig memory cfg,
-        address collateralManagementProxy
+        address collateralManagementProxy,
+        address pauseRegistryProxy
     ) private returns (DeploymentResult memory result) {
         result.implementation = address(new FlyoverDiscovery());
         result.admin = address(new ProxyAdmin(defaultAdmin));
@@ -51,7 +63,12 @@ contract DeployFlyoverDiscovery is Script {
                 result.admin,
                 abi.encodeCall(
                     FlyoverDiscovery.initialize,
-                    (defaultAdmin, cfg.adminDelay, collateralManagementProxy)
+                    (
+                        defaultAdmin,
+                        cfg.adminDelay,
+                        collateralManagementProxy,
+                        PauseRegistry(pauseRegistryProxy)
+                    )
                 )
             )
         );

--- a/script/deployment/DeployPauseRegistry.s.sol
+++ b/script/deployment/DeployPauseRegistry.s.sol
@@ -3,15 +3,13 @@ pragma solidity 0.8.25;
 
 import {Script, console} from "lib/forge-std/src/Script.sol";
 import {HelperConfig} from "../HelperConfig.s.sol";
-import {CollateralManagementContract} from "../../src/CollateralManagement.sol";
 import {PauseRegistry} from "../../src/PauseRegistry.sol";
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 
-/// @title DeployCollateralManagement
-/// @notice Deploys the CollateralManagement contract with proxy pattern
-/// @dev Requires PAUSE_REGISTRY_PROXY env var
-contract DeployCollateralManagement is Script {
+/// @title DeployPauseRegistry
+/// @notice Deploys the PauseRegistry with proxy pattern (no dependencies)
+contract DeployPauseRegistry is Script {
     struct DeploymentResult {
         address implementation;
         address proxy;
@@ -20,51 +18,32 @@ contract DeployCollateralManagement is Script {
 
     function run() external returns (DeploymentResult memory result) {
         HelperConfig helper = new HelperConfig();
-        HelperConfig.FlyoverConfig memory cfg = helper.getFlyoverConfig();
         uint256 deployerKey = helper.getDeployerPrivateKey();
         address deployer = vm.rememberKey(deployerKey);
 
-        address pauseRegistryProxy = vm.envAddress("PAUSE_REGISTRY_PROXY");
-        require(
-            pauseRegistryProxy != address(0),
-            "PAUSE_REGISTRY_PROXY required"
-        );
-
         vm.startBroadcast(deployerKey);
-        result = _deploy(deployer, cfg, pauseRegistryProxy);
+        result = _deploy(deployer);
         vm.stopBroadcast();
 
         _log(result);
     }
 
     function _deploy(
-        address defaultAdmin,
-        HelperConfig.FlyoverConfig memory cfg,
-        address pauseRegistryProxy
+        address defaultAdmin
     ) private returns (DeploymentResult memory result) {
-        result.implementation = address(new CollateralManagementContract());
+        result.implementation = address(new PauseRegistry());
         result.admin = address(new ProxyAdmin(defaultAdmin));
         result.proxy = address(
             new TransparentUpgradeableProxy(
                 result.implementation,
                 result.admin,
-                abi.encodeCall(
-                    CollateralManagementContract.initialize,
-                    (
-                        defaultAdmin,
-                        cfg.adminDelay,
-                        cfg.minimumCollateral,
-                        cfg.resignDelayBlocks,
-                        cfg.rewardPercentage,
-                        PauseRegistry(pauseRegistryProxy)
-                    )
-                )
+                abi.encodeCall(PauseRegistry.initialize, (0, defaultAdmin))
             )
         );
     }
 
     function _log(DeploymentResult memory r) private pure {
-        console.log("=== CollateralManagement Deployed ===");
+        console.log("=== PauseRegistry Deployed ===");
         console.log("Implementation:", r.implementation);
         console.log("Proxy:", r.proxy);
         console.log("ProxyAdmin:", r.admin);

--- a/script/deployment/DeployPegIn.s.sol
+++ b/script/deployment/DeployPegIn.s.sol
@@ -4,12 +4,13 @@ pragma solidity 0.8.25;
 import {Script, console} from "lib/forge-std/src/Script.sol";
 import {HelperConfig} from "../HelperConfig.s.sol";
 import {PegInContract} from "../../src/PegInContract.sol";
+import {PauseRegistry} from "../../src/PauseRegistry.sol";
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 
 /// @title DeployPegIn
 /// @notice Deploys the PegInContract with proxy pattern
-/// @dev Requires COLLATERAL_MANAGEMENT_PROXY env var
+/// @dev Requires COLLATERAL_MANAGEMENT_PROXY and PAUSE_REGISTRY_PROXY env vars
 contract DeployPegIn is Script {
     struct DeploymentResult {
         address implementation;
@@ -26,13 +27,23 @@ contract DeployPegIn is Script {
         address collateralManagementProxy = vm.envAddress(
             "COLLATERAL_MANAGEMENT_PROXY"
         );
+        address pauseRegistryProxy = vm.envAddress("PAUSE_REGISTRY_PROXY");
         require(
             collateralManagementProxy != address(0),
             "COLLATERAL_MANAGEMENT_PROXY required"
         );
+        require(
+            pauseRegistryProxy != address(0),
+            "PAUSE_REGISTRY_PROXY required"
+        );
 
         vm.startBroadcast(deployerKey);
-        result = _deploy(deployer, cfg, collateralManagementProxy);
+        result = _deploy(
+            deployer,
+            cfg,
+            collateralManagementProxy,
+            pauseRegistryProxy
+        );
         vm.stopBroadcast();
 
         _log(result);
@@ -41,7 +52,8 @@ contract DeployPegIn is Script {
     function _deploy(
         address defaultAdmin,
         HelperConfig.FlyoverConfig memory cfg,
-        address collateralManagementProxy
+        address collateralManagementProxy,
+        address pauseRegistryProxy
     ) private returns (DeploymentResult memory result) {
         result.implementation = address(new PegInContract());
         result.admin = address(new ProxyAdmin(defaultAdmin));
@@ -57,7 +69,8 @@ contract DeployPegIn is Script {
                         cfg.dustThreshold,
                         cfg.minimumPegIn,
                         collateralManagementProxy,
-                        cfg.mainnet
+                        cfg.mainnet,
+                        PauseRegistry(pauseRegistryProxy)
                     )
                 )
             )

--- a/script/deployment/DeployPegOut.s.sol
+++ b/script/deployment/DeployPegOut.s.sol
@@ -4,12 +4,13 @@ pragma solidity 0.8.25;
 import {Script, console} from "lib/forge-std/src/Script.sol";
 import {HelperConfig} from "../HelperConfig.s.sol";
 import {PegOutContract} from "../../src/PegOutContract.sol";
+import {PauseRegistry} from "../../src/PauseRegistry.sol";
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 
 /// @title DeployPegOut
 /// @notice Deploys the PegOutContract with proxy pattern
-/// @dev Requires COLLATERAL_MANAGEMENT_PROXY env var
+/// @dev Requires COLLATERAL_MANAGEMENT_PROXY and PAUSE_REGISTRY_PROXY env vars
 contract DeployPegOut is Script {
     struct DeploymentResult {
         address implementation;
@@ -26,13 +27,23 @@ contract DeployPegOut is Script {
         address collateralManagementProxy = vm.envAddress(
             "COLLATERAL_MANAGEMENT_PROXY"
         );
+        address pauseRegistryProxy = vm.envAddress("PAUSE_REGISTRY_PROXY");
         require(
             collateralManagementProxy != address(0),
             "COLLATERAL_MANAGEMENT_PROXY required"
         );
+        require(
+            pauseRegistryProxy != address(0),
+            "PAUSE_REGISTRY_PROXY required"
+        );
 
         vm.startBroadcast(deployerKey);
-        result = _deploy(deployer, cfg, collateralManagementProxy);
+        result = _deploy(
+            deployer,
+            cfg,
+            collateralManagementProxy,
+            pauseRegistryProxy
+        );
         vm.stopBroadcast();
 
         _log(result);
@@ -41,7 +52,8 @@ contract DeployPegOut is Script {
     function _deploy(
         address defaultAdmin,
         HelperConfig.FlyoverConfig memory cfg,
-        address collateralManagementProxy
+        address collateralManagementProxy,
+        address pauseRegistryProxy
     ) private returns (DeploymentResult memory result) {
         result.implementation = address(new PegOutContract());
         result.admin = address(new ProxyAdmin(defaultAdmin));
@@ -57,7 +69,8 @@ contract DeployPegOut is Script {
                         cfg.dustThreshold,
                         collateralManagementProxy,
                         cfg.mainnet,
-                        cfg.btcBlockTime
+                        cfg.btcBlockTime,
+                        PauseRegistry(pauseRegistryProxy)
                     )
                 )
             )

--- a/script/helpers/AddressResolver.sol
+++ b/script/helpers/AddressResolver.sol
@@ -88,6 +88,12 @@ library AddressResolverLib {
                 "CollateralManagement"
             );
     }
+
+    /// @notice Get PauseRegistry contract address
+    function getPauseRegistryAddress(Vm vm) internal view returns (address) {
+        return
+            getContractAddress(vm, "PAUSE_REGISTRY_ADDRESS", "PauseRegistry");
+    }
 }
 
 /**
@@ -119,5 +125,9 @@ abstract contract AddressResolver {
 
     function getCollateralManagementAddress() internal view returns (address) {
         return AddressResolverLib.getCollateralManagementAddress(VM);
+    }
+
+    function getPauseRegistryAddress() internal view returns (address) {
+        return AddressResolverLib.getPauseRegistryAddress(VM);
     }
 }

--- a/script/tasks/PauseSystem.s.sol
+++ b/script/tasks/PauseSystem.s.sol
@@ -7,12 +7,15 @@ import {AddressResolver} from "../helpers/AddressResolver.sol";
 
 /**
  * @title PauseSystem
- * @notice Foundry script to pause/unpause all Flyover system contracts simultaneously
- * @dev This script handles FlyoverDiscovery, PegInContract, PegOutContract, and CollateralManagementContract
+ * @notice Foundry script to pause/unpause the Flyover system via the central PauseRegistry
+ * @dev All Flyover contracts (Discovery, PegIn, PegOut, Collateral) read pause state from PauseRegistry.
+ *      Signer must have PAUSER_ROLE on the PauseRegistry.
+ *      Before running, verifies that PegIn, PegOut, CollateralManagement and FlyoverDiscovery
+ *      all use the same PauseRegistry; otherwise the task fails.
  *
  * ## Prerequisites
- * - Contract addresses must be provided via environment variables or addresses.json
- * - Signer must have PAUSER_ROLE on all contracts
+ * - PAUSE_REGISTRY_ADDRESS must be set (or PauseRegistry in addresses.json)
+ * - Signer must have PAUSER_ROLE on the PauseRegistry
  *
  * ## Usage
  *
@@ -36,111 +39,94 @@ import {AddressResolver} from "../helpers/AddressResolver.sol";
  *     --private-key <private-key>
  *
  * ## Environment Variables
- * - FLYOVER_DISCOVERY_ADDRESS: Address of FlyoverDiscovery contract
- * - PEGIN_CONTRACT_ADDRESS: Address of PegInContract
- * - PEGOUT_CONTRACT_ADDRESS: Address of PegOutContract
- * - COLLATERAL_MANAGEMENT_ADDRESS: Address of CollateralManagementContract
- * - NETWORK: Network name to use when reading from addresses.json (default: rskRegtest)
+ * - PAUSE_REGISTRY_ADDRESS: Address of PauseRegistry (required; or set in addresses.json)
+ * - PEGIN_CONTRACT_ADDRESS, PEGOUT_CONTRACT_ADDRESS, COLLATERAL_MANAGEMENT_ADDRESS, FLYOVER_DISCOVERY_ADDRESS:
+ *   Used to verify all contracts point to the same registry (or from addresses.json)
+ * - NETWORK: Network name for addresses.json (default: rskRegtest)
  */
 
-interface IPausable {
-    function pause(string calldata reason) external;
+import {IPauseRegistry} from "../../src/interfaces/IPauseRegistry.sol";
 
-    function unpause() external;
-
-    function pauseStatus()
-        external
-        view
-        returns (bool isPaused, string memory reason, uint64 since);
+/// @dev Minimal interface to read pauseRegistry() from contracts that inherit EmergencyPause
+interface IPauseRegistryGetter {
+    function pauseRegistry() external view returns (IPauseRegistry);
 }
 
 contract PauseSystem is Script, AddressResolver {
-    struct ContractInfo {
-        string name;
-        address addr;
-        bool isPaused;
-        string reason;
-        uint64 since;
-    }
-
-    error PartialPauseFailure(
-        uint256 succeeded,
-        uint256 total,
-        string[] failedContracts
-    );
-    error PartialUnpauseFailure(
-        uint256 succeeded,
-        uint256 total,
-        string[] failedContracts
-    );
-
     /**
-     * @notice Load all contract addresses
+     * @notice Resolve PauseRegistry from env / addresses.json
      */
-    function loadContracts() internal view returns (ContractInfo[] memory) {
-        ContractInfo[] memory contracts = new ContractInfo[](4);
-
-        contracts[0].name = "FlyoverDiscovery";
-        contracts[0].addr = getFlyoverDiscoveryAddress();
-
-        contracts[1].name = "PegInContract";
-        contracts[1].addr = getPegInAddress();
-
-        contracts[2].name = "PegOutContract";
-        contracts[2].addr = getPegOutAddress();
-
-        contracts[3].name = "CollateralManagement";
-        contracts[3].addr = getCollateralManagementAddress();
-
-        return contracts;
+    function getPauseRegistry() internal view returns (IPauseRegistry) {
+        return IPauseRegistry(getPauseRegistryAddress());
     }
 
     /**
-     * @notice Check and display pause status of all contracts
+     * @notice Verify PegIn, PegOut, CollateralManagement and FlyoverDiscovery all use the same registry
+     * @param registry The expected PauseRegistry address
+     * @dev Reverts if any contract has a different registry
+     */
+    function _verifyAllContractsUseRegistry(
+        IPauseRegistry registry
+    ) internal view {
+        address expected = address(registry);
+
+        address pegInAddr = getPegInAddress();
+        require(
+            address(IPauseRegistryGetter(pegInAddr).pauseRegistry()) ==
+                expected,
+            "PauseSystem: PegInContract has different PauseRegistry"
+        );
+
+        address pegOutAddr = getPegOutAddress();
+        require(
+            address(IPauseRegistryGetter(pegOutAddr).pauseRegistry()) ==
+                expected,
+            "PauseSystem: PegOutContract has different PauseRegistry"
+        );
+
+        address collateralAddr = getCollateralManagementAddress();
+        require(
+            address(IPauseRegistryGetter(collateralAddr).pauseRegistry()) ==
+                expected,
+            "PauseSystem: CollateralManagement has different PauseRegistry"
+        );
+
+        address discoveryAddr = getFlyoverDiscoveryAddress();
+        require(
+            address(IPauseRegistryGetter(discoveryAddr).pauseRegistry()) ==
+                expected,
+            "PauseSystem: FlyoverDiscovery has different PauseRegistry"
+        );
+    }
+
+    /**
+     * @notice Check and display pause status (from central registry)
      */
     function checkStatus() public view {
         console.log("\n=== FLYOVER PAUSE STATUS ===\n");
 
-        ContractInfo[] memory contracts = loadContracts();
+        IPauseRegistry registry = getPauseRegistry();
+        _verifyAllContractsUseRegistry(registry);
 
-        console.log("Contract Addresses:");
-        for (uint256 i = 0; i < contracts.length; i++) {
-            console.log(
-                string.concat(
-                    "  ",
-                    contracts[i].name,
-                    ": ",
-                    vm.toString(contracts[i].addr)
-                )
-            );
-        }
+        console.log(
+            string.concat("PauseRegistry: ", vm.toString(address(registry)))
+        );
+        console.log("");
 
-        console.log("\nCurrent Pause Status:");
-        for (uint256 i = 0; i < contracts.length; i++) {
-            IPausable pausable = IPausable(contracts[i].addr);
-            (bool isPaused, string memory reason, uint64 since) = pausable
-                .pauseStatus();
+        (bool isPaused, string memory reason, uint64 since) = registry
+            .pauseStatus();
 
-            console.log(
-                string.concat(
-                    "  ",
-                    contracts[i].name,
-                    ": ",
-                    isPaused ? "PAUSED" : "ACTIVE"
-                )
-            );
-            if (isPaused) {
-                console.log(string.concat("    - Reason: ", reason));
-                console.log(string.concat("    - Since: ", vm.toString(since)));
-            }
+        console.log(string.concat("System: ", isPaused ? "PAUSED" : "ACTIVE"));
+        if (isPaused) {
+            console.log(string.concat("  Reason: ", reason));
+            console.log(string.concat("  Since: ", vm.toString(since)));
         }
 
         console.log("\n=============================\n");
     }
 
     /**
-     * @notice Pause all system contracts atomically
-     * @dev If any contract fails to pause, the entire transaction reverts to prevent inconsistent state
+     * @notice Pause the system via the central PauseRegistry (affects all Flyover contracts)
      */
     function pauseAll(string memory reason) public {
         require(bytes(reason).length > 0, "Reason cannot be empty");
@@ -148,112 +134,35 @@ contract PauseSystem is Script, AddressResolver {
         console.log("\n=== PAUSE OPERATION ===\n");
         console.log(string.concat("Reason: ", reason));
 
-        ContractInfo[] memory contracts = loadContracts();
+        IPauseRegistry registry = getPauseRegistry();
+        _verifyAllContractsUseRegistry(registry);
 
         vm.startBroadcast();
-
-        // First pass: attempt all pauses, collect failures
-        string[] memory failedContracts = new string[](contracts.length);
-        uint256 failCount = 0;
-
-        for (uint256 i = 0; i < contracts.length; i++) {
-            try IPausable(contracts[i].addr).pause(reason) {
-                console.log(
-                    string.concat("  [OK] ", contracts[i].name, " paused")
-                );
-            } catch Error(string memory error) {
-                console.log(
-                    string.concat("  [FAIL] ", contracts[i].name, " - ", error)
-                );
-                failedContracts[failCount] = contracts[i].name;
-                failCount++;
-            }
-        }
-
+        registry.pause(reason);
         vm.stopBroadcast();
 
-        uint256 successCount = contracts.length - failCount;
         console.log(
-            string.concat(
-                "\nPaused: ",
-                vm.toString(successCount),
-                "/",
-                vm.toString(contracts.length)
-            )
+            "  [OK] PauseRegistry paused - all Flyover contracts are now paused"
         );
-
-        // If any failed, revert the entire transaction to prevent inconsistent state
-        if (failCount > 0) {
-            // Trim the failed contracts array
-            string[] memory trimmedFailed = new string[](failCount);
-            for (uint256 i = 0; i < failCount; i++) {
-                trimmedFailed[i] = failedContracts[i];
-            }
-            revert PartialPauseFailure(
-                successCount,
-                contracts.length,
-                trimmedFailed
-            );
-        }
-
-        console.log("\n[SUCCESS] All contracts paused successfully!");
+        console.log("\n[SUCCESS] System paused successfully!");
     }
 
     /**
-     * @notice Unpause all system contracts atomically
-     * @dev If any contract fails to unpause, the entire transaction reverts to prevent inconsistent state
+     * @notice Unpause the system via the central PauseRegistry
      */
     function unpauseAll() public {
         console.log("\n=== UNPAUSE OPERATION ===\n");
 
-        ContractInfo[] memory contracts = loadContracts();
+        IPauseRegistry registry = getPauseRegistry();
+        _verifyAllContractsUseRegistry(registry);
 
         vm.startBroadcast();
-
-        // First pass: attempt all unpauses, collect failures
-        string[] memory failedContracts = new string[](contracts.length);
-        uint256 failCount = 0;
-
-        for (uint256 i = 0; i < contracts.length; i++) {
-            try IPausable(contracts[i].addr).unpause() {
-                console.log(
-                    string.concat("  [OK] ", contracts[i].name, " unpaused")
-                );
-            } catch Error(string memory error) {
-                console.log(
-                    string.concat("  [FAIL] ", contracts[i].name, " - ", error)
-                );
-                failedContracts[failCount] = contracts[i].name;
-                failCount++;
-            }
-        }
-
+        registry.unpause();
         vm.stopBroadcast();
 
-        uint256 successCount = contracts.length - failCount;
         console.log(
-            string.concat(
-                "\nUnpaused: ",
-                vm.toString(successCount),
-                "/",
-                vm.toString(contracts.length)
-            )
+            "  [OK] PauseRegistry unpaused - all Flyover contracts are now active"
         );
-
-        // If any failed, revert the entire transaction to prevent inconsistent state
-        if (failCount > 0) {
-            // Trim the failed contracts array
-            string[] memory trimmedFailed = new string[](failCount);
-            for (uint256 i = 0; i < failCount; i++) {
-                trimmedFailed[i] = failedContracts[i];
-            }
-            revert PartialUnpauseFailure(
-                successCount,
-                contracts.length,
-                trimmedFailed
-            );
-        }
-
-        console.log("\n[SUCCESS] All contracts unpaused successfully!");
+        console.log("\n[SUCCESS] System unpaused successfully!");
     }
 }

--- a/src/CollateralManagement.sol
+++ b/src/CollateralManagement.sol
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
+import {
+    AccessControlDefaultAdminRulesUpgradeable
+} from "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlDefaultAdminRulesUpgradeable.sol";
 import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {EmergencyPause} from "./EmergencyPause/EmergencyPause.sol";
 import {ICollateralManagement} from "./interfaces/ICollateralManagement.sol";
+import {IPauseRegistry} from "./interfaces/IPauseRegistry.sol";
 import {Flyover} from "./libraries/Flyover.sol";
 import {Quotes} from "./libraries/Quotes.sol";
 
@@ -13,6 +17,7 @@ import {Quotes} from "./libraries/Quotes.sol";
 /// This involves adding, slashing, resigning and withdrawing collateral.
 /// @author Rootstock Labs
 contract CollateralManagementContract is
+    AccessControlDefaultAdminRulesUpgradeable,
     ReentrancyGuardUpgradeable,
     EmergencyPause,
     ICollateralManagement
@@ -93,17 +98,20 @@ contract CollateralManagementContract is
     /// @param minCollateral The minimum collateral required for a liquidity provider **per operation**
     /// @param resignDelayInBlocks The delay in blocks before a liquidity provider can withdraw their collateral
     /// @param rewardPercentage The reward percentage from the penalty fee of the quotes that the punisher will receive
+    /// @param pauseRegistry The central PauseRegistry for pause state
     // solhint-disable-next-line comprehensive-interface
     function initialize(
         address defaultAdmin,
         uint48 initialDelay,
         uint256 minCollateral,
         uint256 resignDelayInBlocks,
-        uint256 rewardPercentage
+        uint256 rewardPercentage,
+        IPauseRegistry pauseRegistry
     ) external initializer {
+        if (address(pauseRegistry).code.length == 0) revert Flyover.NoContract(address(pauseRegistry));
+        __AccessControlDefaultAdminRules_init(initialDelay, defaultAdmin);
         __ReentrancyGuard_init();
-        // Initialize EmergencyPause (includes AccessControl, Pausable, and grants PAUSER_ROLE)
-        __EmergencyPause_init(initialDelay, defaultAdmin);
+        __EmergencyPause_init(pauseRegistry);
         _minCollateral = minCollateral;
         _resignDelayInBlocks = resignDelayInBlocks;
         _rewardPercentage = rewardPercentage;
@@ -138,7 +146,7 @@ contract CollateralManagementContract is
         address punisher,
         Quotes.PegInQuote calldata quote,
         bytes32 quoteHash
-    ) external whenNotPaused onlyRole(COLLATERAL_SLASHER) override {
+    ) external onlyRole(COLLATERAL_SLASHER) override {
         uint256 penalty = Math.min(
             quote.penaltyFee,
             _pegInCollateral[quote.liquidityProviderRskAddress]
@@ -162,7 +170,7 @@ contract CollateralManagementContract is
         address punisher,
         Quotes.PegOutQuote calldata quote,
         bytes32 quoteHash
-    ) external whenNotPaused onlyRole(COLLATERAL_SLASHER) override {
+    ) external onlyRole(COLLATERAL_SLASHER) override {
         uint penalty = Math.min(
             quote.penaltyFee,
             _pegOutCollateral[quote.lpRskAddress]
@@ -213,7 +221,7 @@ contract CollateralManagementContract is
     }
 
     /// @inheritdoc ICollateralManagement
-    function resign() external whenNotPaused override {
+    function resign() external override {
         address providerAddress = msg.sender;
         if (_resignationBlockNum[providerAddress] != 0) revert AlreadyResigned(providerAddress);
         if (_pegInCollateral[providerAddress] < 1 && _pegOutCollateral[providerAddress] < 1) {

--- a/src/EmergencyPause/EmergencyPause.sol
+++ b/src/EmergencyPause/EmergencyPause.sol
@@ -3,65 +3,73 @@ pragma solidity 0.8.25;
 
 /* solhint-disable comprehensive-interface */
 
-import {
-    AccessControlDefaultAdminRulesUpgradeable
-} from "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlDefaultAdminRulesUpgradeable.sol";
-import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {IPausable} from "../interfaces/IPausable.sol";
+import {IPauseRegistry} from "../interfaces/IPauseRegistry.sol";
+import {Flyover} from "../libraries/Flyover.sol";
 
-abstract contract EmergencyPause is AccessControlDefaultAdminRulesUpgradeable, PausableUpgradeable, IPausable {
+/// @notice Base contract for Flyover contracts that delegate pause state to a central PauseRegistry.
+/// pauseStatus() and whenNotPaused read from the registry. Pause/unpause are done only on the registry.
+/// Uses namespaced storage; no AccessControl (children that need roles inherit it separately).
+abstract contract EmergencyPause is Initializable, IPausable {
 
-    bytes32 internal constant _PAUSER_ROLE = keccak256("PAUSER_ROLE");
+    /// @custom:storage-location erc7201:rsk.flyover.EmergencyPause
+    struct EmergencyPauseStorage {
+        IPauseRegistry pauseRegistry;
+    }
 
-    string private _pauseReason;
-    uint64 private _pauseTimestamp;
+    // ERC-7201: keccak256(abi.encode(uint256(keccak256("rsk.flyover.EmergencyPause")) - 1)) &
+    // ~bytes32(uint256(0xff))
+    bytes32 private constant _EMERGENCY_PAUSE_STORAGE =
+        0x9231f352ae2e78fc5cd04a185b8fc917dd5cf9947923b7000e25955769a61f00;
 
-    event EmergencyPaused(address indexed by, string reason);
-    event EmergencyUnpaused(address indexed by);
+    /// @notice Modifier that reverts if the system is paused (reads from PauseRegistry)
+    modifier whenNotPaused() {
+        if (_getEmergencyPauseStorage().pauseRegistry.paused()) {
+            revert Flyover.EnforcedPause();
+        }
+        _;
+    }
 
     /// @inheritdoc IPausable
-    function pause(string calldata reason) public virtual override(IPausable) onlyRole(_PAUSER_ROLE) {
-        _emergencyPause(reason);
-    }
-
-    //// @inheritdoc IPausable
-    function unpause() public virtual override(IPausable) onlyRole(_PAUSER_ROLE) {
-        _emergencyUnpause();
-    }
-
     function pauseStatus()
-        public virtual
-        override(IPausable)
+        public
         view
+        virtual
+        override(IPausable)
         returns (bool isPaused, string memory reason, uint64 since)
     {
-        return (paused(), _pauseReason, _pauseTimestamp);
+        return _getEmergencyPauseStorage().pauseRegistry.pauseStatus();
     }
 
-    /// @notice Initialize EmergencyPause with AccessControl and Pausable
-    /// @param initialDelay The initial delay for admin role changes (use 0 for immediate access)
-    /// @param defaultAdmin The default admin address
+    /// @notice Returns the PauseRegistry used for pause state
+    function pauseRegistry() public view returns (IPauseRegistry) {
+        return _getEmergencyPauseStorage().pauseRegistry;
+    }
+
+    /// @notice Initialize EmergencyPause with reference to PauseRegistry
+    /// @param pauseRegistry_ The central PauseRegistry
     // solhint-disable-next-line func-name-mixedcase
-    function __EmergencyPause_init(
-        uint48 initialDelay,
-        address defaultAdmin
-    ) internal onlyInitializing {
-        __AccessControlDefaultAdminRules_init(initialDelay, defaultAdmin);
-        __Pausable_init();
-        _grantRole(_PAUSER_ROLE, defaultAdmin);
+    function __EmergencyPause_init(IPauseRegistry pauseRegistry_)
+        internal
+        onlyInitializing
+    {
+        _getEmergencyPauseStorage().pauseRegistry = pauseRegistry_;
     }
 
-    function _emergencyPause(string calldata reason) internal {
-        _pause();
-        _pauseReason = reason; // storage string or reason hash/URI
-        _pauseTimestamp = uint64(block.timestamp);
-        emit EmergencyPaused(msg.sender, reason);
+    /// @notice Allows child contracts to update the pause registry (e.g. after upgrade or config change)
+    /// @param pauseRegistry_ The new PauseRegistry
+    function _setPauseRegistry(IPauseRegistry pauseRegistry_) internal {
+        _getEmergencyPauseStorage().pauseRegistry = pauseRegistry_;
     }
 
-    function _emergencyUnpause() internal {
-        _pauseReason = "";
-        _pauseTimestamp = 0;
-        _unpause();
-        emit EmergencyUnpaused(msg.sender);
+    function _getEmergencyPauseStorage()
+        private
+        pure
+        returns (EmergencyPauseStorage storage $)
+    {
+        assembly {
+            $.slot := _EMERGENCY_PAUSE_STORAGE
+        }
     }
 }

--- a/src/FlyoverDiscovery.sol
+++ b/src/FlyoverDiscovery.sol
@@ -3,15 +3,20 @@ pragma solidity 0.8.25;
 
 /* solhint-disable comprehensive-interface */
 
+import {
+    AccessControlDefaultAdminRulesUpgradeable
+} from "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlDefaultAdminRulesUpgradeable.sol";
 import {EmergencyPause} from "./EmergencyPause/EmergencyPause.sol";
 import {ICollateralManagement} from "./interfaces/ICollateralManagement.sol";
 import {IFlyoverDiscovery} from "./interfaces/IFlyoverDiscovery.sol";
+import {IPauseRegistry} from "./interfaces/IPauseRegistry.sol";
 import {Flyover} from "./libraries/Flyover.sol";
 
 /// @title FlyoverDiscovery
 /// @notice Registry and discovery of Liquidity Providers (LPs) for Flyover
 /// @dev Keeps LP metadata and consults `ICollateralManagement` to decide listing and operational status
 contract FlyoverDiscovery is
+    AccessControlDefaultAdminRulesUpgradeable,
     EmergencyPause,
     IFlyoverDiscovery
 {
@@ -35,14 +40,17 @@ contract FlyoverDiscovery is
     /// @param defaultAdmin The Default Admin and initial owner address
     /// @param initialDelay The initial admin delay for `EmergencyPause`
     /// @param collateralManagement The address of the `ICollateralManagement` contract
+    /// @param pauseRegistry The central PauseRegistry for pause state
     function initialize(
         address defaultAdmin,
         uint48 initialDelay,
-        address collateralManagement
+        address collateralManagement,
+        IPauseRegistry pauseRegistry
     ) external initializer {
         if (collateralManagement.code.length == 0) revert Flyover.NoContract(collateralManagement);
-        // Initialize EmergencyPause (includes AccessControl, Pausable, and grants PAUSER_ROLE)
-        __EmergencyPause_init(initialDelay, defaultAdmin);
+        if (address(pauseRegistry).code.length == 0) revert Flyover.NoContract(address(pauseRegistry));
+        __AccessControlDefaultAdminRules_init(initialDelay, defaultAdmin);
+        __EmergencyPause_init(pauseRegistry);
         _collateralManagement = ICollateralManagement(collateralManagement);
     }
 

--- a/src/PauseRegistry.sol
+++ b/src/PauseRegistry.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+/* solhint-disable comprehensive-interface */
+
+import {
+    AccessControlDefaultAdminRulesUpgradeable
+} from "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlDefaultAdminRulesUpgradeable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {IPauseRegistry} from "./interfaces/IPauseRegistry.sol";
+
+/// @title PauseRegistry
+/// @notice Centralized registry for pause state; all Flyover contracts read from here
+/// @dev Only accounts with PAUSER_ROLE can pause/unpause. Uses namespaced storage.
+contract PauseRegistry is
+    Initializable,
+    AccessControlDefaultAdminRulesUpgradeable,
+    IPauseRegistry
+{
+    /// @custom:storage-location erc7201:rsk.flyover.PauseRegistry
+    struct PauseRegistryStorage {
+        bool paused;
+        uint64 pauseTimestamp;
+        string pauseReason;
+    }
+
+    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
+    // ERC-7201: keccak256(abi.encode(uint256(keccak256("rsk.flyover.PauseRegistry")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant _PAUSE_REGISTRY_STORAGE =
+        0xde609c7d5a78f434280e4782344f7bcf6ccb01cacb109dfb3b05fed1bfa41900;
+
+    event EmergencyPaused(address indexed by, string reason);
+    event EmergencyUnpaused(address indexed by);
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    /// @notice Initialize the registry
+    /// @param initialDelay The initial delay for admin role changes (use 0 for immediate access)
+    /// @param defaultAdmin The default admin and initial pauser
+    function initialize(uint48 initialDelay, address defaultAdmin) external initializer {
+        __AccessControlDefaultAdminRules_init(initialDelay, defaultAdmin);
+        _grantRole(PAUSER_ROLE, defaultAdmin);
+    }
+
+    /// @inheritdoc IPauseRegistry
+    function pause(string calldata reason) external onlyRole(PAUSER_ROLE) {
+        PauseRegistryStorage storage $ = _getPauseRegistryStorage();
+        if ($.paused) return;
+        $.paused = true;
+        $.pauseReason = reason;
+        $.pauseTimestamp = uint64(block.timestamp);
+        emit EmergencyPaused(msg.sender, reason);
+    }
+
+    /// @inheritdoc IPauseRegistry
+    function unpause() external onlyRole(PAUSER_ROLE) {
+        PauseRegistryStorage storage $ = _getPauseRegistryStorage();
+        if (!$.paused) return;
+        $.paused = false;
+        $.pauseReason = "";
+        $.pauseTimestamp = 0;
+        emit EmergencyUnpaused(msg.sender);
+    }
+
+    /// @inheritdoc IPauseRegistry
+    function paused() external view returns (bool) {
+        return _getPauseRegistryStorage().paused;
+    }
+
+    /// @inheritdoc IPauseRegistry
+    function pauseStatus()
+        external
+        view
+        returns (bool isPaused, string memory reason, uint64 since)
+    {
+        PauseRegistryStorage storage $ = _getPauseRegistryStorage();
+        return ($.paused, $.pauseReason, $.pauseTimestamp);
+    }
+
+    function _getPauseRegistryStorage()
+        private
+        pure
+        returns (PauseRegistryStorage storage $)
+    {
+        assembly {
+            $.slot := _PAUSE_REGISTRY_STORAGE
+        }
+    }
+}

--- a/src/PegInContract.sol
+++ b/src/PegInContract.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
+import {
+    AccessControlDefaultAdminRulesUpgradeable
+} from "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlDefaultAdminRulesUpgradeable.sol";
 import {EIP712Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol";
 import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
 import {BtcUtils} from "@rsksmart/btc-transaction-solidity-helper/contracts/BtcUtils.sol";
@@ -8,6 +11,7 @@ import {OpCodes} from "@rsksmart/btc-transaction-solidity-helper/contracts/OpCod
 import {EmergencyPause} from "./EmergencyPause/EmergencyPause.sol";
 import {IBridge} from "./interfaces/IBridge.sol";
 import {ICollateralManagement, CollateralManagementSet} from "./interfaces/ICollateralManagement.sol";
+import {IPauseRegistry} from "./interfaces/IPauseRegistry.sol";
 import {IPegIn} from "./interfaces/IPegIn.sol";
 import {Flyover} from "./libraries/Flyover.sol";
 import {Quotes} from "./libraries/Quotes.sol";
@@ -18,6 +22,7 @@ import {SignatureValidator} from "./libraries/SignatureValidator.sol";
 /// @dev All non pure/view functions in this contract should be marked as nonReentrant
 /// @author Rootstock Labs
 contract PegInContract is
+    AccessControlDefaultAdminRulesUpgradeable,
     EmergencyPause,
     ReentrancyGuardUpgradeable,
     EIP712Upgradeable,
@@ -83,6 +88,7 @@ contract PegInContract is
     /// @param minPegIn the minimum peg in amount supported by the bridge
     /// @param collateralManagement the address of the Collateral Management contract
     /// @param mainnet whether the contract is on the mainnet or not
+    /// @param pauseRegistry the central PauseRegistry for pause state
     // solhint-disable-next-line comprehensive-interface
     function initialize(
         address defaultAdmin,
@@ -90,13 +96,15 @@ contract PegInContract is
         uint256 dustThreshold_,
         uint256 minPegIn,
         address collateralManagement,
-        bool mainnet
+        bool mainnet,
+        IPauseRegistry pauseRegistry
     ) external initializer {
         if (collateralManagement.code.length == 0) revert Flyover.NoContract(collateralManagement);
+        if (address(pauseRegistry).code.length == 0) revert Flyover.NoContract(address(pauseRegistry));
+        __AccessControlDefaultAdminRules_init(0, defaultAdmin);
         __ReentrancyGuard_init();
         __EIP712_init(NAME, VERSION);
-        // Initialize EmergencyPause (includes AccessControl, Pausable, and grants PAUSER_ROLE)
-        __EmergencyPause_init(0, defaultAdmin);
+        __EmergencyPause_init(pauseRegistry);
         _bridge = IBridge(bridge);
         _collateralManagement = ICollateralManagement(collateralManagement);
         _mainnet = mainnet;
@@ -157,7 +165,7 @@ contract PegInContract is
     /// @inheritdoc IPegIn
     function callForUser(
         Quotes.PegInQuote calldata quote
-    ) external payable nonReentrant whenNotPaused override returns (bool) {
+    ) external payable nonReentrant override returns (bool) {
         if(!_collateralManagement.isRegistered(_PEG_TYPE, msg.sender)) {
             revert Flyover.ProviderNotRegistered(msg.sender);
         }
@@ -212,7 +220,7 @@ contract PegInContract is
         bytes calldata btcRawTransaction,
         bytes calldata partialMerkleTree,
         uint256 height
-    ) external nonReentrant whenNotPaused override returns (int256) {
+    ) external nonReentrant override returns (int256) {
         bytes32 quoteHash = _hashPegInQuote(quote);
         _validateRegisterParams(quote, quoteHash, height, signature);
         int256 registerResult = _registerBridge(quote, btcRawTransaction, partialMerkleTree, height, quoteHash);

--- a/src/PegOutContract.sol
+++ b/src/PegOutContract.sol
@@ -1,12 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
+import {
+    AccessControlDefaultAdminRulesUpgradeable
+} from "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlDefaultAdminRulesUpgradeable.sol";
 import {EIP712Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol";
 import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
 import {BtcUtils} from "@rsksmart/btc-transaction-solidity-helper/contracts/BtcUtils.sol";
 import {EmergencyPause} from "./EmergencyPause/EmergencyPause.sol";
 import {IBridge} from "./interfaces/IBridge.sol";
 import {ICollateralManagement, CollateralManagementSet} from "./interfaces/ICollateralManagement.sol";
+import {IPauseRegistry} from "./interfaces/IPauseRegistry.sol";
 import {IPegOut} from "./interfaces/IPegOut.sol";
 import {Flyover} from "./libraries/Flyover.sol";
 import {Quotes} from "./libraries/Quotes.sol";
@@ -16,6 +20,7 @@ import {SignatureValidator} from "./libraries/SignatureValidator.sol";
 /// @notice This contract is used to handle the peg out of the RSK network to the Bitcoin network
 /// @author Rootstock Labs
 contract PegOutContract is
+    AccessControlDefaultAdminRulesUpgradeable,
     EmergencyPause,
     ReentrancyGuardUpgradeable,
     EIP712Upgradeable,
@@ -126,6 +131,7 @@ contract PegOutContract is
     /// @param collateralManagement the address of the Collateral Management contract
     /// @param mainnet whether the contract is on the mainnet or not
     /// @param btcBlockTime_ the average Bitcoin block time in seconds
+    /// @param pauseRegistry the central PauseRegistry for pause state
     // solhint-disable-next-line comprehensive-interface
     function initialize(
         address defaultAdmin,
@@ -133,13 +139,15 @@ contract PegOutContract is
         uint256 dustThreshold_,
         address collateralManagement,
         bool mainnet,
-        uint256 btcBlockTime_
+        uint256 btcBlockTime_,
+        IPauseRegistry pauseRegistry
     ) external initializer {
         if (collateralManagement.code.length == 0) revert Flyover.NoContract(collateralManagement);
+        if (address(pauseRegistry).code.length == 0) revert Flyover.NoContract(address(pauseRegistry));
+        __AccessControlDefaultAdminRules_init(0, defaultAdmin);
         __ReentrancyGuard_init();
         __EIP712_init(NAME, VERSION);
-        // Initialize EmergencyPause (includes AccessControl, Pausable, and grants PAUSER_ROLE)
-        __EmergencyPause_init(0, defaultAdmin);
+        __EmergencyPause_init(pauseRegistry);
         _bridge = IBridge(bridge);
         _collateralManagement = ICollateralManagement(collateralManagement);
         _mainnet = mainnet;
@@ -182,7 +190,7 @@ contract PegOutContract is
         bytes32 btcBlockHeaderHash,
         uint256 merkleBranchPath,
         bytes32[] calldata merkleBranchHashes
-    ) external nonReentrant whenNotPaused override {
+    ) external nonReentrant override {
         Quotes.PegOutQuote memory quote = _validatePegOutTransaction(quoteHash, btcTx);
         _validateBtcTxConfirmations(quote, btcTx, btcBlockHeaderHash, merkleBranchPath, merkleBranchHashes);
 
@@ -202,7 +210,7 @@ contract PegOutContract is
     }
 
     /// @inheritdoc IPegOut
-    function refundUserPegOut(bytes32 quoteHash) external nonReentrant whenNotPaused override {
+    function refundUserPegOut(bytes32 quoteHash) external nonReentrant override {
         Quotes.PegOutQuote memory quote = _pegOutQuotes[quoteHash];
 
         if (quote.lbcAddress == address(0)) revert Flyover.QuoteNotFound(quoteHash);

--- a/src/interfaces/IPausable.sol
+++ b/src/interfaces/IPausable.sol
@@ -2,16 +2,9 @@
 pragma solidity 0.8.25;
 
 interface IPausable {
-    /// @notice Pauses the contract
-    /// @param reason The reason for pausing
-    function pause(string calldata reason) external;
-
-    /// @notice Unpauses the contract
-    function unpause() external;
-
-    /// @notice Returns the pause status of the contract
-    /// @return isPaused Whether the contract is paused
+    /// @notice Returns the pause status (from the central PauseRegistry)
+    /// @return isPaused Whether the system is paused
     /// @return reason The reason for pausing
-    /// @return since The timestamp when the contract was paused
+    /// @return since The timestamp when the system was paused
     function pauseStatus() external view returns (bool isPaused, string memory reason, uint64 since);
 }

--- a/src/interfaces/IPauseRegistry.sol
+++ b/src/interfaces/IPauseRegistry.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+interface IPauseRegistry {
+    /// @notice Pauses the system (all contracts using this registry)
+    /// @param reason The reason for pausing
+    function pause(string calldata reason) external;
+
+    /// @notice Unpauses the system
+    function unpause() external;
+
+    /// @notice Returns whether the system is paused
+    /// @return True if paused
+    function paused() external view returns (bool);
+
+    /// @notice Returns full pause status
+    /// @return isPaused Whether the system is paused
+    /// @return reason The reason for pausing
+    /// @return since The timestamp when the system was paused
+    function pauseStatus()
+        external
+        view
+        returns (bool isPaused, string memory reason, uint64 since);
+}

--- a/src/libraries/Flyover.sol
+++ b/src/libraries/Flyover.sol
@@ -35,4 +35,6 @@ library Flyover {
     /// @param expected The current chain id (block.chainid)
     /// @param actual The chain id in the quote
     error InvalidChainId(uint256 expected, uint256 actual);
+    /// @notice Used by whenNotPaused when the system is paused via PauseRegistry
+    error EnforcedPause();
 }

--- a/src/test-contracts/CollateralManagementMock.sol
+++ b/src/test-contracts/CollateralManagementMock.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import {EmergencyPause} from "../EmergencyPause/EmergencyPause.sol";
 import {ICollateralManagement} from "../interfaces/ICollateralManagement.sol";
 import {Flyover} from "../libraries/Flyover.sol";
 import {Quotes} from "../libraries/Quotes.sol";
@@ -87,16 +86,8 @@ contract CollateralManagementMock is ICollateralManagement {
         return true;
     }
 
-    function pause(string calldata reason) public {
-        emit EmergencyPause.EmergencyPaused(msg.sender, reason);
-    }
-
-    function unpause() public {
-        emit EmergencyPause.EmergencyUnpaused(msg.sender);
-    }
-
     function pauseStatus()
-        public
+        external
         pure
         returns (bool isPaused, string memory reason, uint64 since)
     {

--- a/test/Benchmark.t.sol
+++ b/test/Benchmark.t.sol
@@ -1,14 +1,20 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.19;
+pragma solidity 0.8.25;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";
 import {CollateralManagementContract} from "../src/CollateralManagement.sol";
 import {FlyoverDiscovery} from "../src/FlyoverDiscovery.sol";
+import {PauseRegistry} from "../src/PauseRegistry.sol";
+import {IPauseRegistry} from "../src/interfaces/IPauseRegistry.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {Flyover} from "../src/libraries/Flyover.sol";
 
 contract BenchmarkTest is Test {
+    PauseRegistry public pauseRegistryImpl;
+    ERC1967Proxy public pauseRegistryProxy;
+    IPauseRegistry public pauseRegistry;
+
     CollateralManagementContract public collateralManagementImpl;
     ERC1967Proxy public collateralManagementProxy;
     CollateralManagementContract public collateralManagement;
@@ -32,6 +38,19 @@ contract BenchmarkTest is Test {
             vm.deal(account, 100 ether);
         }
 
+        // Deploy PauseRegistry (required by CollateralManagement and FlyoverDiscovery)
+        pauseRegistryImpl = new PauseRegistry();
+        bytes memory pauseRegistryInitData = abi.encodeWithSelector(
+            PauseRegistry.initialize.selector,
+            uint48(0),
+            owner
+        );
+        pauseRegistryProxy = new ERC1967Proxy(
+            address(pauseRegistryImpl),
+            pauseRegistryInitData
+        );
+        pauseRegistry = IPauseRegistry(address(pauseRegistryProxy));
+
         // Deploy CollateralManagementContract
         collateralManagementImpl = new CollateralManagementContract();
         bytes memory collateralInitData = abi.encodeWithSelector(
@@ -40,7 +59,8 @@ contract BenchmarkTest is Test {
             5000,
             0.03 ether,
             60,
-            10
+            10,
+            pauseRegistry
         );
         collateralManagementProxy = new ERC1967Proxy(
             address(collateralManagementImpl),
@@ -56,7 +76,8 @@ contract BenchmarkTest is Test {
             FlyoverDiscovery.initialize.selector,
             owner,
             5000,
-            address(collateralManagement)
+            address(collateralManagement),
+            pauseRegistry
         );
         discoveryProxy = new ERC1967Proxy(
             address(discoveryImpl),

--- a/test/Pause.t.sol
+++ b/test/Pause.t.sol
@@ -175,7 +175,7 @@ contract PauseTest is Test {
 
         (bool isPausedPI, string memory reasonPI, ) = pegInContract
             .pauseStatus();
-        (bool isPausedPO, string memory reasonPO, ) = pegInContract
+        (bool isPausedPO, string memory reasonPO, ) = pegOutContract
             .pauseStatus();
         (bool isPausedD, string memory reasonD, ) = flyoverDiscovery
             .pauseStatus();
@@ -199,7 +199,7 @@ contract PauseTest is Test {
         pauseRegistry.pause("Test");
 
         (bool isPausedPI, , ) = pegInContract.pauseStatus();
-        (bool isPausedPO, , ) = pegInContract.pauseStatus();
+        (bool isPausedPO, , ) = pegOutContract.pauseStatus();
         (bool isPausedD, , ) = flyoverDiscovery.pauseStatus();
         (bool isPausedC, , ) = collateralManagement.pauseStatus();
         assertTrue(isPausedD);

--- a/test/Pause.t.sol
+++ b/test/Pause.t.sol
@@ -5,15 +5,19 @@ import "forge-std/Test.sol";
 import {FlyoverDiscovery} from "src/FlyoverDiscovery.sol";
 import {CollateralManagementContract} from "src/CollateralManagement.sol";
 import {ICollateralManagement} from "src/interfaces/ICollateralManagement.sol";
+import {PauseRegistry} from "src/PauseRegistry.sol";
 import {PegInContract} from "src/PegInContract.sol";
 import {PegOutContract} from "src/PegOutContract.sol";
 import {BridgeMock} from "src/test-contracts/BridgeMock.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {Flyover} from "src/libraries/Flyover.sol";
+import {IPauseRegistry} from "src/interfaces/IPauseRegistry.sol";
+import {Quotes} from "src/libraries/Quotes.sol";
 
 /// @title System-wide Pause Functionality Tests
 /// @notice Tests that verify pause/unpause operations across all contracts in the system
 contract PauseTest is Test {
+    PauseRegistry public pauseRegistry;
     FlyoverDiscovery public flyoverDiscovery;
     CollateralManagementContract public collateralManagement;
     PegInContract public pegInContract;
@@ -44,6 +48,18 @@ contract PauseTest is Test {
     function _deployContracts() internal {
         bridgeMock = new BridgeMock();
 
+        PauseRegistry prImpl = new PauseRegistry();
+        pauseRegistry = PauseRegistry(
+            payable(
+                address(
+                    new ERC1967Proxy(
+                        address(prImpl),
+                        abi.encodeCall(prImpl.initialize, (0, owner))
+                    )
+                )
+            )
+        );
+
         CollateralManagementContract cmImpl = new CollateralManagementContract();
         collateralManagement = CollateralManagementContract(
             payable(
@@ -52,7 +68,14 @@ contract PauseTest is Test {
                         address(cmImpl),
                         abi.encodeCall(
                             cmImpl.initialize,
-                            (owner, 30, TEST_MIN_COLLATERAL, 500, 1000)
+                            (
+                                owner,
+                                30,
+                                TEST_MIN_COLLATERAL,
+                                500,
+                                1000,
+                                pauseRegistry
+                            )
                         )
                     )
                 )
@@ -67,7 +90,12 @@ contract PauseTest is Test {
                         address(dImpl),
                         abi.encodeCall(
                             dImpl.initialize,
-                            (owner, 5000, address(collateralManagement))
+                            (
+                                owner,
+                                5000,
+                                address(collateralManagement),
+                                pauseRegistry
+                            )
                         )
                     )
                 )
@@ -88,7 +116,8 @@ contract PauseTest is Test {
                                 2300 * 65164000,
                                 0.5 ether,
                                 address(collateralManagement),
-                                false
+                                false,
+                                pauseRegistry
                             )
                         )
                     )
@@ -110,7 +139,8 @@ contract PauseTest is Test {
                                 2300 * 65164000,
                                 address(collateralManagement),
                                 false,
-                                900
+                                900,
+                                pauseRegistry
                             )
                         )
                     )
@@ -134,18 +164,19 @@ contract PauseTest is Test {
     }
 
     function _grantPauserRole() internal {
-        flyoverDiscovery.grantRole(PAUSER_ROLE, pauser);
-        collateralManagement.grantRole(PAUSER_ROLE, pauser);
+        pauseRegistry.grantRole(PAUSER_ROLE, pauser);
     }
 
     function test_CanPauseAllContractsSimultaneously() public {
         _grantPauserRole();
 
-        vm.startPrank(pauser);
-        flyoverDiscovery.pause("Emergency system-wide pause");
-        collateralManagement.pause("Emergency system-wide pause");
-        vm.stopPrank();
+        vm.prank(pauser);
+        pauseRegistry.pause("Emergency system-wide pause");
 
+        (bool isPausedPI, string memory reasonPI, ) = pegInContract
+            .pauseStatus();
+        (bool isPausedPO, string memory reasonPO, ) = pegInContract
+            .pauseStatus();
         (bool isPausedD, string memory reasonD, ) = flyoverDiscovery
             .pauseStatus();
         (bool isPausedC, string memory reasonC, ) = collateralManagement
@@ -155,31 +186,43 @@ contract PauseTest is Test {
         assertEq(reasonD, "Emergency system-wide pause");
         assertTrue(isPausedC);
         assertEq(reasonC, "Emergency system-wide pause");
+        assertTrue(isPausedPI);
+        assertEq(reasonPI, "Emergency system-wide pause");
+        assertTrue(isPausedPO);
+        assertEq(reasonPO, "Emergency system-wide pause");
     }
 
     function test_CanUnpauseAllContractsSimultaneously() public {
         _grantPauserRole();
 
-        vm.startPrank(pauser);
-        flyoverDiscovery.pause("Test");
-        collateralManagement.pause("Test");
-        vm.stopPrank();
+        vm.prank(pauser);
+        pauseRegistry.pause("Test");
 
+        (bool isPausedPI, , ) = pegInContract.pauseStatus();
+        (bool isPausedPO, , ) = pegInContract.pauseStatus();
         (bool isPausedD, , ) = flyoverDiscovery.pauseStatus();
         (bool isPausedC, , ) = collateralManagement.pauseStatus();
         assertTrue(isPausedD);
         assertTrue(isPausedC);
+        assertTrue(isPausedPI);
+        assertTrue(isPausedPO);
 
-        vm.startPrank(pauser);
-        flyoverDiscovery.unpause();
-        collateralManagement.unpause();
-        vm.stopPrank();
+        vm.prank(pauser);
+        pauseRegistry.unpause();
 
         string memory reasonD;
         string memory reasonC;
+        string memory reasonPI;
+        string memory reasonPO;
         (isPausedD, reasonD, ) = flyoverDiscovery.pauseStatus();
         (isPausedC, reasonC, ) = collateralManagement.pauseStatus();
+        (isPausedPI, reasonPI, ) = pegInContract.pauseStatus();
+        (isPausedPO, reasonPO, ) = pegOutContract.pauseStatus();
 
+        assertFalse(isPausedPI);
+        assertEq(reasonPI, "");
+        assertFalse(isPausedPO);
+        assertEq(reasonPO, "");
         assertFalse(isPausedD);
         assertEq(reasonD, "");
         assertFalse(isPausedC);
@@ -189,16 +232,18 @@ contract PauseTest is Test {
     function test_TracksPauseTimestampsConsistentlyAcrossContracts() public {
         _grantPauserRole();
 
-        vm.startPrank(pauser);
-        flyoverDiscovery.pause("Timestamp test");
-        collateralManagement.pause("Timestamp test");
-        vm.stopPrank();
+        vm.prank(pauser);
+        pauseRegistry.pause("Timestamp test");
 
         (, , uint256 timeD) = flyoverDiscovery.pauseStatus();
         (, , uint256 timeC) = collateralManagement.pauseStatus();
+        (, , uint256 timePI) = pegInContract.pauseStatus();
+        (, , uint256 timePO) = pegOutContract.pauseStatus();
 
-        assertTrue(timeD > 0 && timeC > 0);
+        assertTrue(timeD > 0 && timeC > 0 && timePI > 0 && timePO > 0);
         assertEq(timeD, timeC);
+        assertEq(timePI, timeD);
+        assertEq(timePO, timePI);
     }
 
     function test_BlocksCriticalOperationsAcrossAllContractsWhenPaused()
@@ -206,10 +251,8 @@ contract PauseTest is Test {
     {
         _grantPauserRole();
 
-        vm.startPrank(pauser);
-        flyoverDiscovery.pause("Emergency");
-        collateralManagement.pause("Emergency");
-        vm.stopPrank();
+        vm.prank(pauser);
+        pauseRegistry.pause("Emergency");
 
         vm.prank(signers[1]);
         vm.expectRevert(abi.encodeWithSignature("EnforcedPause()"));
@@ -227,6 +270,13 @@ contract PauseTest is Test {
 
         vm.expectRevert(abi.encodeWithSignature("EnforcedPause()"));
         collateralManagement.addPegInCollateralTo{value: 1 ether}(signers[1]);
+
+        vm.expectRevert(abi.encodeWithSignature("EnforcedPause()"));
+        pegInContract.deposit{value: 1 ether}();
+
+        Quotes.PegOutQuote memory quote;
+        vm.expectRevert(abi.encodeWithSignature("EnforcedPause()"));
+        pegOutContract.depositPegOut{value: 1 ether}(quote, hex"010203");
     }
 
     function test_AllowsViewFunctionsToContinueWorkingWhenPaused() public view {
@@ -251,11 +301,9 @@ contract PauseTest is Test {
         uint256 providerId = flyoverDiscovery.getProvidersId();
         assertEq(providerId, 1, "Provider should be registered");
 
-        // Pause the contracts
-        vm.startPrank(pauser);
-        flyoverDiscovery.pause("Emergency");
-        collateralManagement.pause("Emergency");
-        vm.stopPrank();
+        // Pause via central registry
+        vm.prank(pauser);
+        pauseRegistry.pause("Emergency");
 
         // Verify contracts are paused
         (bool isPausedD, , ) = flyoverDiscovery.pauseStatus();
@@ -311,25 +359,29 @@ contract PauseTest is Test {
     function test_RestoresFullFunctionalityAfterSystemWideUnpause() public {
         _grantPauserRole();
 
-        vm.startPrank(pauser);
-        flyoverDiscovery.pause("Test");
-        collateralManagement.pause("Test");
-        vm.stopPrank();
+        vm.prank(pauser);
+        pauseRegistry.pause("Test");
 
         (bool isPausedD, , ) = flyoverDiscovery.pauseStatus();
         (bool isPausedC, , ) = collateralManagement.pauseStatus();
+        (bool isPausedPI, , ) = pegInContract.pauseStatus();
+        (bool isPausedPO, , ) = pegOutContract.pauseStatus();
         assertTrue(isPausedD);
         assertTrue(isPausedC);
+        assertTrue(isPausedPI);
+        assertTrue(isPausedPO);
 
-        vm.startPrank(pauser);
-        flyoverDiscovery.unpause();
-        collateralManagement.unpause();
-        vm.stopPrank();
+        vm.prank(pauser);
+        pauseRegistry.unpause();
 
         (isPausedD, , ) = flyoverDiscovery.pauseStatus();
         (isPausedC, , ) = collateralManagement.pauseStatus();
+        (isPausedPI, , ) = pegInContract.pauseStatus();
+        (isPausedPO, , ) = pegOutContract.pauseStatus();
         assertFalse(isPausedD);
         assertFalse(isPausedC);
+        assertFalse(isPausedPI);
+        assertFalse(isPausedPO);
 
         vm.prank(signers[1]);
         flyoverDiscovery.register{value: 1 ether}(
@@ -353,18 +405,21 @@ contract PauseTest is Test {
         );
     }
 
-    function test_HandlesWhereSomeContractsFailToPause() public {
+    function test_PauseOncePausesAllContracts() public {
         _grantPauserRole();
 
-        vm.startPrank(pauser);
-        flyoverDiscovery.pause("Partial pause");
-        collateralManagement.pause("Partial pause");
-        vm.stopPrank();
+        vm.prank(pauser);
+        pauseRegistry.pause("System-wide pause");
 
         (bool isPausedD, , ) = flyoverDiscovery.pauseStatus();
         (bool isPausedC, , ) = collateralManagement.pauseStatus();
+        (bool isPausedPI, , ) = pegInContract.pauseStatus();
+        (bool isPausedPO, , ) = pegOutContract.pauseStatus();
 
-        assertTrue(isPausedD || isPausedC);
+        assertTrue(isPausedD, "Discovery should be paused");
+        assertTrue(isPausedC, "Collateral should be paused");
+        assertTrue(isPausedPI, "PegIn should be paused");
+        assertTrue(isPausedPO, "PegOut should be paused");
     }
 
     function test_CanPerformEmergencyPauseWithCustomReason() public {
@@ -373,25 +428,25 @@ contract PauseTest is Test {
         string
             memory reason = "Critical security vulnerability detected - immediate pause required";
 
-        vm.startPrank(pauser);
-        flyoverDiscovery.pause(reason);
-        collateralManagement.pause(reason);
-        vm.stopPrank();
+        vm.prank(pauser);
+        pauseRegistry.pause(reason);
 
         (, string memory reasonD, ) = flyoverDiscovery.pauseStatus();
         (, string memory reasonC, ) = collateralManagement.pauseStatus();
+        (, string memory reasonPI, ) = pegInContract.pauseStatus();
+        (, string memory reasonPO, ) = pegOutContract.pauseStatus();
 
         assertEq(reasonD, reason);
         assertEq(reasonC, reason);
+        assertEq(reasonPI, reason);
+        assertEq(reasonPO, reason);
     }
 
     function test_MaintainsPauseStateAcrossMultipleOperations() public {
         _grantPauserRole();
 
-        vm.startPrank(pauser);
-        flyoverDiscovery.pause("Multiple ops");
-        collateralManagement.pause("Multiple ops");
-        vm.stopPrank();
+        vm.prank(pauser);
+        pauseRegistry.pause("Multiple ops");
 
         vm.startPrank(signers[1]);
 
@@ -415,8 +470,12 @@ contract PauseTest is Test {
 
         (bool isPausedD, , ) = flyoverDiscovery.pauseStatus();
         (bool isPausedC, , ) = collateralManagement.pauseStatus();
+        (bool isPausedPI, , ) = pegInContract.pauseStatus();
+        (bool isPausedPO, , ) = pegOutContract.pauseStatus();
 
         assertTrue(isPausedD);
         assertTrue(isPausedC);
+        assertTrue(isPausedPI);
+        assertTrue(isPausedPO);
     }
 }

--- a/test/collateral/Addition.t.sol
+++ b/test/collateral/Addition.t.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.25;
 import {Test, console} from "forge-std/Test.sol";
 import {CollateralManagementContract} from "../../src/CollateralManagement.sol";
 import {ICollateralManagement} from "../../src/interfaces/ICollateralManagement.sol";
+import {PauseRegistry} from "../../src/PauseRegistry.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {Flyover} from "../../src/libraries/Flyover.sol";
 import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
@@ -49,6 +50,14 @@ contract AdditionTest is Test {
         vm.deal(registeredPegOutAccount, 100 ether);
         vm.deal(notRegisteredAccount2, 100 ether);
 
+        // Deploy PauseRegistry
+        PauseRegistry prImpl = new PauseRegistry();
+        ERC1967Proxy prProxy = new ERC1967Proxy(
+            address(prImpl),
+            abi.encodeCall(prImpl.initialize, (0, owner))
+        );
+        PauseRegistry pr = PauseRegistry(payable(address(prProxy)));
+
         // Deploy implementation
         CollateralManagementContract implementation = new CollateralManagementContract();
 
@@ -60,7 +69,8 @@ contract AdditionTest is Test {
                 TEST_DEFAULT_ADMIN_DELAY,
                 TEST_MIN_COLLATERAL,
                 TEST_RESIGN_DELAY_BLOCKS,
-                TEST_REWARD_PERCENTAGE
+                TEST_REWARD_PERCENTAGE,
+                pr
             )
         );
 

--- a/test/collateral/CollateralTestBase.sol
+++ b/test/collateral/CollateralTestBase.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.25;
 import {Test, console} from "forge-std/Test.sol";
 import {CollateralManagementContract} from "../../src/CollateralManagement.sol";
 import {ICollateralManagement} from "../../src/interfaces/ICollateralManagement.sol";
+import {PauseRegistry} from "../../src/PauseRegistry.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {Flyover} from "../../src/libraries/Flyover.sol";
 import {Quotes} from "../../src/libraries/Quotes.sol";
@@ -12,6 +13,7 @@ import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol"
 /// @title Base contract for CollateralManagement tests
 /// @notice Provides shared deployment and setup logic
 abstract contract CollateralTestBase is Test {
+    PauseRegistry public pauseRegistry;
     CollateralManagementContract public collateralManagement;
 
     address public owner;
@@ -41,6 +43,14 @@ abstract contract CollateralTestBase is Test {
         // Fund owner
         vm.deal(owner, 100 ether);
 
+        // Deploy PauseRegistry first
+        PauseRegistry prImpl = new PauseRegistry();
+        ERC1967Proxy prProxy = new ERC1967Proxy(
+            address(prImpl),
+            abi.encodeCall(prImpl.initialize, (0, owner))
+        );
+        pauseRegistry = PauseRegistry(payable(address(prProxy)));
+
         // Deploy implementation
         CollateralManagementContract implementation = new CollateralManagementContract();
 
@@ -52,7 +62,8 @@ abstract contract CollateralTestBase is Test {
                 TEST_DEFAULT_ADMIN_DELAY,
                 TEST_MIN_COLLATERAL,
                 TEST_RESIGN_DELAY_BLOCKS,
-                TEST_REWARD_PERCENTAGE
+                TEST_REWARD_PERCENTAGE,
+                pauseRegistry
             )
         );
 

--- a/test/collateral/Configuration.t.sol
+++ b/test/collateral/Configuration.t.sol
@@ -90,7 +90,8 @@ contract ConfigurationTest is CollateralTestBase {
             TEST_DEFAULT_ADMIN_DELAY,
             TEST_MIN_COLLATERAL,
             TEST_RESIGN_DELAY_BLOCKS,
-            TEST_REWARD_PERCENTAGE
+            TEST_REWARD_PERCENTAGE,
+            pauseRegistry
         );
     }
 

--- a/test/deployment/DeployCollateralManagement.t.sol
+++ b/test/deployment/DeployCollateralManagement.t.sol
@@ -5,6 +5,7 @@ import "lib/forge-std/src/Test.sol";
 import "lib/forge-std/src/console.sol";
 import {HelperConfig} from "../../script/HelperConfig.s.sol";
 import {CollateralManagementContract} from "../../src/CollateralManagement.sol";
+import {PauseRegistry} from "../../src/PauseRegistry.sol";
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 
@@ -63,6 +64,16 @@ contract DeployCollateralManagementTest is Test {
         ProxyAdmin admin = new ProxyAdmin(deployer);
         console.log("   Admin deployed at:", address(admin));
 
+        console.log("\n2b. Deploying PauseRegistry...");
+        PauseRegistry prImpl = new PauseRegistry();
+        address pauseRegistryProxy = address(
+            new TransparentUpgradeableProxy(
+                address(prImpl),
+                address(admin),
+                abi.encodeCall(prImpl.initialize, (0, deployer))
+            )
+        );
+
         console.log("\n3. Preparing initializer calldata...");
         bytes memory initData = abi.encodeCall(
             CollateralManagementContract.initialize,
@@ -71,7 +82,8 @@ contract DeployCollateralManagementTest is Test {
                 cfg.adminDelay,
                 cfg.minimumCollateral,
                 cfg.resignDelayBlocks,
-                cfg.rewardPercentage
+                cfg.rewardPercentage,
+                PauseRegistry(pauseRegistryProxy)
             )
         );
         console.log("   Init data length:", initData.length);
@@ -122,8 +134,16 @@ contract DeployCollateralManagementTest is Test {
         address deployer = address(this);
 
         // Inline deployment (script.run() uses private _deploy internally)
-        address impl = address(new CollateralManagementContract());
         address admin = address(new ProxyAdmin(deployer));
+        PauseRegistry prImpl = new PauseRegistry();
+        address pauseRegistryProxy = address(
+            new TransparentUpgradeableProxy(
+                address(prImpl),
+                admin,
+                abi.encodeCall(prImpl.initialize, (0, deployer))
+            )
+        );
+        address impl = address(new CollateralManagementContract());
         address proxy = address(
             new TransparentUpgradeableProxy(
                 impl,
@@ -135,7 +155,8 @@ contract DeployCollateralManagementTest is Test {
                         cfg.adminDelay,
                         cfg.minimumCollateral,
                         cfg.resignDelayBlocks,
-                        cfg.rewardPercentage
+                        cfg.rewardPercentage,
+                        PauseRegistry(pauseRegistryProxy)
                     )
                 )
             )
@@ -172,8 +193,16 @@ contract DeployCollateralManagementTest is Test {
         address deployer = address(this);
 
         // Inline deployment
-        address impl = address(new CollateralManagementContract());
         address admin = address(new ProxyAdmin(deployer));
+        PauseRegistry prImpl = new PauseRegistry();
+        address pauseRegistryProxy = address(
+            new TransparentUpgradeableProxy(
+                address(prImpl),
+                admin,
+                abi.encodeCall(prImpl.initialize, (0, deployer))
+            )
+        );
+        address impl = address(new CollateralManagementContract());
         address proxy = address(
             new TransparentUpgradeableProxy(
                 impl,
@@ -185,7 +214,8 @@ contract DeployCollateralManagementTest is Test {
                         cfg.adminDelay,
                         cfg.minimumCollateral,
                         cfg.resignDelayBlocks,
-                        cfg.rewardPercentage
+                        cfg.rewardPercentage,
+                        PauseRegistry(pauseRegistryProxy)
                     )
                 )
             )

--- a/test/deployment/DeployFlyover.t.sol
+++ b/test/deployment/DeployFlyover.t.sol
@@ -6,6 +6,7 @@ import "lib/forge-std/src/console.sol";
 import {HelperConfig} from "../../script/HelperConfig.s.sol";
 import {CollateralManagementContract} from "../../src/CollateralManagement.sol";
 import {FlyoverDiscovery} from "../../src/FlyoverDiscovery.sol";
+import {PauseRegistry} from "../../src/PauseRegistry.sol";
 import {PegInContract} from "../../src/PegInContract.sol";
 import {PegOutContract} from "../../src/PegOutContract.sol";
 import {Flyover} from "../../src/libraries/Flyover.sol";
@@ -23,6 +24,7 @@ contract DeployFlyoverTest is Test {
     BridgeMock public bridgeMock;
 
     // Deployed contracts
+    address public pauseRegistryProxy;
     CollateralManagementContract public collateralManagement;
     FlyoverDiscovery public discovery;
     PegInContract public pegInContract;
@@ -59,6 +61,14 @@ contract DeployFlyoverTest is Test {
         address deployer,
         HelperConfig.FlyoverConfig memory cfg
     ) private {
+        PauseRegistry prImpl = new PauseRegistry();
+        pauseRegistryProxy = address(
+            new TransparentUpgradeableProxy(
+                address(prImpl),
+                proxyAdmin,
+                abi.encodeCall(prImpl.initialize, (0, deployer))
+            )
+        );
         address impl = address(new CollateralManagementContract());
         bytes memory initData = abi.encodeCall(
             CollateralManagementContract.initialize,
@@ -67,7 +77,8 @@ contract DeployFlyoverTest is Test {
                 cfg.adminDelay,
                 cfg.minimumCollateral,
                 cfg.resignDelayBlocks,
-                cfg.rewardPercentage
+                cfg.rewardPercentage,
+                PauseRegistry(pauseRegistryProxy)
             )
         );
         address proxy = address(
@@ -83,7 +94,12 @@ contract DeployFlyoverTest is Test {
         address impl = address(new FlyoverDiscovery());
         bytes memory initData = abi.encodeCall(
             FlyoverDiscovery.initialize,
-            (deployer, cfg.adminDelay, address(collateralManagement))
+            (
+                deployer,
+                cfg.adminDelay,
+                address(collateralManagement),
+                PauseRegistry(pauseRegistryProxy)
+            )
         );
         address proxy = address(
             new TransparentUpgradeableProxy(impl, proxyAdmin, initData)
@@ -104,7 +120,8 @@ contract DeployFlyoverTest is Test {
                 cfg.dustThreshold,
                 cfg.minimumPegIn,
                 address(collateralManagement),
-                cfg.mainnet
+                cfg.mainnet,
+                PauseRegistry(pauseRegistryProxy)
             )
         );
         address proxy = address(
@@ -126,7 +143,8 @@ contract DeployFlyoverTest is Test {
                 cfg.dustThreshold,
                 address(collateralManagement),
                 cfg.mainnet,
-                cfg.btcBlockTime
+                cfg.btcBlockTime,
+                PauseRegistry(pauseRegistryProxy)
             )
         );
         address proxy = address(

--- a/test/deployment/DeployFlyoverDiscovery.t.sol
+++ b/test/deployment/DeployFlyoverDiscovery.t.sol
@@ -6,6 +6,7 @@ import "lib/forge-std/src/console.sol";
 import {HelperConfig} from "../../script/HelperConfig.s.sol";
 import {FlyoverDiscovery} from "../../src/FlyoverDiscovery.sol";
 import {CollateralManagementContract} from "../../src/CollateralManagement.sol";
+import {PauseRegistry} from "../../src/PauseRegistry.sol";
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 
@@ -18,16 +19,26 @@ contract DeployFlyoverDiscoveryTest is Test {
     HelperConfig public helperConfig;
 
     address public collateralManagementProxy;
+    address public pauseRegistryProxy;
 
     function setUp() public {
         helperConfig = new HelperConfig();
 
-        // Deploy CollateralManagement first (dependency)
+        // Deploy PauseRegistry and CollateralManagement first (dependency)
         HelperConfig.FlyoverConfig memory cfg = helperConfig.getFlyoverConfig();
         address deployer = address(this);
+        address cmAdmin = address(new ProxyAdmin(deployer));
+
+        PauseRegistry prImpl = new PauseRegistry();
+        pauseRegistryProxy = address(
+            new TransparentUpgradeableProxy(
+                address(prImpl),
+                cmAdmin,
+                abi.encodeCall(prImpl.initialize, (0, deployer))
+            )
+        );
 
         address cmImpl = address(new CollateralManagementContract());
-        address cmAdmin = address(new ProxyAdmin(deployer));
         collateralManagementProxy = address(
             new TransparentUpgradeableProxy(
                 cmImpl,
@@ -39,7 +50,8 @@ contract DeployFlyoverDiscoveryTest is Test {
                         cfg.adminDelay,
                         cfg.minimumCollateral,
                         cfg.resignDelayBlocks,
-                        cfg.rewardPercentage
+                        cfg.rewardPercentage,
+                        PauseRegistry(pauseRegistryProxy)
                     )
                 )
             )
@@ -68,7 +80,12 @@ contract DeployFlyoverDiscoveryTest is Test {
         console.log("\n3. Preparing initializer calldata...");
         bytes memory initData = abi.encodeCall(
             FlyoverDiscovery.initialize,
-            (deployer, cfg.adminDelay, collateralManagementProxy)
+            (
+                deployer,
+                cfg.adminDelay,
+                collateralManagementProxy,
+                PauseRegistry(pauseRegistryProxy)
+            )
         );
         console.log("   Init data length:", initData.length);
 
@@ -106,7 +123,12 @@ contract DeployFlyoverDiscoveryTest is Test {
                 admin,
                 abi.encodeCall(
                     FlyoverDiscovery.initialize,
-                    (deployer, cfg.adminDelay, collateralManagementProxy)
+                    (
+                        deployer,
+                        cfg.adminDelay,
+                        collateralManagementProxy,
+                        PauseRegistry(pauseRegistryProxy)
+                    )
                 )
             )
         );
@@ -142,7 +164,12 @@ contract DeployFlyoverDiscoveryTest is Test {
                 admin,
                 abi.encodeCall(
                     FlyoverDiscovery.initialize,
-                    (deployer, cfg.adminDelay, collateralManagementProxy)
+                    (
+                        deployer,
+                        cfg.adminDelay,
+                        collateralManagementProxy,
+                        PauseRegistry(pauseRegistryProxy)
+                    )
                 )
             )
         );
@@ -179,7 +206,12 @@ contract DeployFlyoverDiscoveryTest is Test {
                 admin,
                 abi.encodeCall(
                     FlyoverDiscovery.initialize,
-                    (deployer, cfg.adminDelay, collateralManagementProxy)
+                    (
+                        deployer,
+                        cfg.adminDelay,
+                        collateralManagementProxy,
+                        PauseRegistry(pauseRegistryProxy)
+                    )
                 )
             )
         );

--- a/test/deployment/DeployPegIn.t.sol
+++ b/test/deployment/DeployPegIn.t.sol
@@ -6,6 +6,7 @@ import "lib/forge-std/src/console.sol";
 import {HelperConfig} from "../../script/HelperConfig.s.sol";
 import {PegInContract} from "../../src/PegInContract.sol";
 import {CollateralManagementContract} from "../../src/CollateralManagement.sol";
+import {PauseRegistry} from "../../src/PauseRegistry.sol";
 import {BridgeMock} from "../../src/test-contracts/BridgeMock.sol";
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
@@ -18,6 +19,7 @@ contract DeployPegInTest is Test {
     HelperConfig public helperConfig;
     BridgeMock public bridgeMock;
     address public collateralManagementProxy;
+    address public pauseRegistryProxy;
 
     function setUp() public {
         helperConfig = new HelperConfig();
@@ -26,8 +28,16 @@ contract DeployPegInTest is Test {
         HelperConfig.FlyoverConfig memory cfg = helperConfig.getFlyoverConfig();
         address deployer = address(this);
 
-        address cmImpl = address(new CollateralManagementContract());
         address cmAdmin = address(new ProxyAdmin(deployer));
+        PauseRegistry prImpl = new PauseRegistry();
+        pauseRegistryProxy = address(
+            new TransparentUpgradeableProxy(
+                address(prImpl),
+                cmAdmin,
+                abi.encodeCall(prImpl.initialize, (0, deployer))
+            )
+        );
+        address cmImpl = address(new CollateralManagementContract());
         bytes memory cmInitData = abi.encodeCall(
             CollateralManagementContract.initialize,
             (
@@ -35,7 +45,8 @@ contract DeployPegInTest is Test {
                 cfg.adminDelay,
                 cfg.minimumCollateral,
                 cfg.resignDelayBlocks,
-                cfg.rewardPercentage
+                cfg.rewardPercentage,
+                PauseRegistry(pauseRegistryProxy)
             )
         );
         collateralManagementProxy = address(
@@ -47,8 +58,8 @@ contract DeployPegInTest is Test {
         address deployer,
         HelperConfig.FlyoverConfig memory cfg
     ) internal returns (address) {
-        address impl = address(new PegInContract());
         address admin = address(new ProxyAdmin(deployer));
+        address impl = address(new PegInContract());
         bytes memory initData = abi.encodeCall(
             PegInContract.initialize,
             (
@@ -57,7 +68,8 @@ contract DeployPegInTest is Test {
                 cfg.dustThreshold,
                 cfg.minimumPegIn,
                 collateralManagementProxy,
-                cfg.mainnet
+                cfg.mainnet,
+                PauseRegistry(pauseRegistryProxy)
             )
         );
         return address(new TransparentUpgradeableProxy(impl, admin, initData));

--- a/test/deployment/DeployPegOut.t.sol
+++ b/test/deployment/DeployPegOut.t.sol
@@ -6,6 +6,7 @@ import "lib/forge-std/src/console.sol";
 import {HelperConfig} from "../../script/HelperConfig.s.sol";
 import {PegOutContract} from "../../src/PegOutContract.sol";
 import {CollateralManagementContract} from "../../src/CollateralManagement.sol";
+import {PauseRegistry} from "../../src/PauseRegistry.sol";
 import {BridgeMock} from "../../src/test-contracts/BridgeMock.sol";
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
@@ -18,6 +19,7 @@ contract DeployPegOutTest is Test {
     HelperConfig public helperConfig;
     BridgeMock public bridgeMock;
     address public collateralManagementProxy;
+    address public pauseRegistryProxy;
 
     function setUp() public {
         helperConfig = new HelperConfig();
@@ -26,8 +28,16 @@ contract DeployPegOutTest is Test {
         HelperConfig.FlyoverConfig memory cfg = helperConfig.getFlyoverConfig();
         address deployer = address(this);
 
-        address cmImpl = address(new CollateralManagementContract());
         address cmAdmin = address(new ProxyAdmin(deployer));
+        PauseRegistry prImpl = new PauseRegistry();
+        pauseRegistryProxy = address(
+            new TransparentUpgradeableProxy(
+                address(prImpl),
+                cmAdmin,
+                abi.encodeCall(prImpl.initialize, (0, deployer))
+            )
+        );
+        address cmImpl = address(new CollateralManagementContract());
         bytes memory cmInitData = abi.encodeCall(
             CollateralManagementContract.initialize,
             (
@@ -35,7 +45,8 @@ contract DeployPegOutTest is Test {
                 cfg.adminDelay,
                 cfg.minimumCollateral,
                 cfg.resignDelayBlocks,
-                cfg.rewardPercentage
+                cfg.rewardPercentage,
+                PauseRegistry(pauseRegistryProxy)
             )
         );
         collateralManagementProxy = address(
@@ -57,7 +68,8 @@ contract DeployPegOutTest is Test {
                 cfg.dustThreshold,
                 collateralManagementProxy,
                 cfg.mainnet,
-                cfg.btcBlockTime
+                cfg.btcBlockTime,
+                PauseRegistry(pauseRegistryProxy)
             )
         );
         return address(new TransparentUpgradeableProxy(impl, admin, initData));

--- a/test/discovery/DiscoveryTestBase.sol
+++ b/test/discovery/DiscoveryTestBase.sol
@@ -5,12 +5,14 @@ import {Test, console} from "forge-std/Test.sol";
 import {FlyoverDiscovery} from "../../src/FlyoverDiscovery.sol";
 import {CollateralManagementContract} from "../../src/CollateralManagement.sol";
 import {ICollateralManagement} from "../../src/interfaces/ICollateralManagement.sol";
+import {PauseRegistry} from "../../src/PauseRegistry.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {Flyover} from "../../src/libraries/Flyover.sol";
 
 /// @title Base contract for FlyoverDiscovery tests
 /// @notice Provides shared deployment and setup logic
 abstract contract DiscoveryTestBase is Test {
+    PauseRegistry public pauseRegistry;
     FlyoverDiscovery public discovery;
     CollateralManagementContract public collateralManagement;
 
@@ -34,6 +36,14 @@ abstract contract DiscoveryTestBase is Test {
         owner = makeAddr("owner");
         vm.deal(owner, 100 ether);
 
+        // Deploy PauseRegistry
+        PauseRegistry prImpl = new PauseRegistry();
+        ERC1967Proxy prProxy = new ERC1967Proxy(
+            address(prImpl),
+            abi.encodeCall(prImpl.initialize, (0, owner))
+        );
+        pauseRegistry = PauseRegistry(payable(address(prProxy)));
+
         // Deploy CollateralManagement
         CollateralManagementContract cmImplementation = new CollateralManagementContract();
         bytes memory cmInitData = abi.encodeCall(
@@ -43,7 +53,8 @@ abstract contract DiscoveryTestBase is Test {
                 TEST_DEFAULT_ADMIN_DELAY,
                 TEST_MIN_COLLATERAL,
                 TEST_RESIGN_DELAY_BLOCKS,
-                TEST_REWARD_PERCENTAGE
+                TEST_REWARD_PERCENTAGE,
+                pauseRegistry
             )
         );
         ERC1967Proxy cmProxy = new ERC1967Proxy(
@@ -58,7 +69,12 @@ abstract contract DiscoveryTestBase is Test {
         FlyoverDiscovery discoveryImplementation = new FlyoverDiscovery();
         bytes memory discoveryInitData = abi.encodeCall(
             FlyoverDiscovery.initialize,
-            (owner, uint48(INITIAL_DELAY), address(collateralManagement))
+            (
+                owner,
+                uint48(INITIAL_DELAY),
+                address(collateralManagement),
+                pauseRegistry
+            )
         );
         ERC1967Proxy discoveryProxy = new ERC1967Proxy(
             address(discoveryImplementation),

--- a/test/fuzz/collateral/CollateralFuzzTestBase.sol
+++ b/test/fuzz/collateral/CollateralFuzzTestBase.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.25;
 import {Test, console} from "forge-std/Test.sol";
 import {CollateralManagementContract} from "../../../src/CollateralManagement.sol";
 import {ICollateralManagement} from "../../../src/interfaces/ICollateralManagement.sol";
+import {PauseRegistry} from "../../../src/PauseRegistry.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {Flyover} from "../../../src/libraries/Flyover.sol";
 import {Quotes} from "../../../src/libraries/Quotes.sol";
@@ -12,6 +13,7 @@ import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol"
 /// @title Base contract for CollateralManagement fuzz tests
 /// @notice Provides shared deployment and setup logic for fuzz testing
 abstract contract CollateralFuzzTestBase is Test {
+    PauseRegistry public pauseRegistry;
     CollateralManagementContract public collateralManagement;
 
     address public owner;
@@ -52,6 +54,13 @@ abstract contract CollateralFuzzTestBase is Test {
         owner = makeAddr("owner");
         vm.deal(owner, 100 ether);
 
+        PauseRegistry prImpl = new PauseRegistry();
+        ERC1967Proxy prProxy = new ERC1967Proxy(
+            address(prImpl),
+            abi.encodeCall(prImpl.initialize, (0, owner))
+        );
+        pauseRegistry = PauseRegistry(payable(address(prProxy)));
+
         CollateralManagementContract implementation = new CollateralManagementContract();
 
         bytes memory initData = abi.encodeCall(
@@ -61,7 +70,8 @@ abstract contract CollateralFuzzTestBase is Test {
                 TEST_DEFAULT_ADMIN_DELAY,
                 TEST_MIN_COLLATERAL,
                 TEST_RESIGN_DELAY_BLOCKS,
-                TEST_REWARD_PERCENTAGE
+                TEST_REWARD_PERCENTAGE,
+                pauseRegistry
             )
         );
 

--- a/test/fuzz/discovery/DiscoveryFuzzTestBase.sol
+++ b/test/fuzz/discovery/DiscoveryFuzzTestBase.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.25;
 import {Test, console} from "forge-std/Test.sol";
 import {FlyoverDiscovery} from "../../../src/FlyoverDiscovery.sol";
 import {CollateralManagementContract} from "../../../src/CollateralManagement.sol";
+import {PauseRegistry} from "../../../src/PauseRegistry.sol";
 import {ICollateralManagement} from "../../../src/interfaces/ICollateralManagement.sol";
 import {IFlyoverDiscovery} from "../../../src/interfaces/IFlyoverDiscovery.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
@@ -12,6 +13,7 @@ import {Flyover} from "../../../src/libraries/Flyover.sol";
 /// @title Base contract for FlyoverDiscovery fuzz tests
 /// @notice Provides shared deployment logic and helpers for fuzz testing
 abstract contract DiscoveryFuzzTestBase is Test {
+    PauseRegistry public pauseRegistry;
     FlyoverDiscovery public discovery;
     CollateralManagementContract public collateralManagement;
 
@@ -55,6 +57,14 @@ abstract contract DiscoveryFuzzTestBase is Test {
         owner = makeAddr("owner");
         vm.deal(owner, 100 ether);
 
+        // Deploy PauseRegistry
+        PauseRegistry prImpl = new PauseRegistry();
+        ERC1967Proxy prProxy = new ERC1967Proxy(
+            address(prImpl),
+            abi.encodeCall(prImpl.initialize, (0, owner))
+        );
+        pauseRegistry = PauseRegistry(payable(address(prProxy)));
+
         // Deploy CollateralManagement
         CollateralManagementContract cmImplementation = new CollateralManagementContract();
         bytes memory cmInitData = abi.encodeCall(
@@ -64,7 +74,8 @@ abstract contract DiscoveryFuzzTestBase is Test {
                 TEST_DEFAULT_ADMIN_DELAY,
                 TEST_MIN_COLLATERAL,
                 TEST_RESIGN_DELAY_BLOCKS,
-                TEST_REWARD_PERCENTAGE
+                TEST_REWARD_PERCENTAGE,
+                pauseRegistry
             )
         );
         ERC1967Proxy cmProxy = new ERC1967Proxy(
@@ -79,7 +90,12 @@ abstract contract DiscoveryFuzzTestBase is Test {
         FlyoverDiscovery discoveryImplementation = new FlyoverDiscovery();
         bytes memory discoveryInitData = abi.encodeCall(
             FlyoverDiscovery.initialize,
-            (owner, uint48(INITIAL_DELAY), address(collateralManagement))
+            (
+                owner,
+                uint48(INITIAL_DELAY),
+                address(collateralManagement),
+                pauseRegistry
+            )
         );
         ERC1967Proxy discoveryProxy = new ERC1967Proxy(
             address(discoveryImplementation),

--- a/test/helpers/FlyoverTestBase.sol
+++ b/test/helpers/FlyoverTestBase.sol
@@ -6,9 +6,11 @@ import {Test, console} from "forge-std/Test.sol";
 // Contracts
 import {CollateralManagementContract} from "../../src/CollateralManagement.sol";
 import {FlyoverDiscovery} from "../../src/FlyoverDiscovery.sol";
+import {PauseRegistry} from "../../src/PauseRegistry.sol";
 import {PegInContract} from "../../src/PegInContract.sol";
 import {PegOutContract} from "../../src/PegOutContract.sol";
 import {BridgeMock} from "../../src/test-contracts/BridgeMock.sol";
+import {IPauseRegistry} from "../../src/interfaces/IPauseRegistry.sol";
 
 // Libraries
 import {Quotes} from "../../src/libraries/Quotes.sol";
@@ -64,6 +66,7 @@ abstract contract FlyoverTestBase is Test {
     // Contract Instances
     // ============================================================
 
+    PauseRegistry public pauseRegistry;
     CollateralManagementContract public collateralManagement;
     FlyoverDiscovery public discovery;
     PegInContract public pegInContract;
@@ -115,14 +118,28 @@ abstract contract FlyoverTestBase is Test {
     // Deployment Functions - Using Deployment Scripts
     // ============================================================
 
+    /// @notice Deploy PauseRegistry (used by all pausable contracts)
+    function _deployPauseRegistry() internal {
+        PauseRegistry prImpl = new PauseRegistry();
+        address admin = address(new ProxyAdmin(owner));
+        address proxy = address(
+            new TransparentUpgradeableProxy(
+                address(prImpl),
+                admin,
+                abi.encodeCall(prImpl.initialize, (0, owner))
+            )
+        );
+        pauseRegistry = PauseRegistry(proxy);
+    }
+
     /// @notice Deploy only CollateralManagement contract
     function deployCollateralManagement() internal {
         owner = makeAddr("owner");
         vm.deal(owner, 100 ether);
 
         HelperConfig.FlyoverConfig memory cfg = _getTestConfig();
+        _deployPauseRegistry();
 
-        // Inline deployment
         address impl = address(new CollateralManagementContract());
         address admin = address(new ProxyAdmin(owner));
         address proxy = address(
@@ -136,7 +153,8 @@ abstract contract FlyoverTestBase is Test {
                         cfg.adminDelay,
                         cfg.minimumCollateral,
                         cfg.resignDelayBlocks,
-                        cfg.rewardPercentage
+                        cfg.rewardPercentage,
+                        pauseRegistry
                     )
                 )
             )
@@ -151,7 +169,6 @@ abstract contract FlyoverTestBase is Test {
 
         HelperConfig.FlyoverConfig memory cfg = _getTestConfig();
 
-        // Inline deployment
         address impl = address(new FlyoverDiscovery());
         address admin = address(new ProxyAdmin(owner));
         address proxy = address(
@@ -160,7 +177,12 @@ abstract contract FlyoverTestBase is Test {
                 admin,
                 abi.encodeCall(
                     FlyoverDiscovery.initialize,
-                    (owner, cfg.adminDelay, address(collateralManagement))
+                    (
+                        owner,
+                        cfg.adminDelay,
+                        address(collateralManagement),
+                        pauseRegistry
+                    )
                 )
             )
         );
@@ -199,7 +221,8 @@ abstract contract FlyoverTestBase is Test {
                 cfg.dustThreshold,
                 cfg.minimumPegIn,
                 address(collateralManagement),
-                cfg.mainnet
+                cfg.mainnet,
+                pauseRegistry
             )
         );
         address proxy = address(
@@ -235,7 +258,8 @@ abstract contract FlyoverTestBase is Test {
                 cfg.dustThreshold,
                 address(collateralManagement),
                 cfg.mainnet,
-                cfg.btcBlockTime
+                cfg.btcBlockTime,
+                pauseRegistry
             )
         );
         address proxy = address(
@@ -264,8 +288,18 @@ abstract contract FlyoverTestBase is Test {
 
         HelperConfig.FlyoverConfig memory cfg = _getTestConfig();
 
-        // Single ProxyAdmin for all contracts
         address proxyAdmin = address(new ProxyAdmin(owner));
+
+        // 0) PauseRegistry
+        PauseRegistry prImpl = new PauseRegistry();
+        address prProxy = address(
+            new TransparentUpgradeableProxy(
+                address(prImpl),
+                proxyAdmin,
+                abi.encodeCall(prImpl.initialize, (0, owner))
+            )
+        );
+        pauseRegistry = PauseRegistry(prProxy);
 
         // 1) CollateralManagement
         address cmImpl = address(new CollateralManagementContract());
@@ -280,7 +314,8 @@ abstract contract FlyoverTestBase is Test {
                         cfg.adminDelay,
                         cfg.minimumCollateral,
                         cfg.resignDelayBlocks,
-                        cfg.rewardPercentage
+                        cfg.rewardPercentage,
+                        IPauseRegistry(prProxy)
                     )
                 )
             )
@@ -295,7 +330,7 @@ abstract contract FlyoverTestBase is Test {
                 proxyAdmin,
                 abi.encodeCall(
                     FlyoverDiscovery.initialize,
-                    (owner, cfg.adminDelay, cmProxy)
+                    (owner, cfg.adminDelay, cmProxy, IPauseRegistry(prProxy))
                 )
             )
         );
@@ -312,7 +347,8 @@ abstract contract FlyoverTestBase is Test {
                     cfg.dustThreshold,
                     cfg.minimumPegIn,
                     cmProxy,
-                    cfg.mainnet
+                    cfg.mainnet,
+                    IPauseRegistry(prProxy)
                 )
             );
             address piProxy = address(
@@ -332,7 +368,8 @@ abstract contract FlyoverTestBase is Test {
                     cfg.dustThreshold,
                     cmProxy,
                     cfg.mainnet,
-                    cfg.btcBlockTime
+                    cfg.btcBlockTime,
+                    IPauseRegistry(prProxy)
                 )
             );
             address poProxy = address(

--- a/test/integration/CollateralManagement.t.sol
+++ b/test/integration/CollateralManagement.t.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.25;
 import "forge-std/Test.sol";
 import {FlyoverDiscovery} from "../../src/FlyoverDiscovery.sol";
 import {CollateralManagementContract} from "../../src/CollateralManagement.sol";
+import {PauseRegistry} from "../../src/PauseRegistry.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {Flyover} from "../../src/libraries/Flyover.sol";
 import {Quotes} from "../../src/libraries/Quotes.sol";
@@ -11,6 +12,7 @@ import {Quotes} from "../../src/libraries/Quotes.sol";
 /// @title CollateralManagement Integration Tests
 /// @notice Tests cross-contract interactions between CollateralManagement and Discovery
 contract CollateralManagementIntegrationTest is Test {
+    PauseRegistry public pauseRegistry;
     FlyoverDiscovery public discovery;
     CollateralManagementContract public collateralManagement;
 
@@ -36,11 +38,26 @@ contract CollateralManagementIntegrationTest is Test {
             signers.push(signer);
         }
 
+        // Deploy PauseRegistry
+        PauseRegistry prImpl = new PauseRegistry();
+        ERC1967Proxy prProxy = new ERC1967Proxy(
+            address(prImpl),
+            abi.encodeCall(prImpl.initialize, (0, owner))
+        );
+        pauseRegistry = PauseRegistry(payable(address(prProxy)));
+
         // Deploy CollateralManagement
         CollateralManagementContract cmImpl = new CollateralManagementContract();
         bytes memory cmInitData = abi.encodeCall(
             CollateralManagementContract.initialize,
-            (owner, 30, MIN_COLLATERAL, RESIGN_DELAY_BLOCKS, 1000)
+            (
+                owner,
+                30,
+                MIN_COLLATERAL,
+                RESIGN_DELAY_BLOCKS,
+                1000,
+                pauseRegistry
+            )
         );
         ERC1967Proxy cmProxy = new ERC1967Proxy(address(cmImpl), cmInitData);
         collateralManagement = CollateralManagementContract(
@@ -51,7 +68,7 @@ contract CollateralManagementIntegrationTest is Test {
         FlyoverDiscovery discoveryImpl = new FlyoverDiscovery();
         bytes memory discoveryInitData = abi.encodeCall(
             FlyoverDiscovery.initialize,
-            (owner, 5000, address(collateralManagement))
+            (owner, 5000, address(collateralManagement), pauseRegistry)
         );
         ERC1967Proxy discoveryProxy = new ERC1967Proxy(
             address(discoveryImpl),

--- a/test/integration/FlyoverDiscovery.t.sol
+++ b/test/integration/FlyoverDiscovery.t.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.25;
 import "forge-std/Test.sol";
 import {FlyoverDiscovery} from "../../src/FlyoverDiscovery.sol";
 import {CollateralManagementContract} from "../../src/CollateralManagement.sol";
+import {PauseRegistry} from "../../src/PauseRegistry.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {Flyover} from "../../src/libraries/Flyover.sol";
 import {Quotes} from "../../src/libraries/Quotes.sol";
@@ -11,6 +12,7 @@ import {Quotes} from "../../src/libraries/Quotes.sol";
 /// @title FlyoverDiscovery Integration Tests
 /// @notice Tests cross-contract interactions between FlyoverDiscovery and CollateralManagement
 contract FlyoverDiscoveryIntegrationTest is Test {
+    PauseRegistry public pauseRegistry;
     FlyoverDiscovery public discovery;
     CollateralManagementContract public collateralManagement;
 
@@ -69,11 +71,26 @@ contract FlyoverDiscoveryIntegrationTest is Test {
             signers.push(signer);
         }
 
+        // Deploy PauseRegistry
+        PauseRegistry prImpl = new PauseRegistry();
+        ERC1967Proxy prProxy = new ERC1967Proxy(
+            address(prImpl),
+            abi.encodeCall(prImpl.initialize, (0, owner))
+        );
+        pauseRegistry = PauseRegistry(payable(address(prProxy)));
+
         // Deploy CollateralManagement
         CollateralManagementContract cmImpl = new CollateralManagementContract();
         bytes memory cmInitData = abi.encodeCall(
             CollateralManagementContract.initialize,
-            (owner, 30, MIN_COLLATERAL, RESIGN_DELAY_BLOCKS, 1000)
+            (
+                owner,
+                30,
+                MIN_COLLATERAL,
+                RESIGN_DELAY_BLOCKS,
+                1000,
+                pauseRegistry
+            )
         );
         ERC1967Proxy cmProxy = new ERC1967Proxy(address(cmImpl), cmInitData);
         collateralManagement = CollateralManagementContract(
@@ -84,7 +101,7 @@ contract FlyoverDiscoveryIntegrationTest is Test {
         FlyoverDiscovery discoveryImpl = new FlyoverDiscovery();
         bytes memory discoveryInitData = abi.encodeCall(
             FlyoverDiscovery.initialize,
-            (owner, 5000, address(collateralManagement))
+            (owner, 5000, address(collateralManagement), pauseRegistry)
         );
         ERC1967Proxy discoveryProxy = new ERC1967Proxy(
             address(discoveryImpl),

--- a/test/pegin/Configuration.t.sol
+++ b/test/pegin/Configuration.t.sol
@@ -76,7 +76,8 @@ contract ConfigurationTest is PegInTestBase {
             TEST_DUST_THRESHOLD,
             TEST_MIN_PEGIN,
             address(collateralManagement),
-            false
+            false,
+            pauseRegistry
         );
     }
 
@@ -94,7 +95,8 @@ contract ConfigurationTest is PegInTestBase {
                 TEST_DUST_THRESHOLD,
                 TEST_MIN_PEGIN,
                 noCodeAddress, // Address with no code
-                false
+                false,
+                pauseRegistry
             )
         );
 
@@ -150,7 +152,8 @@ contract ConfigurationTest is PegInTestBase {
                 TEST_DEFAULT_ADMIN_DELAY,
                 TEST_MIN_COLLATERAL,
                 TEST_RESIGN_DELAY_BLOCKS,
-                TEST_REWARD_PERCENTAGE
+                TEST_REWARD_PERCENTAGE,
+                pauseRegistry
             )
         );
         ERC1967Proxy otherProxy = new ERC1967Proxy(address(otherCM), initData);
@@ -198,7 +201,8 @@ contract ConfigurationTest is PegInTestBase {
                 TEST_DEFAULT_ADMIN_DELAY,
                 TEST_MIN_COLLATERAL,
                 TEST_RESIGN_DELAY_BLOCKS,
-                TEST_REWARD_PERCENTAGE
+                TEST_REWARD_PERCENTAGE,
+                pauseRegistry
             )
         );
         ERC1967Proxy otherProxy = new ERC1967Proxy(address(otherCM), initData);

--- a/test/pegin/DerivationAddress.t.sol
+++ b/test/pegin/DerivationAddress.t.sol
@@ -5,6 +5,7 @@ import {Test, console} from "forge-std/Test.sol";
 import {PegInContract} from "../../src/PegInContract.sol";
 import {CollateralManagementContract} from "../../src/CollateralManagement.sol";
 import {FlyoverDiscovery} from "../../src/FlyoverDiscovery.sol";
+import {PauseRegistry} from "../../src/PauseRegistry.sol";
 import {BridgeMock} from "../../src/test-contracts/BridgeMock.sol";
 import {Flyover} from "../../src/libraries/Flyover.sol";
 import {Quotes} from "../../src/libraries/Quotes.sol";
@@ -38,25 +39,26 @@ contract DerivationAddressTest is Test {
 
     // Deposit addresses (mainnet and testnet for each test case)
     bytes constant MAINNET_DEPOSIT_ADDRESS_1 =
-        hex"05c93c3553c0f288e2390f0b0ea4192457c3a8c4e534963c55";
+        hex"05a028a93b57d3ae056504de4ccedbe45349f728708f508621";
     bytes constant TESTNET_DEPOSIT_ADDRESS_1 =
-        hex"c4c93c3553c0f288e2390f0b0ea4192457c3a8c4e57f0fd8ff";
+        hex"c4a028a93b57d3ae056504de4ccedbe45349f72870077cc2a3";
     bytes constant MAINNET_DEPOSIT_ADDRESS_2 =
-        hex"057fd692c0a900d497fa104ea5c0ec8bc93972d23ccf917ecf";
+        hex"05f3d8cc0272674bf44b53d1a2c4012a35b8161dfec4f77bd2";
     bytes constant TESTNET_DEPOSIT_ADDRESS_2 =
-        hex"c47fd692c0a900d497fa104ea5c0ec8bc93972d23ccbd23ea5";
+        hex"c4f3d8cc0272674bf44b53d1a2c4012a35b8161dfea43d7a4c";
     bytes constant MAINNET_DEPOSIT_ADDRESS_3 =
-        hex"0585417b12e5387b07e5796da23feac0e4840da9763def19df";
+        hex"0560478d263979f125a4b0fa58a0fc2238eca545ab2f3c1de5";
     bytes constant TESTNET_DEPOSIT_ADDRESS_3 =
-        hex"c485417b12e5387b07e5796da23feac0e4840da97652a1a047";
+        hex"c460478d263979f125a4b0fa58a0fc2238eca545abe95f5e84";
 
     address owner = address(1);
+    PauseRegistry internal _pauseRegistry;
 
     // Foundry deterministic deployment addresses (with real CollateralManagement)
     address constant FOUNDRY_MAINNET_CONTRACT =
-        0x1d1499e622D69689cdf9004d05Ec547d650Ff211;
+        0x03A6a84cD762D9707A21605b548aaaB891562aAb;
     address constant FOUNDRY_TESTNET_CONTRACT =
-        0x1d1499e622D69689cdf9004d05Ec547d650Ff211;
+        0x03A6a84cD762D9707A21605b548aaaB891562aAb;
 
     // ============ hashPegInQuote function tests ============
 
@@ -201,7 +203,8 @@ contract DerivationAddressTest is Test {
                 TEST_DUST_THRESHOLD,
                 TEST_MIN_PEGIN,
                 address(collateralManagement),
-                mainnet // mainnet flag
+                mainnet, // mainnet flag
+                _pauseRegistry
             )
         );
 
@@ -217,6 +220,14 @@ contract DerivationAddressTest is Test {
         internal
         returns (CollateralManagementContract)
     {
+        // Deploy PauseRegistry
+        PauseRegistry prImpl = new PauseRegistry();
+        ERC1967Proxy prProxy = new ERC1967Proxy(
+            address(prImpl),
+            abi.encodeCall(prImpl.initialize, (0, owner))
+        );
+        _pauseRegistry = PauseRegistry(payable(address(prProxy)));
+
         // Deploy CollateralManagement first (matching PegInTestBase pattern)
         CollateralManagementContract cmImplementation = new CollateralManagementContract();
         bytes memory cmInitData = abi.encodeCall(
@@ -226,7 +237,8 @@ contract DerivationAddressTest is Test {
                 TEST_DEFAULT_ADMIN_DELAY,
                 TEST_MIN_COLLATERAL,
                 TEST_RESIGN_DELAY_BLOCKS,
-                TEST_REWARD_PERCENTAGE
+                TEST_REWARD_PERCENTAGE,
+                _pauseRegistry
             )
         );
 
@@ -243,7 +255,12 @@ contract DerivationAddressTest is Test {
         FlyoverDiscovery discoveryImplementation = new FlyoverDiscovery();
         bytes memory discoveryInitData = abi.encodeCall(
             FlyoverDiscovery.initialize,
-            (owner, uint48(DISCOVERY_INITIAL_DELAY), address(cm))
+            (
+                owner,
+                uint48(DISCOVERY_INITIAL_DELAY),
+                address(cm),
+                _pauseRegistry
+            )
         );
 
         ERC1967Proxy discoveryProxy = new ERC1967Proxy(

--- a/test/pegin/PegInTestBase.sol
+++ b/test/pegin/PegInTestBase.sol
@@ -5,6 +5,7 @@ import {Test, console} from "forge-std/Test.sol";
 import {PegInContract} from "../../src/PegInContract.sol";
 import {CollateralManagementContract} from "../../src/CollateralManagement.sol";
 import {FlyoverDiscovery} from "../../src/FlyoverDiscovery.sol";
+import {PauseRegistry} from "../../src/PauseRegistry.sol";
 import {BridgeMock} from "../../src/test-contracts/BridgeMock.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {Quotes} from "../../src/libraries/Quotes.sol";
@@ -13,6 +14,7 @@ import {Flyover} from "../../src/libraries/Flyover.sol";
 /// @title Base contract for PegIn tests
 /// @notice Provides shared deployment and setup logic for PegIn tests
 abstract contract PegInTestBase is Test {
+    PauseRegistry public pauseRegistry;
     PegInContract public pegInContract;
     CollateralManagementContract public collateralManagement;
     FlyoverDiscovery public discovery;
@@ -66,7 +68,8 @@ abstract contract PegInTestBase is Test {
                 TEST_DUST_THRESHOLD,
                 TEST_MIN_PEGIN,
                 address(collateralManagement),
-                false // mainnet
+                false, // mainnet
+                pauseRegistry
             )
         );
 
@@ -84,6 +87,13 @@ abstract contract PegInTestBase is Test {
     }
 
     function deployCollateralManagement() internal {
+        PauseRegistry prImpl = new PauseRegistry();
+        ERC1967Proxy prProxy = new ERC1967Proxy(
+            address(prImpl),
+            abi.encodeCall(prImpl.initialize, (0, owner))
+        );
+        pauseRegistry = PauseRegistry(payable(address(prProxy)));
+
         CollateralManagementContract cmImplementation = new CollateralManagementContract();
 
         bytes memory cmInitData = abi.encodeCall(
@@ -93,7 +103,8 @@ abstract contract PegInTestBase is Test {
                 TEST_DEFAULT_ADMIN_DELAY,
                 TEST_MIN_COLLATERAL,
                 TEST_RESIGN_DELAY_BLOCKS,
-                TEST_REWARD_PERCENTAGE
+                TEST_REWARD_PERCENTAGE,
+                pauseRegistry
             )
         );
 
@@ -122,7 +133,8 @@ abstract contract PegInTestBase is Test {
             (
                 owner,
                 uint48(DISCOVERY_INITIAL_DELAY),
-                address(collateralManagement)
+                address(collateralManagement),
+                pauseRegistry
             )
         );
 

--- a/test/pegout/Configuration.t.sol
+++ b/test/pegout/Configuration.t.sol
@@ -52,7 +52,8 @@ contract ConfigurationTest is PegOutTestBase {
             TEST_DUST_THRESHOLD,
             address(collateralManagement),
             false,
-            TEST_BTC_BLOCK_TIME
+            TEST_BTC_BLOCK_TIME,
+            pauseRegistry
         );
     }
 
@@ -70,7 +71,8 @@ contract ConfigurationTest is PegOutTestBase {
                 TEST_DUST_THRESHOLD,
                 noCodeAddress, // Address with no code
                 false,
-                TEST_BTC_BLOCK_TIME
+                TEST_BTC_BLOCK_TIME,
+                pauseRegistry
             )
         );
 
@@ -159,7 +161,8 @@ contract ConfigurationTest is PegOutTestBase {
                 TEST_DEFAULT_ADMIN_DELAY,
                 TEST_MIN_COLLATERAL,
                 TEST_RESIGN_DELAY_BLOCKS,
-                TEST_REWARD_PERCENTAGE
+                TEST_REWARD_PERCENTAGE,
+                pauseRegistry
             )
         );
         ERC1967Proxy otherProxy = new ERC1967Proxy(address(otherCM), initData);
@@ -207,7 +210,8 @@ contract ConfigurationTest is PegOutTestBase {
                 TEST_DEFAULT_ADMIN_DELAY,
                 TEST_MIN_COLLATERAL,
                 TEST_RESIGN_DELAY_BLOCKS,
-                TEST_REWARD_PERCENTAGE
+                TEST_REWARD_PERCENTAGE,
+                pauseRegistry
             )
         );
         ERC1967Proxy otherProxy = new ERC1967Proxy(address(otherCM), initData);

--- a/test/pegout/PegOutTestBase.sol
+++ b/test/pegout/PegOutTestBase.sol
@@ -5,6 +5,7 @@ import {Test, console} from "forge-std/Test.sol";
 import {PegOutContract} from "../../src/PegOutContract.sol";
 import {CollateralManagementContract} from "../../src/CollateralManagement.sol";
 import {FlyoverDiscovery} from "../../src/FlyoverDiscovery.sol";
+import {PauseRegistry} from "../../src/PauseRegistry.sol";
 import {BridgeMock} from "../../src/test-contracts/BridgeMock.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {Quotes} from "../../src/libraries/Quotes.sol";
@@ -13,6 +14,7 @@ import {Flyover} from "../../src/libraries/Flyover.sol";
 /// @title Base contract for PegOut tests
 /// @notice Provides shared deployment and setup logic for PegOut tests
 abstract contract PegOutTestBase is Test {
+    PauseRegistry public pauseRegistry;
     PegOutContract public pegOutContract;
     CollateralManagementContract public collateralManagement;
     FlyoverDiscovery public discovery;
@@ -69,7 +71,8 @@ abstract contract PegOutTestBase is Test {
                 TEST_DUST_THRESHOLD,
                 address(collateralManagement),
                 false, // mainnet
-                TEST_BTC_BLOCK_TIME
+                TEST_BTC_BLOCK_TIME,
+                pauseRegistry
             )
         );
 
@@ -86,6 +89,13 @@ abstract contract PegOutTestBase is Test {
     }
 
     function deployCollateralManagement() internal {
+        PauseRegistry prImpl = new PauseRegistry();
+        ERC1967Proxy prProxy = new ERC1967Proxy(
+            address(prImpl),
+            abi.encodeCall(prImpl.initialize, (0, owner))
+        );
+        pauseRegistry = PauseRegistry(payable(address(prProxy)));
+
         CollateralManagementContract cmImplementation = new CollateralManagementContract();
 
         bytes memory cmInitData = abi.encodeCall(
@@ -95,7 +105,8 @@ abstract contract PegOutTestBase is Test {
                 TEST_DEFAULT_ADMIN_DELAY,
                 TEST_MIN_COLLATERAL,
                 TEST_RESIGN_DELAY_BLOCKS,
-                TEST_REWARD_PERCENTAGE
+                TEST_REWARD_PERCENTAGE,
+                pauseRegistry
             )
         );
 
@@ -124,7 +135,8 @@ abstract contract PegOutTestBase is Test {
             (
                 owner,
                 uint48(DISCOVERY_INITIAL_DELAY),
-                address(collateralManagement)
+                address(collateralManagement),
+                pauseRegistry
             )
         );
 

--- a/test/tasks/PauseSystem.t.sol
+++ b/test/tasks/PauseSystem.t.sol
@@ -91,7 +91,7 @@ contract PauseSystemTest is FlyoverTestBase {
         (bool p2, , ) = mockPegOut.pauseStatus();
         (bool c1, , ) = mockCollateral.pauseStatus();
 
-        assertFalse(d1 && p1 && p2 && c1, "None should be paused initially");
+        assertFalse(d1 || p1 || p2 || c1, "None should be paused initially");
 
         string memory reason = "Test emergency pause";
         mockRegistry.pause(reason);
@@ -140,7 +140,7 @@ contract PauseSystemTest is FlyoverTestBase {
         (bool p2, string memory p2Reason, ) = mockPegOut.pauseStatus();
         (bool c1, string memory cReason, ) = mockCollateral.pauseStatus();
 
-        assertFalse(d1 && p1 && p2 && c1, "All should be unpaused");
+        assertFalse(d1 || p1 || p2 || c1, "All should be unpaused");
         assertEq(dReason, "", "Discovery reason should be cleared");
         assertEq(pReason, "", "PegIn reason should be cleared");
         assertEq(p2Reason, "", "PegOut reason should be cleared");
@@ -214,7 +214,7 @@ contract PauseSystemTest is FlyoverTestBase {
         (bool p2, , ) = mockPegOut.pauseStatus();
         (bool c1, , ) = mockCollateral.pauseStatus();
 
-        assertFalse(d1 && p1 && p2 && c1, "All should report unpaused");
+        assertFalse(d1 || p1 || p2 || c1, "All should report unpaused");
 
         console.log("\n[PASS] unpauseAll script function works correctly!");
     }

--- a/test/tasks/PauseSystem.t.sol
+++ b/test/tasks/PauseSystem.t.sol
@@ -4,27 +4,38 @@ pragma solidity 0.8.25;
 import {console} from "forge-std/console.sol";
 import {FlyoverTestBase} from "../helpers/FlyoverTestBase.sol";
 import {PauseSystem} from "../../script/tasks/PauseSystem.s.sol";
+import {IPauseRegistry} from "../../src/interfaces/IPauseRegistry.sol";
 
 /**
  * @title PauseSystemTest
- * @notice Test for the pause-system task with new Flyover contracts
- * @dev Uses direct contract calls to avoid env var race conditions with parallel tests
+ * @notice Test for the pause-system task: registry from env, verify all contracts use same registry
+ * @dev Uses mocks that expose pauseRegistry() and delegate pauseStatus() to the registry.
  */
 contract PauseSystemTest is FlyoverTestBase {
     PauseSystem public pauseScript;
 
+    MockPauseRegistry public mockRegistry;
     MockPausableContract public mockDiscovery;
     MockPausableContract public mockPegIn;
     MockPausableContract public mockPegOut;
     MockPausableContract public mockCollateral;
 
     function setUp() public {
-        mockDiscovery = new MockPausableContract("FlyoverDiscovery");
-        mockPegIn = new MockPausableContract("PegInContract");
-        mockPegOut = new MockPausableContract("PegOutContract");
-        mockCollateral = new MockPausableContract("CollateralManagement");
+        mockRegistry = new MockPauseRegistry();
+
+        mockDiscovery = new MockPausableContract(
+            "FlyoverDiscovery",
+            mockRegistry
+        );
+        mockPegIn = new MockPausableContract("PegInContract", mockRegistry);
+        mockPegOut = new MockPausableContract("PegOutContract", mockRegistry);
+        mockCollateral = new MockPausableContract(
+            "CollateralManagement",
+            mockRegistry
+        );
 
         console.log("Mock contracts deployed:");
+        console.log("  PauseRegistry:", address(mockRegistry));
         console.log("  FlyoverDiscovery:", address(mockDiscovery));
         console.log("  PegInContract:", address(mockPegIn));
         console.log("  PegOutContract:", address(mockPegOut));
@@ -34,9 +45,10 @@ contract PauseSystemTest is FlyoverTestBase {
     }
 
     /**
-     * @notice Set environment variables to point to our mock contracts
+     * @notice Set environment variables: registry from env, and all four contract addresses
      */
     function _setEnvVars() internal {
+        vm.setEnv("PAUSE_REGISTRY_ADDRESS", vm.toString(address(mockRegistry)));
         vm.setEnv(
             "FLYOVER_DISCOVERY_ADDRESS",
             vm.toString(address(mockDiscovery))
@@ -53,34 +65,17 @@ contract PauseSystemTest is FlyoverTestBase {
         _setEnvVars();
         console.log("\n=== TEST CHECK STATUS ===\n");
 
-        (bool d1, , ) = mockDiscovery.pauseStatus();
-        (bool p1, , ) = mockPegIn.pauseStatus();
-        (bool p2, , ) = mockPegOut.pauseStatus();
-        (bool c1, , ) = mockCollateral.pauseStatus();
-
-        assertFalse(d1, "Discovery should not be paused initially");
-        assertFalse(p1, "PegIn should not be paused initially");
-        assertFalse(p2, "PegOut should not be paused initially");
-        assertFalse(c1, "Collateral should not be paused initially");
+        (bool r1, , ) = mockRegistry.pauseStatus();
+        assertFalse(r1, "Registry should not be paused initially");
 
         pauseScript.checkStatus();
 
-        // Directly pause contracts
+        // Pause the registry (central source of truth)
         string memory reason = "Test pause for status check";
-        mockDiscovery.pause(reason);
-        mockPegIn.pause(reason);
-        mockPegOut.pause(reason);
-        mockCollateral.pause(reason);
+        mockRegistry.pause(reason);
 
-        (d1, , ) = mockDiscovery.pauseStatus();
-        (p1, , ) = mockPegIn.pauseStatus();
-        (p2, , ) = mockPegOut.pauseStatus();
-        (c1, , ) = mockCollateral.pauseStatus();
-
-        assertTrue(d1, "Discovery should be paused");
-        assertTrue(p1, "PegIn should be paused");
-        assertTrue(p2, "PegOut should be paused");
-        assertTrue(c1, "Collateral should be paused");
+        (r1, , ) = mockRegistry.pauseStatus();
+        assertTrue(r1, "Registry should be paused");
 
         _setEnvVars();
         pauseScript.checkStatus();
@@ -88,86 +83,64 @@ contract PauseSystemTest is FlyoverTestBase {
         console.log("\n[PASS] PauseSystem checkStatus works correctly!");
     }
 
-    function test_PauseAllContracts() public {
-        console.log("\n=== TEST PAUSE ALL CONTRACTS ===\n");
+    function test_RegistryPauseAffectsAllContracts() public {
+        console.log("\n=== TEST REGISTRY PAUSE AFFECTS ALL ===\n");
 
         (bool d1, , ) = mockDiscovery.pauseStatus();
         (bool p1, , ) = mockPegIn.pauseStatus();
         (bool p2, , ) = mockPegOut.pauseStatus();
         (bool c1, , ) = mockCollateral.pauseStatus();
 
-        assertFalse(d1, "Discovery should not be paused initially");
-        assertFalse(p1, "PegIn should not be paused initially");
-        assertFalse(p2, "PegOut should not be paused initially");
-        assertFalse(c1, "Collateral should not be paused initially");
+        assertFalse(d1 && p1 && p2 && c1, "None should be paused initially");
 
-        // Directly pause contracts to avoid env var race conditions
         string memory reason = "Test emergency pause";
-        mockDiscovery.pause(reason);
-        mockPegIn.pause(reason);
-        mockPegOut.pause(reason);
-        mockCollateral.pause(reason);
+        mockRegistry.pause(reason);
 
-        string memory dReason;
-        string memory pReason;
-        string memory p2Reason;
-        string memory cReason;
+        (d1, , ) = mockDiscovery.pauseStatus();
+        (p1, , ) = mockPegIn.pauseStatus();
+        (p2, , ) = mockPegOut.pauseStatus();
+        (c1, , ) = mockCollateral.pauseStatus();
 
-        (d1, dReason, ) = mockDiscovery.pauseStatus();
-        (p1, pReason, ) = mockPegIn.pauseStatus();
-        (p2, p2Reason, ) = mockPegOut.pauseStatus();
-        (c1, cReason, ) = mockCollateral.pauseStatus();
+        assertTrue(d1, "Discovery should report paused (from registry)");
+        assertTrue(p1, "PegIn should report paused (from registry)");
+        assertTrue(p2, "PegOut should report paused (from registry)");
+        assertTrue(c1, "Collateral should report paused (from registry)");
 
-        assertTrue(d1, "Discovery should be paused");
-        assertTrue(p1, "PegIn should be paused");
-        assertTrue(p2, "PegOut should be paused");
-        assertTrue(c1, "Collateral should be paused");
+        mockRegistry.unpause();
 
-        assertEq(dReason, reason, "Discovery pause reason should match");
-        assertEq(pReason, reason, "PegIn pause reason should match");
-        assertEq(p2Reason, reason, "PegOut pause reason should match");
-        assertEq(cReason, reason, "Collateral pause reason should match");
+        (d1, , ) = mockDiscovery.pauseStatus();
+        (p1, , ) = mockPegIn.pauseStatus();
+        (p2, , ) = mockPegOut.pauseStatus();
+        (c1, , ) = mockCollateral.pauseStatus();
 
-        console.log("\n[PASS] All contracts paused successfully!");
+        assertFalse(d1, "Discovery should report unpaused");
+        assertFalse(p1, "PegIn should report unpaused");
+        assertFalse(p2, "PegOut should report unpaused");
+        assertFalse(c1, "Collateral should report unpaused");
+
+        console.log("\n[PASS] Registry pause/unpause affects all contracts!");
     }
 
     function test_UnpauseAllContracts() public {
         console.log("\n=== TEST UNPAUSE ALL CONTRACTS ===\n");
 
-        // Directly pause then unpause
         string memory pauseReason = "Setup for unpause test";
-        mockDiscovery.pause(pauseReason);
-        mockPegIn.pause(pauseReason);
-        mockPegOut.pause(pauseReason);
-        mockCollateral.pause(pauseReason);
+        mockRegistry.pause(pauseReason);
 
-        (bool d1, , ) = mockDiscovery.pauseStatus();
-        (bool p1, , ) = mockPegIn.pauseStatus();
-        (bool p2, , ) = mockPegOut.pauseStatus();
-        (bool c1, , ) = mockCollateral.pauseStatus();
+        (bool r1, , ) = mockRegistry.pauseStatus();
+        assertTrue(r1, "Registry should be paused");
 
-        assertTrue(d1 && p1 && p2 && c1, "All should be paused");
+        mockRegistry.unpause();
 
-        mockDiscovery.unpause();
-        mockPegIn.unpause();
-        mockPegOut.unpause();
-        mockCollateral.unpause();
+        (r1, , ) = mockRegistry.pauseStatus();
+        assertFalse(r1, "Registry should be unpaused");
 
-        string memory dReason;
-        string memory pReason;
-        string memory p2Reason;
-        string memory cReason;
+        (bool d1, string memory dReason, ) = mockDiscovery.pauseStatus();
+        (bool p1, string memory pReason, ) = mockPegIn.pauseStatus();
+        (bool p2, string memory p2Reason, ) = mockPegOut.pauseStatus();
+        (bool c1, string memory cReason, ) = mockCollateral.pauseStatus();
 
-        (d1, dReason, ) = mockDiscovery.pauseStatus();
-        (p1, pReason, ) = mockPegIn.pauseStatus();
-        (p2, p2Reason, ) = mockPegOut.pauseStatus();
-        (c1, cReason, ) = mockCollateral.pauseStatus();
-
-        assertFalse(d1, "Discovery should be unpaused");
-        assertFalse(p1, "PegIn should be unpaused");
-        assertFalse(p2, "PegOut should be unpaused");
-        assertFalse(c1, "Collateral should be unpaused");
-
+        assertFalse(d1 && p1 && p2 && c1, "All should be unpaused");
         assertEq(dReason, "", "Discovery reason should be cleared");
         assertEq(pReason, "", "PegIn reason should be cleared");
         assertEq(p2Reason, "", "PegOut reason should be cleared");
@@ -185,21 +158,15 @@ contract PauseSystemTest is FlyoverTestBase {
         console.log("1. Initial status check");
         pauseScript.checkStatus();
 
-        console.log("\n2. Pausing all contracts");
-        mockDiscovery.pause(reason);
-        mockPegIn.pause(reason);
-        mockPegOut.pause(reason);
-        mockCollateral.pause(reason);
+        console.log("\n2. Pausing via registry");
+        mockRegistry.pause(reason);
 
         console.log("\n3. Status while paused");
         _setEnvVars();
         pauseScript.checkStatus();
 
-        console.log("\n4. Unpausing all contracts");
-        mockDiscovery.unpause();
-        mockPegIn.unpause();
-        mockPegOut.unpause();
-        mockCollateral.unpause();
+        console.log("\n4. Unpausing registry");
+        mockRegistry.unpause();
 
         console.log("\n5. Final status check");
         _setEnvVars();
@@ -212,19 +179,18 @@ contract PauseSystemTest is FlyoverTestBase {
         _setEnvVars();
         console.log("\n=== TEST PAUSE ALL VIA SCRIPT ===\n");
 
-        // Test that the script's pauseAll function works correctly
         pauseScript.pauseAll("Script-initiated pause");
+
+        (bool r1, string memory rReason, ) = mockRegistry.pauseStatus();
+        assertTrue(r1, "Registry should be paused");
+        assertEq(rReason, "Script-initiated pause", "Reason should match");
 
         (bool d1, string memory dReason, ) = mockDiscovery.pauseStatus();
         (bool p1, string memory pReason, ) = mockPegIn.pauseStatus();
         (bool p2, string memory p2Reason, ) = mockPegOut.pauseStatus();
         (bool c1, string memory cReason, ) = mockCollateral.pauseStatus();
 
-        assertTrue(d1, "Discovery should be paused");
-        assertTrue(p1, "PegIn should be paused");
-        assertTrue(p2, "PegOut should be paused");
-        assertTrue(c1, "Collateral should be paused");
-
+        assertTrue(d1 && p1 && p2 && c1, "All should report paused");
         assertEq(dReason, "Script-initiated pause", "Reason should match");
         assertEq(pReason, "Script-initiated pause", "Reason should match");
         assertEq(p2Reason, "Script-initiated pause", "Reason should match");
@@ -237,49 +203,153 @@ contract PauseSystemTest is FlyoverTestBase {
         _setEnvVars();
         console.log("\n=== TEST UNPAUSE ALL VIA SCRIPT ===\n");
 
-        // First pause all
         pauseScript.pauseAll("Pre-test pause");
-
-        // Then unpause via script
         pauseScript.unpauseAll();
+
+        (bool r1, , ) = mockRegistry.pauseStatus();
+        assertFalse(r1, "Registry should be unpaused");
 
         (bool d1, , ) = mockDiscovery.pauseStatus();
         (bool p1, , ) = mockPegIn.pauseStatus();
         (bool p2, , ) = mockPegOut.pauseStatus();
         (bool c1, , ) = mockCollateral.pauseStatus();
 
-        assertFalse(d1, "Discovery should be unpaused");
-        assertFalse(p1, "PegIn should be unpaused");
-        assertFalse(p2, "PegOut should be unpaused");
-        assertFalse(c1, "Collateral should be unpaused");
+        assertFalse(d1 && p1 && p2 && c1, "All should report unpaused");
 
         console.log("\n[PASS] unpauseAll script function works correctly!");
+    }
+
+    function test_RevertsWhenContractHasDifferentRegistry() public {
+        _setEnvVars();
+
+        // Deploy another registry and a mock that points to it
+        MockPauseRegistry otherRegistry = new MockPauseRegistry();
+        MockPausableContract mockWithOtherRegistry = new MockPausableContract(
+            "Other",
+            otherRegistry
+        );
+
+        // Point PegIn to a contract that has a *different* registry
+        vm.setEnv(
+            "PEGIN_CONTRACT_ADDRESS",
+            vm.toString(address(mockWithOtherRegistry))
+        );
+
+        vm.expectRevert(
+            "PauseSystem: PegInContract has different PauseRegistry"
+        );
+        pauseScript.checkStatus();
+    }
+
+    function test_RevertsWhenPegOutHasDifferentRegistry() public {
+        _setEnvVars();
+
+        MockPauseRegistry otherRegistry = new MockPauseRegistry();
+        MockPausableContract mockWithOtherRegistry = new MockPausableContract(
+            "Other",
+            otherRegistry
+        );
+
+        vm.setEnv(
+            "PEGOUT_CONTRACT_ADDRESS",
+            vm.toString(address(mockWithOtherRegistry))
+        );
+
+        vm.expectRevert(
+            "PauseSystem: PegOutContract has different PauseRegistry"
+        );
+        pauseScript.checkStatus();
+    }
+
+    function test_RevertsWhenCollateralHasDifferentRegistry() public {
+        _setEnvVars();
+
+        MockPauseRegistry otherRegistry = new MockPauseRegistry();
+        MockPausableContract mockWithOtherRegistry = new MockPausableContract(
+            "Other",
+            otherRegistry
+        );
+
+        vm.setEnv(
+            "COLLATERAL_MANAGEMENT_ADDRESS",
+            vm.toString(address(mockWithOtherRegistry))
+        );
+
+        vm.expectRevert(
+            "PauseSystem: CollateralManagement has different PauseRegistry"
+        );
+        pauseScript.checkStatus();
+    }
+
+    function test_RevertsWhenDiscoveryHasDifferentRegistry() public {
+        _setEnvVars();
+
+        MockPauseRegistry otherRegistry = new MockPauseRegistry();
+        MockPausableContract mockWithOtherRegistry = new MockPausableContract(
+            "Other",
+            otherRegistry
+        );
+
+        vm.setEnv(
+            "FLYOVER_DISCOVERY_ADDRESS",
+            vm.toString(address(mockWithOtherRegistry))
+        );
+
+        vm.expectRevert(
+            "PauseSystem: FlyoverDiscovery has different PauseRegistry"
+        );
+        pauseScript.checkStatus();
     }
 }
 
 /**
- * @notice Mock pausable contract matching the new Flyover contract interface
+ * @notice Mock PauseRegistry: central pause state used by the script
+ */
+contract MockPauseRegistry is IPauseRegistry {
+    bool private _paused;
+    string private _reason;
+    uint64 private _since;
+
+    function pause(string calldata reason) external override {
+        _paused = true;
+        _reason = reason;
+        _since = uint64(block.timestamp);
+    }
+
+    function unpause() external override {
+        _paused = false;
+        _reason = "";
+        _since = 0;
+    }
+
+    function paused() external view override returns (bool) {
+        return _paused;
+    }
+
+    function pauseStatus()
+        external
+        view
+        override
+        returns (bool isPaused, string memory reason, uint64 since)
+    {
+        return (_paused, _reason, _since);
+    }
+}
+
+/**
+ * @notice Mock contract that exposes pauseRegistry() and delegates pauseStatus() to the registry
  */
 contract MockPausableContract {
     string public name;
-    bool private _isPaused;
-    string private _pauseReason;
-    uint64 private _pausedSince;
+    IPauseRegistry private _registry;
 
-    constructor(string memory _name) {
+    constructor(string memory _name, IPauseRegistry registry) {
         name = _name;
+        _registry = registry;
     }
 
-    function pause(string calldata reason) external {
-        _isPaused = true;
-        _pauseReason = reason;
-        _pausedSince = uint64(block.timestamp);
-    }
-
-    function unpause() external {
-        _isPaused = false;
-        _pauseReason = "";
-        _pausedSince = 0;
+    function pauseRegistry() external view returns (IPauseRegistry) {
+        return _registry;
     }
 
     function pauseStatus()
@@ -287,6 +357,6 @@ contract MockPausableContract {
         view
         returns (bool isPaused, string memory reason, uint64 since)
     {
-        return (_isPaused, _pauseReason, _pausedSince);
+        return _registry.pauseStatus();
     }
 }


### PR DESCRIPTION
## What
Implemented the centralized pause registry as explained in the jira ticket attached to the FLY-2224

## Why
Because having partial pauses might derivate in inconsistent pause states which may cause issues

## Task
https://rsklabs.atlassian.net/browse/FLY-2224

## Important
Please review #414 and #412 first as this branch uses changes included in those PRs