### PR TITLE
Refactor/fly 2252

### DIFF
--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: recursive
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -24,10 +24,10 @@ jobs:
           submodules: recursive
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ghcr.io/${{ github.repository_owner }}/liquidity-bridge-contract
           tags: |
@@ -42,7 +42,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           push: true

--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -1,0 +1,51 @@
+name: Publish Docker Image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/liquidity-bridge-contract
+          tags: |
+            type=sha,format=long
+            type=ref,event=tag
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VCS_REF=${{ github.sha }}
+            VERSION=${{ steps.meta.outputs.version }}

--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -3,7 +3,9 @@ name: Publish Docker Image
 on:
   push:
     branches:
-      - main
+      - master
+      - refactor/FLY-2252
+      - v2.6.0
     tags:
       - "v*"
   workflow_dispatch:

--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - master
-      - refactor/FLY-2252
-      - v2.6.0
     tags:
       - "v*"
   workflow_dispatch:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:20.15.1@sha256:6326b52a508f0d99ffdbfaa29a69380321b215153db6f32974835bac71b38fa4
 
-ARG VCS_REF
+ARG VCS_REF=unknown
 ARG VERSION=dev
 LABEL org.opencontainers.image.source="https://github.com/rsksmart/liquidity-bridge-contract"
 LABEL org.opencontainers.image.revision="${VCS_REF}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM node:20.15.1@sha256:6326b52a508f0d99ffdbfaa29a69380321b215153db6f32974835bac71b38fa4
 
+ARG VCS_REF
+ARG VERSION=dev
+LABEL org.opencontainers.image.source="https://github.com/rsksmart/liquidity-bridge-contract"
+LABEL org.opencontainers.image.revision="${VCS_REF}"
+LABEL org.opencontainers.image.version="${VERSION}"
+
 # Install Foundry and required tools
 RUN apt-get update -y && \
     apt-get install -y -qq --no-install-recommends jq make curl && \
@@ -21,7 +27,6 @@ COPY --chown=node:node package.json \
     deploy.sh \
     .solhintignore \
     .solhint.json \
-    .solhintignore \
     tsconfig.json \
     addresses.json \
     foundry.toml \

--- a/deploy.sh
+++ b/deploy.sh
@@ -5,5 +5,16 @@ npm config set //npm.pkg.github.com/:_authToken "$GITHUB_TOKEN"
 make deploy-lbc-broadcast NETWORK="$NETWORK_NAME" VERIFY=true
 make upgrade-lbc-broadcast NETWORK="$NETWORK_NAME" VERIFY=true
 
-LBC_ADDRESS=$(jq -r '.[env.NETWORK_NAME].LiquidityBridgeContract.address' ./addresses.json)
+get_addresses_network_name() {
+  case "$1" in
+    mainnet|rskMainnet) echo "rskMainnet" ;;
+    testnet|rskTestnet) echo "rskTestnet" ;;
+    development|rskDevelopment) echo "rskDevelopment" ;;
+    dev|regtest|rskRegtest) echo "rskRegtest" ;;
+    *) echo "$1" ;;
+  esac
+}
+
+ADDRESSES_NETWORK_NAME=$(get_addresses_network_name "$NETWORK_NAME")
+LBC_ADDRESS=$(jq -r --arg network "$ADDRESSES_NETWORK_NAME" '.[$network].LiquidityBridgeContract.address' ./addresses.json)
 echo "LBC_ADDRESS=$LBC_ADDRESS"


### PR DESCRIPTION
## What

This PR enables a prebuilt LBC Docker image flow so local environments can pull a published image instead of rebuilding from source each time.

In `liquidity-bridge-contract`:
- Updated `Dockerfile` with OCI metadata labels (`source`, `revision`, `version`) and cleaned duplicate copy entry.
- Added/updated Docker publish workflow (`.github/workflows/docker-ghcr.yml`) to build/push to GHCR with SHA/tag metadata.
- Updated workflow checkout to include submodules recursively (required for `forge-std` during image build).
- Updated `deploy.sh` network-name mapping logic so `addresses.json` lookup is consistent across `mainnet/testnet/development/dev/regtest` aliases.

