### PR TITLE
Feature/FLY-2209

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,17 @@ Validates that the LP made the deposit of the service and applies the correspond
     * partialMerkleTree: PMT to validate transaction
     * merkleBranchHashes: merkleBranchHashes used by the bridge to validate transaction
 
+#### Peg-out BTC transaction structure (required)
+
+For `refundPegOut`, the contract expects a Bitcoin transaction with two specific outputs used to prove the LP delivered the service:
+
+1. **Payment output** at index `0`: pays the user destination (`quote.depositAddress`) with the peg-out amount.
+2. **Quote-hash output** at index `1`: an `OP_RETURN` output containing the peg-out quote hash.
+
+The structure is intentionally enforced by contract validation for peg-out refunding. Bitcoin consensus does not enforce output ordering, but `refundPegOut` currently validates these outputs using fixed positions. If the required outputs are present but swapped, validation fails and the LP cannot be refunded through this function.
+
+`btcTx` must be the raw Bitcoin transaction serialization without witness data.
+
 ### **refundUserPegOut**
 
     function refundUserPegOut(

--- a/src/PegOutContract.sol
+++ b/src/PegOutContract.sol
@@ -33,7 +33,9 @@ contract PegOutContract is
     /// @notice The version of the contract
     string constant public VERSION = "1.0.0";
     Flyover.ProviderType constant private _PEG_TYPE = Flyover.ProviderType.PegOut;
+    // Index of the BTC output that must pay quote.depositAddress during peg-out refund validation.
     uint256 constant private _PAY_TO_ADDRESS_OUTPUT = 0;
+    // Index of the BTC output that must be OP_RETURN with the quote hash during peg-out refund validation.
     uint256 constant private _QUOTE_HASH_OUTPUT = 1;
     uint256 constant private _SAT_TO_WEI_CONVERSION = 10**10;
     uint256 constant private _QUOTE_HASH_SIZE = 32;
@@ -312,6 +314,8 @@ contract PegOutContract is
 
     /// @notice This function performs common validations for peg out transactions without checking confirmations.
     /// Used by both validatePegout (for unbroadcasted transactions) and refundPegOut (before confirmation check).
+    /// The validation expects fixed output positions in btcTx:
+    /// output 0 is the payment output and output 1 is the OP_RETURN quote-hash output.
     /// @param quoteHash the hash of the quote being validated
     /// @param btcTx the Bitcoin transaction
     /// @return quote the PegOutQuote associated with the transaction
@@ -393,7 +397,9 @@ contract PegOutContract is
     }
 
     /// @notice This function is used to validate the null data of the Bitcoin transaction. The null data
-    /// is used to store the hash of the peg out quote in the Bitcoin transaction
+    /// is used to store the hash of the peg out quote in the Bitcoin transaction.
+    /// It reads the OP_RETURN script from output index 1 and expects:
+    /// first byte == 32, followed by 32 bytes containing quoteHash.
     /// @param outputs the outputs of the Bitcoin transaction
     /// @param quoteHash the hash of the peg out quote
     function _validateBtcTxNullData(BtcUtils.TxRawOutput[] memory outputs, bytes32 quoteHash) private pure {

--- a/src/interfaces/IPegOut.sol
+++ b/src/interfaces/IPegOut.sol
@@ -103,7 +103,8 @@ interface IPegOut is IPausable, IDaoContributor {
     /// their fee for the service. It proves the inclusion of the transaction paying to the user in the Bitcoin network
     /// @param quoteHash hash of the quote being refunded
     /// @param btcTx the Bitcoin raw transaction without witness data. It must include
-    /// the required outputs in this EXACT order(otherwise the LP risks losing its funds and getting its collateral slashed):
+    /// the required outputs in this EXACT order
+    /// (otherwise the LP risks losing its funds and getting its collateral slashed):
     /// - output 0: payment to quote.depositAddress
     /// - output 1: OP_RETURN storing the quoteHash
     /// The contract validates these outputs by fixed indices during peg-out refunds.

--- a/src/interfaces/IPegOut.sol
+++ b/src/interfaces/IPegOut.sol
@@ -102,7 +102,11 @@ interface IPegOut is IPausable, IDaoContributor {
     /// @notice This function is used by the liquidity provider to recover the funds spent on the peg out service plus
     /// their fee for the service. It proves the inclusion of the transaction paying to the user in the Bitcoin network
     /// @param quoteHash hash of the quote being refunded
-    /// @param btcTx the bitcoin raw transaction without the witness
+    /// @param btcTx the Bitcoin raw transaction without witness data. It must include
+    /// the required outputs in this EXACT order(otherwise the LP risks losing its funds and getting its collateral slashed):
+    /// - output 0: payment to quote.depositAddress
+    /// - output 1: OP_RETURN storing the quoteHash
+    /// The contract validates these outputs by fixed indices during peg-out refunds.
     /// @param btcBlockHeaderHash header hash of the block where the transaction was included
     /// @param merkleBranchPath index of the leaf that is being proved to be included in the merkle tree
     /// @param merkleBranchHashes hashes of the merkle branch to get to the merkle root using the leaf being proved


### PR DESCRIPTION
**What**

These documentation updates clarify that refundPegOut expects a specific BTC transaction layout for contract validation: the payment output to quote.depositAddress must be at index 0, and the OP_RETURN carrying quoteHash must be at index 1; this requirement is now explained in the README, reinforced in IPegOut NatSpec, and mirrored in PegOutContract comments so integrators and maintainers understand that output ordering here is an intentional contract-level rule (fixed-index validation), not a Bitcoin protocol consensus rule.

**Why**

Without this clarity, LPs can submit a valid Bitcoin transaction that still fails refundPegOut due to contract-side fixed-index checks, which can block LP reimbursement and create avoidable loss scenarios (including user refund plus LP slashing after expiry). 

**Task**

https://rsklabs.atlassian.net/browse/FLY-2209