### PR TITLE
docs: add clarification about the penalty reward calculation

### DIFF
--- a/src/interfaces/ICollateralManagement.sol
+++ b/src/interfaces/ICollateralManagement.sol
@@ -90,6 +90,8 @@ interface ICollateralManagement is IPausable {
     /// @notice Slashes peg in collateral from a liquidity provider. The slashed amount
     /// is the penalty fee of the quote. Depending on the reward percentage, the punisher
     /// will receive a reward. The rest of the penalty fee remains in the contract.
+    /// In case of non integer reward, the remainder of the calculation will stay in
+    /// the protocol as penalties.
     /// @param punisher The address of the punisher
     /// @param quote The quote of the peg in collateral
     /// @param quoteHash The hash of the quote
@@ -114,6 +116,8 @@ interface ICollateralManagement is IPausable {
     /// @notice Slashes peg out collateral from a liquidity provider. The slashed amount
     /// is the penalty fee of the quote. Depending on the reward percentage, the punisher
     /// will receive a reward. The rest of the penalty fee remains in the contract.
+    /// In case of non integer reward, the remainder of the calculation will stay in
+    /// the protocol as penalties.
     /// @param punisher The address of the punisher
     /// @param quote The quote of the peg out collateral
     /// @param quoteHash The hash of the quote

--- a/src/interfaces/ICollateralManagement.sol
+++ b/src/interfaces/ICollateralManagement.sol
@@ -90,8 +90,8 @@ interface ICollateralManagement is IPausable {
     /// @notice Slashes peg in collateral from a liquidity provider. The slashed amount
     /// is the penalty fee of the quote. Depending on the reward percentage, the punisher
     /// will receive a reward. The rest of the penalty fee remains in the contract.
-    /// In case of non integer reward, the remainder of the calculation will stay in
-    /// the protocol as penalties.
+    /// The punisher's reward is calculated using integer division (rounded down), and any
+    /// remainder from this calculation stays in the protocol as additional penalties.
     /// @param punisher The address of the punisher
     /// @param quote The quote of the peg in collateral
     /// @param quoteHash The hash of the quote
@@ -115,9 +115,9 @@ interface ICollateralManagement is IPausable {
 
     /// @notice Slashes peg out collateral from a liquidity provider. The slashed amount
     /// is the penalty fee of the quote. Depending on the reward percentage, the punisher
-    /// will receive a reward. The rest of the penalty fee remains in the contract.
-    /// In case of non integer reward, the remainder of the calculation will stay in
-    /// the protocol as penalties.
+    /// will receive a reward. The reward is calculated using integer division (rounded
+    /// down), and any remainder from this calculation remains in the contract as part
+    /// of the protocol penalties.
     /// @param punisher The address of the punisher
     /// @param quote The quote of the peg out collateral
     /// @param quoteHash The hash of the quote


### PR DESCRIPTION
## What
Add clarification about the penalty reward calculation to specify the punisher only gets the quotient of the division to calculate the reward but in the case of a remainder, the remainder stays in the protocol

## Why
It can be interpreted as a bug by accident

## Task
https://rsklabs.atlassian.net/browse/FLY-2205