### PR TITLE
Feature/fly 2213

### DIFF
--- a/src/PegInContract.sol
+++ b/src/PegInContract.sol
@@ -182,13 +182,13 @@ contract PegInContract is
         if (gasleft() < quote.gasLimit + _MAX_CALL_GAS_COST) {
             revert InsufficientGas(gasleft(), quote.gasLimit + _MAX_CALL_GAS_COST);
         }
-        _callRegistry[quoteHash].timestamp = block.timestamp;
-        _processedQuotes[quoteHash] = PegInStates.CALL_DONE;
-
         (bool success,) = quote.contractAddress.call{
             gas: quote.gasLimit,
             value: quote.value
         }(quote.data);
+
+        _callRegistry[quoteHash].timestamp = block.timestamp;
+        _processedQuotes[quoteHash] = PegInStates.CALL_DONE;
 
         if (success) {
             _callRegistry[quoteHash].success = true;

--- a/test/pegin/CallForUser.t.sol
+++ b/test/pegin/CallForUser.t.sol
@@ -8,6 +8,12 @@ import {Flyover} from "../../src/libraries/Flyover.sol";
 import {Mock} from "../../src/test-contracts/Mock.sol";
 import {ReentrancyCaller} from "../../src/test-contracts/ReentrancyCaller.sol";
 
+contract GasAwareRecipient {
+    function requireMinGas(uint256 minGas) external payable {
+        require(gasleft() >= minGas, "insufficient forwarded gas");
+    }
+}
+
 contract CallForUserTest is PegInTestBase {
     address public user;
 
@@ -479,6 +485,48 @@ contract CallForUserTest is PegInTestBase {
 
         // Should have reverted
         assertTrue(!success);
+    }
+
+    function test_CallForUser_RevertsWhenGasOnlyCoversCallAndNotPostCallStorage()
+        public
+    {
+        GasAwareRecipient recipient = new GasAwareRecipient();
+        bytes memory data = abi.encodeWithSelector(
+            GasAwareRecipient.requireMinGas.selector,
+            18000
+        );
+        Quotes.PegInQuote memory quote = createTestQuoteForLPWithData(
+            0.6 ether,
+            address(recipient),
+            user,
+            fullLp,
+            data
+        );
+        bytes32 quoteHash = pegInContract.hashPegInQuote(quote);
+
+        uint256 requiredGasAtCheck = quote.gasLimit + 35000;
+        uint256 estimatedSetupGas = 50000;
+        uint256 constrainedTxGas = requiredGasAtCheck +
+            estimatedSetupGas +
+            1000;
+
+        vm.prank(fullLp);
+        (bool success, ) = address(pegInContract).call{
+            gas: constrainedTxGas,
+            value: quote.value
+        }(abi.encodeWithSelector(IPegIn.callForUser.selector, quote));
+
+        assertTrue(!success, "callForUser should revert under constrained gas");
+        assertEq(
+            uint256(pegInContract.getQuoteStatus(quoteHash)),
+            uint256(IPegIn.PegInStates.UNPROCESSED_QUOTE),
+            "Quote must remain unprocessed when transaction reverts"
+        );
+        assertEq(
+            pegInContract.getBalance(fullLp),
+            0,
+            "LP balance must not change on reverted callForUser"
+        );
     }
 
     function test_CallForUser_NotAllowReentrancy() public {


### PR DESCRIPTION
**What**

Reorder state updates in `callForUser` function

**Why**

The `callForUser` function in `PegIn` contract performs a gas check before executing an external call on behalf of the user

A malicious LP can exploit this by providing minimal transaction gas that passes the check but starves the actual call, causing it to fail. Despite the failure, when `registerPegIn` is called later, the LP still receives `callFee` + `gasFee` via `_registerCallDone`, while the user's intended contract call was never executed. 

The reordering assures that if insufficient gas remains for `SSTOREs`, the transaction reverts entirely

**Task**

https://rsklabs.atlassian.net/browse/FLY-2213