### PR TITLE
Feature/fly 2211

### DIFF
--- a/src/FlyoverDiscovery.sol
+++ b/src/FlyoverDiscovery.sol
@@ -23,6 +23,7 @@ contract FlyoverDiscovery is
     // ------------------------------------------------------------
 
     mapping(uint => Flyover.LiquidityProvider) private _liquidityProviders;
+    mapping(address => uint) private _providerIdByAddress;
     ICollateralManagement private _collateralManagement;
     uint public lastProviderId;
 
@@ -56,18 +57,24 @@ contract FlyoverDiscovery is
 
        _validateRegistration(name, apiBaseUrl, providerType, msg.sender, msg.value);
 
-        ++lastProviderId;
-        _liquidityProviders[lastProviderId] = Flyover.LiquidityProvider({
-            id: lastProviderId,
+        uint providerId = _providerIdByAddress[msg.sender];
+        if (providerId == 0) {
+            ++lastProviderId;
+            providerId = lastProviderId;
+            _providerIdByAddress[msg.sender] = providerId;
+        }
+
+        _liquidityProviders[providerId] = Flyover.LiquidityProvider({
+            id: providerId,
             providerAddress: msg.sender,
             name: name,
             apiBaseUrl: apiBaseUrl,
             status: status,
             providerType: providerType
         });
-        emit Register(lastProviderId, msg.sender, msg.value);
+        emit Register(providerId, msg.sender, msg.value);
         _addCollateral(providerType, msg.sender, msg.value);
-        return (lastProviderId);
+        return providerId;
     }
 
     /// @inheritdoc IFlyoverDiscovery
@@ -85,18 +92,14 @@ contract FlyoverDiscovery is
     /// @inheritdoc IFlyoverDiscovery
     function updateProvider(string calldata name, string calldata apiBaseUrl) external whenNotPaused {
         if (bytes(name).length < 1 || bytes(apiBaseUrl).length < 1) revert InvalidProviderData(name, apiBaseUrl);
-        Flyover.LiquidityProvider storage lp;
         address providerAddress = msg.sender;
-        for (uint i = 1; i < lastProviderId + 1; ++i) {
-            lp = _liquidityProviders[i];
-            if (providerAddress == lp.providerAddress) {
-                lp.name = name;
-                lp.apiBaseUrl = apiBaseUrl;
-                emit IFlyoverDiscovery.ProviderUpdate(providerAddress, lp.name, lp.apiBaseUrl);
-                return;
-            }
-        }
-        revert Flyover.ProviderNotRegistered(providerAddress);
+        uint providerId = _providerIdByAddress[providerAddress];
+        if (providerId == 0) revert Flyover.ProviderNotRegistered(providerAddress);
+
+        Flyover.LiquidityProvider storage lp = _liquidityProviders[providerId];
+        lp.name = name;
+        lp.apiBaseUrl = apiBaseUrl;
+        emit IFlyoverDiscovery.ProviderUpdate(providerAddress, lp.name, lp.apiBaseUrl);
     }
 
     /// @inheritdoc IFlyoverDiscovery
@@ -221,15 +224,12 @@ contract FlyoverDiscovery is
     }
 
     /// @notice Retrieves a liquidity provider by address
-    /// @dev Searches through all registered providers to find a match
+    /// @dev Uses providerAddress-to-id mapping for O(1) lookup
     /// @param providerAddress The address of the provider to find
     /// @return The liquidity provider record, reverts if not found
     function _getProvider(address providerAddress) private view returns (Flyover.LiquidityProvider memory) {
-        for (uint i = 1; i < lastProviderId + 1; ++i) {
-            if (_liquidityProviders[i].providerAddress == providerAddress) {
-                return _liquidityProviders[i];
-            }
-        }
-        revert Flyover.ProviderNotRegistered(providerAddress);
+        uint providerId = _providerIdByAddress[providerAddress];
+        if (providerId == 0) revert Flyover.ProviderNotRegistered(providerAddress);
+        return _liquidityProviders[providerId];
     }
 }

--- a/src/legacy/LiquidityBridgeContractV2.sol
+++ b/src/legacy/LiquidityBridgeContractV2.sol
@@ -114,6 +114,7 @@ contract LiquidityBridgeContractV2 is OwnableUpgradeable, ReentrancyGuardUpgrade
     mapping(bytes32 => uint8) private processedQuotes;
     mapping(bytes32 => QuotesV2.PegOutQuote) private registeredPegoutQuotes;
     mapping(bytes32 => PegoutRecord) private pegoutRegistry;