In coordinated `liquidity-provider-server` changes (same feature effort):
- Local `lbc-deployer` compose now uses `image: ${LBC_IMAGE}` (no local LBC build).
- Env/docs/scripts updated to use digest-pinned `LBC_IMAGE`.

## Why

Local setup was slower and less deterministic because LPS cloned and built LBC on each setup.  
Pulling a prebuilt, digest-pinned image improves setup time, reproducibility, and traceability.

## Type of Change

- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change
- [x] Refactor (no intended behavior change)
- [ ] Security hardening
- [ ] Tests only
- [x] Build/CI/Tooling
- [ ] Documentation

## Affected Areas

- [ ] PegIn flow (`registerPegIn`, `callForUser`, quote validation)
- [ ] PegOut flow (`depositPegout`, `refundPegOut`, `refundUserPegOut`)
- [ ] Liquidity Provider lifecycle (register/update/status/resign/collateral/withdraw)
- [ ] Pause/operational controls
- [ ] Quote hashing/signature logic
- [ ] Bitcoin tx / PMT / merkle validation
- [x] Deployment or upgrade scripts / Makefile targets
- [x] CI workflows (`ci`, `fuzz`, `slither`, `codeql`)
- [ ] Docs

## Risk & Security Review

- [x] Access control and authorization paths reviewed
- [x] Reentrancy and external call paths reviewed
- [x] Storage layout / upgrade safety reviewed (if upgradeable code changed)
- [x] Time/block/confirmation assumptions reviewed
- [x] BTC tx output/index assumptions reviewed (if pegout validation touched)
- [x] No secrets or sensitive values added

Notes:
- No Solidity contract logic changed.
- Changes are infra/script/workflow focused.

## Test Plan

- Verified Docker publish workflow logic and submodule checkout requirement (`forge-std`) to avoid `npm run compile` failures during image build.
- End-to-end local validation on coordinated LPS flow:
  - `ENV_FILE=.env.regtest ./lps-local.sh --reset`
  - `ENV_FILE=.env.regtest ./lps-local.sh`
  - Confirmed `lbc-deployer` pulled digest-pinned image and exited `0`.
  - Confirmed non-zero contract addresses were written to `.env.regtest`:
    - `PEGIN_CONTRACT_ADDRESS`
    - `PEGOUT_CONTRACT_ADDRESS`
    - `COLLATERAL_MANAGEMENT_ADDRESS`
    - `DISCOVERY_ADDRESS`
- Observed unrelated local permission issues (`lps01` log path, localstack log path) outside LBC image adoption scope.

## Deployment & Ops Impact

- [ ] No deployment impact
- [x] Requires deployment
- [ ] Requires upgrade
- [x] Env/config changes required (`.env`, network RPCs, verification, etc.)
- [x] Runbook/update instructions added to PR description

If deployment/upgrade is needed, include target network(s), simulation command(s), and rollback considerations.
- Deployment target: GHCR image publication for LBC (`ghcr.io/<owner>/liquidity-bridge-contract`).
- Ops update required: set `LBC_IMAGE=ghcr.io/rsksmart/liquidity-bridge-contract@sha256:<published_digest>` in local env used by LPS scripts.
- Rollback: point `LBC_IMAGE` back to previous known-good digest.

## Related Issues

- Jira: [FLY-2252](https://rsklabs.atlassian.net/browse/FLY-2252?atlOrigin=eyJpIjoiYjAzNzkyMTY2NDljNDk2MjljNDU3MTZmYWNmNDUzYjQiLCJwIjoiaiJ9)

## Reviewer Notes

Please focus review on:
1. `docker-ghcr.yml` trigger policy and image tagging strategy.
2. `actions/checkout` submodule handling for deterministic image builds.
3. `deploy.sh` network alias mapping and address lookup compatibility.

Relevant runtime verification snippets(Inside LPS Repo):
- `lbc-deployer` container exited successfully: `exited 0`.
- Resolved image: `ghcr.io/rsksmart/liquidity-bridge-contract@sha256:<digest>`.
- `.env.regtest` updated with non-zero deployed contract addresses.