+    mapping(address => uint256) private providerIdByAddress;
 
     uint256 public productFeePercentage;
     address public daoFeeCollectorAddress;
@@ -234,17 +235,23 @@ contract LiquidityBridgeContractV2 is OwnableUpgradeable, ReentrancyGuardUpgrade
             pegoutCollateral[msg.sender] = halfMsgValue;
         }
 
-        providerId++;
-        liquidityProviders[providerId] = LiquidityProvider({
-            id: providerId,
+        uint256 currentProviderId = providerIdByAddress[msg.sender];
+        if (currentProviderId == 0) {
+            providerId++;
+            currentProviderId = providerId;
+            providerIdByAddress[msg.sender] = currentProviderId;
+        }
+
+        liquidityProviders[currentProviderId] = LiquidityProvider({
+            id: currentProviderId,
             provider: msg.sender,
             name: _name,
             apiBaseUrl: _apiBaseUrl,
             status: _status,
             providerType: _providerType
         });
-        emit Register(providerId, msg.sender, msg.value);
-        return (providerId);
+        emit Register(currentProviderId, msg.sender, msg.value);
+        return currentProviderId;
     }
 
     function getProviders() external view returns (LiquidityProvider[] memory) {
@@ -268,12 +275,9 @@ contract LiquidityBridgeContractV2 is OwnableUpgradeable, ReentrancyGuardUpgrade
     }
 
     function getProvider(address providerAddress) public view returns (LiquidityProvider memory) {
-        for (uint i = 1; i <= providerId; i++) {
-            if (liquidityProviders[i].provider == providerAddress) {
-                return liquidityProviders[i];
-            }
-        }
-        revert("LBC001");
+        uint256 currentProviderId = providerIdByAddress[providerAddress];
+        if (currentProviderId == 0) revert("LBC001");
+        return liquidityProviders[currentProviderId];
     }
 
     function shouldBeListed(LiquidityProvider storage lp) private view returns(bool){
@@ -963,16 +967,12 @@ contract LiquidityBridgeContractV2 is OwnableUpgradeable, ReentrancyGuardUpgrade
 
     function updateProvider(string memory _name, string memory _url) external {
         require(bytes(_name).length > 0 && bytes(_url).length > 0, "LBC076");
-        LiquidityProvider storage lp;
-        for (uint i = 1; i <= providerId; i++) {
-            lp = liquidityProviders[i];
-            if (msg.sender == lp.provider) {
-                lp.name = _name;
-                lp.apiBaseUrl = _url;
-                emit ProviderUpdate(msg.sender, lp.name, lp.apiBaseUrl);
-                return;
-            }
-        }
-        revert("LBC001");
+        uint256 currentProviderId = providerIdByAddress[msg.sender];
+        if (currentProviderId == 0) revert("LBC001");
+
+        LiquidityProvider storage lp = liquidityProviders[currentProviderId];
+        lp.name = _name;
+        lp.apiBaseUrl = _url;
+        emit ProviderUpdate(msg.sender, lp.name, lp.apiBaseUrl);
     }
 }

--- a/test/integration/CollateralManagement.t.sol
+++ b/test/integration/CollateralManagement.t.sol
@@ -355,11 +355,14 @@ contract CollateralManagementIntegrationTest is Test {
             Flyover.ProviderType.PegOut
         );
 
-        // Appears in listing again with new ID
+        // Appears in listing again reusing the same provider ID
         providers = discovery.getProviders();
         assertEq(providers.length, 1);
-        assertEq(providers[0].id, 2);
-        assertEq(providers[0].name, "LP Second");
+        assertEq(providers[0].id, 1);
+        assertEq(
+            keccak256(bytes(providers[0].name)),
+            keccak256(bytes("LP Second"))
+        );
         assertEq(
             uint8(providers[0].providerType),
             uint8(Flyover.ProviderType.PegOut)

--- a/test/integration/FlyoverDiscovery.t.sol
+++ b/test/integration/FlyoverDiscovery.t.sol
@@ -576,6 +576,64 @@ contract FlyoverDiscoveryIntegrationTest is Test {
         assertFalse(discovery.isOperational(Flyover.ProviderType.PegIn, lp2));
     }
 
+    function test_ShouldReuseSameIdAndUpdateCurrentDataWhenSameAddressReRegisters()
+        public
+    {
+        address lp = signers[signers.length - 1];
+
+        vm.prank(lp);
+        uint firstId = discovery.register{value: MIN_COLLATERAL}(
+            "LP v1",
+            "url-v1",
+            true,
+            Flyover.ProviderType.PegIn
+        );
+        assertEq(firstId, 1);
+        assertEq(discovery.getProvidersId(), 1);
+
+        vm.prank(lp);
+        collateralManagement.resign();
+
+        vm.roll(block.number + RESIGN_DELAY_BLOCKS);
+
+        vm.prank(lp);
+        collateralManagement.withdrawCollateral();
+
+        vm.prank(lp);
+        uint secondId = discovery.register{value: MIN_COLLATERAL}(
+            "LP v2",
+            "url-v2",
+            true,
+            Flyover.ProviderType.PegOut
+        );
+
+        assertEq(secondId, 1);
+        assertEq(discovery.getProvidersId(), 1);
+
+        Flyover.LiquidityProvider memory provider = discovery.getProvider(lp);
+        assertEq(provider.id, 1);
+        assertEq(keccak256(bytes(provider.name)), keccak256(bytes("LP v2")));
+        assertEq(
+            keccak256(bytes(provider.apiBaseUrl)),
+            keccak256(bytes("url-v2"))
+        );
+        assertEq(
+            uint8(provider.providerType),
+            uint8(Flyover.ProviderType.PegOut)
+        );
+
+        vm.prank(lp);
+        discovery.updateProvider("LP final", "url-final");
+
+        provider = discovery.getProvider(lp);
+        assertEq(provider.id, 1);
+        assertEq(keccak256(bytes(provider.name)), keccak256(bytes("LP final")));
+        assertEq(
+            keccak256(bytes(provider.apiBaseUrl)),
+            keccak256(bytes("url-final"))
+        );
+    }
+
     // ============ Complex Multi-Provider Scenario ============
 
     function test_ShouldListOnlyEnabledAndNonResignedProvidersInComplexScenario()

--- a/test/legacy/Discovery.t.sol
+++ b/test/legacy/Discovery.t.sol
@@ -402,4 +402,61 @@ contract DiscoveryTest is Test {
         assertEq(result[3].status, true);
         assertEq(result[3].providerType, "both");
     }
+
+    function test_ShouldReuseSameIdAndReturnCurrentEntryAfterReRegistration()
+        public
+    {
+        address lp = liquidityProviders[0].signer;
+
+        vm.prank(lp);
+        lbc.resign();
+
+        vm.prank(lp);
+        lbc.withdrawCollateral();
+
+        vm.prank(lp, lp);
+        uint returnedId = lbc.register{value: LP_COLLATERAL / 2}(
+            "First LP Re",
+            "http://localhost/api1-re",
+            true,
+            "pegin"
+        );
+
+        assertEq(returnedId, 1);
+        assertEq(lbc.providerId(), 3);
+
+        LiquidityBridgeContractV2.LiquidityProvider memory provider = lbc
+            .getProvider(lp);
+        assertEq(provider.id, 1);
+        assertEq(
+            keccak256(bytes(provider.name)),
+            keccak256(bytes("First LP Re"))
+        );
+        assertEq(
+            keccak256(bytes(provider.apiBaseUrl)),
+            keccak256(bytes("http://localhost/api1-re"))
+        );
+        assertEq(
+            keccak256(bytes(provider.providerType)),
+            keccak256(bytes("pegin"))
+        );
+
+        vm.prank(lp);
+        lbc.updateProvider("First LP Final", "http://localhost/api1-final");
+
+        provider = lbc.getProvider(lp);
+        assertEq(provider.id, 1);
+        assertEq(
+            keccak256(bytes(provider.name)),
+            keccak256(bytes("First LP Final"))
+        );
+        assertEq(
+            keccak256(bytes(provider.apiBaseUrl)),
+            keccak256(bytes("http://localhost/api1-final"))
+        );
+        assertEq(
+            keccak256(bytes(provider.providerType)),
+            keccak256(bytes("pegin"))
+        );
+    }
 }


### PR DESCRIPTION
**What**

Provider registration and ID search modification making from O(n) to O(1) with using mapping

**Why**

The `FlyoverDiscovery` contract allows liquidity providers to re-register after completing the full resignation and withdrawal flow. When `withdrawCollateral() `is called in `CollateralManagement`, the `resignationBlockNum` is reset to 0, allowing the provider to pass the registration validation checks again.

Upon re-registration, a new entry is appended to the `_liquidityProviders` mapping with an incremented ID, while the old entry remains in storage.

The functions updateProvider(), getProvider(), and isOperational() perform a linear search starting from index 1 and return on the first address match. After re-registration, these functions always match the old, stale entry (lower ID) instead of the new active entry.

The same problem also exists in the legacy contract

**Task**

https://rsklabs.atlassian.net/browse/VULN-746