### PR TITLE
refactor: update transparent proxy usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,7 @@ help:
 	@echo "  hash-quote               - Hash a PegIn or PegOut quote"
 	@echo "  get-btc-height           - Get current BTC block height"
 	@echo "  get-versions             - Get contract versions"
+	@echo "  query-proxy-admin        - Read ERC-1967 proxy admin for PROXY_ADDRESS (read-only)"
 	@echo "  pause-status             - Check pause status of all system contracts"
 	@echo "  pause-system             - Pause all system contracts (simulation)"
 	@echo "  pause-system-broadcast   - Pause all system contracts (actual)"
@@ -241,6 +242,7 @@ help:
 	@echo "  make hash-quote pegout mainnet my-quote.json       # Hash PegOut with custom file"
 	@echo "  make hash-quote HASH_QUOTE_FILE=my-quote.json     # Hash with named file parameter"
 	@echo "  make pause-status NETWORK=testnet                  # Check pause status"
+	@echo "  make query-proxy-admin NETWORK=mainnet PROXY_ADDRESS=0x... # ERC-1967 admin slot + ProxyAdmin owner"
 	@echo "  make pause-system NETWORK=testnet PAUSE_REASON=\"Security incident\" # Pause (simulation)"
 	@echo "  make pause-system-broadcast NETWORK=mainnet PAUSE_REASON=\"Emergency\" # Pause mainnet"
 	@echo "  make unpause-system-broadcast NETWORK=testnet      # Unpause testnet"
@@ -542,6 +544,23 @@ get-btc-height:
 get-versions:
 	@echo "Getting contract versions..."
 	@bash script/tasks/GetVersions.sh
+
+# Read ERC-1967 proxy admin (read-only; uses script/tasks/QueryProxyAdmin.s.sol)
+# Requires PROXY_ADDRESS (transparent / ERC-1967 proxy contract).
+.PHONY: query-proxy-admin
+query-proxy-admin:
+	@if [ -z "$(PROXY_ADDRESS)" ]; then \
+		echo "Error: Set PROXY_ADDRESS to the proxy contract address."; \
+		echo "  Example: make query-proxy-admin NETWORK=mainnet PROXY_ADDRESS=0x..."; \
+		exit 1; \
+	fi
+	@echo "Querying ERC-1967 proxy admin on $(NETWORK)..."
+	@echo "RPC URL: $(call get_network_config,$(NETWORK))"
+	@export PROXY_ADDRESS="$(PROXY_ADDRESS)"; \
+		forge script script/tasks/QueryProxyAdmin.s.sol:QueryProxyAdmin \
+		--sig "readProxyAdminFromEnv()" \
+		--rpc-url $(call get_network_config,$(NETWORK)) \
+		-vv
 
 # Hash quote - supports both syntaxes:
 # make hash-quote pegin testnet

--- a/script/deployment/DeployCollateralManagement.s.sol
+++ b/script/deployment/DeployCollateralManagement.s.sol
@@ -3,14 +3,13 @@ pragma solidity 0.8.25;
 
 import {Script, console} from "lib/forge-std/src/Script.sol";
 import {HelperConfig} from "../HelperConfig.s.sol";
+import {ProxyReader} from "../helpers/ProxyReader.sol";
 import {CollateralManagementContract} from "../../src/CollateralManagement.sol";
 import {PauseRegistry} from "../../src/PauseRegistry.sol";
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 
 /// @title DeployCollateralManagement
 /// @notice Deploys the CollateralManagement contract with proxy pattern
-/// @dev Requires PAUSE_REGISTRY_PROXY env var
 contract DeployCollateralManagement is Script {
     struct DeploymentResult {
         address implementation;
@@ -43,11 +42,10 @@ contract DeployCollateralManagement is Script {
         address pauseRegistryProxy
     ) private returns (DeploymentResult memory result) {
         result.implementation = address(new CollateralManagementContract());
-        result.admin = address(new ProxyAdmin(defaultAdmin));
         result.proxy = address(
             new TransparentUpgradeableProxy(
                 result.implementation,
-                result.admin,
+                defaultAdmin,
                 abi.encodeCall(
                     CollateralManagementContract.initialize,
                     (
@@ -61,6 +59,7 @@ contract DeployCollateralManagement is Script {
                 )
             )
         );
+        result.admin = ProxyReader.readAdmin(vm, result.proxy);
     }
 
     function _log(DeploymentResult memory r) private pure {

--- a/script/deployment/DeployFlyover.s.sol
+++ b/script/deployment/DeployFlyover.s.sol
@@ -41,7 +41,7 @@ contract DeployFlyover is Script {
         uint256 deployerKey = helper.getDeployerPrivateKey();
         address deployer = vm.rememberKey(deployerKey);
 
-        address defaultAdmin = vm.envOr("PROXY_ADMIN_OWNER", deployer);
+        address defaultAdmin = deployer;
 
         console.log(
             "======================== Config =========================="

--- a/script/deployment/DeployFlyover.s.sol
+++ b/script/deployment/DeployFlyover.s.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.25;
 import {Script, console} from "lib/forge-std/src/Script.sol";
 
 import {HelperConfig} from "../HelperConfig.s.sol";
+import {ProxyReader} from "../helpers/ProxyReader.sol";
 
 import {CollateralManagementContract} from "../../src/CollateralManagement.sol";
 import {FlyoverDiscovery} from "../../src/FlyoverDiscovery.sol";
@@ -12,28 +13,36 @@ import {PegInContract} from "../../src/PegInContract.sol";
 import {PegOutContract} from "../../src/PegOutContract.sol";
 
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 
 /// @title DeployFlyover
 /// @notice Orchestrates the deployment of all Flyover contracts and sets up roles
-/// @dev Gas optimized: single ProxyAdmin, inlined deployment logic, linked libraries
 contract DeployFlyover is Script {
     struct FlyoverDeployment {
         address pauseRegistryProxy;
+        address pauseRegistryProxyAdmin;
         address collateralManagementImpl;
         address collateralManagementProxy;
+        address collateralManagementProxyAdmin;
         address flyoverDiscoveryImpl;
         address flyoverDiscoveryProxy;
+        address flyoverDiscoveryProxyAdmin;
         address pegInImpl;
         address pegInProxy;
+        address pegInProxyAdmin;
         address pegOutImpl;
         address pegOutProxy;
-        address proxyAdmin; // Single ProxyAdmin for all
+        address pegOutProxyAdmin;
     }
 
     function run() external returns (FlyoverDeployment memory) {
         HelperConfig helper = new HelperConfig();
         HelperConfig.FlyoverConfig memory cfg = helper.getFlyoverConfig();
+
+        uint256 deployerKey = helper.getDeployerPrivateKey();
+        address deployer = vm.rememberKey(deployerKey);
+
+        address defaultAdmin = vm.envOr("PROXY_ADMIN_OWNER", deployer);
+
         console.log(
             "======================== Config =========================="
         );
@@ -46,16 +55,14 @@ contract DeployFlyover is Script {
         console.log("BTC Block Time:", cfg.btcBlockTime);
         console.log("Mainnet:", cfg.mainnet);
         console.log("Admin Delay:", cfg.adminDelay);
+        console.log("Default Admin:", defaultAdmin);
         console.log(
             "=========================================================="
         );
 
-        uint256 deployerKey = helper.getDeployerPrivateKey();
-        address deployer = vm.rememberKey(deployerKey);
-
         vm.startBroadcast(deployerKey);
 
-        FlyoverDeployment memory d = _deployAll(deployer, cfg);
+        FlyoverDeployment memory d = _deployAll(defaultAdmin, cfg);
         _setupRoles(d);
 
         vm.stopBroadcast();
@@ -68,20 +75,21 @@ contract DeployFlyover is Script {
         address defaultAdmin,
         HelperConfig.FlyoverConfig memory cfg
     ) private returns (FlyoverDeployment memory d) {
-        // Single ProxyAdmin for all contracts
-        d.proxyAdmin = address(new ProxyAdmin(defaultAdmin));
-
         // 0) PauseRegistry (shared by all)
         PauseRegistry prImpl = new PauseRegistry();
         d.pauseRegistryProxy = address(
             new TransparentUpgradeableProxy(
                 address(prImpl),
-                d.proxyAdmin,
+                defaultAdmin,
                 abi.encodeCall(
                     prImpl.initialize,
                     (cfg.adminDelay, defaultAdmin)
                 )
             )
+        );
+        d.pauseRegistryProxyAdmin = ProxyReader.readAdmin(
+            vm,
+            d.pauseRegistryProxy
         );
 
         // 1) CollateralManagement
@@ -91,7 +99,7 @@ contract DeployFlyover is Script {
         d.collateralManagementProxy = address(
             new TransparentUpgradeableProxy(
                 d.collateralManagementImpl,
-                d.proxyAdmin,
+                defaultAdmin,
                 abi.encodeCall(
                     CollateralManagementContract.initialize,
                     (
@@ -105,13 +113,17 @@ contract DeployFlyover is Script {
                 )
             )
         );
+        d.collateralManagementProxyAdmin = ProxyReader.readAdmin(
+            vm,
+            d.collateralManagementProxy
+        );
 
         // 2) FlyoverDiscovery
         d.flyoverDiscoveryImpl = address(new FlyoverDiscovery());
         d.flyoverDiscoveryProxy = address(
             new TransparentUpgradeableProxy(
                 d.flyoverDiscoveryImpl,
-                d.proxyAdmin,
+                defaultAdmin,
                 abi.encodeCall(
                     FlyoverDiscovery.initialize,
                     (
@@ -123,13 +135,17 @@ contract DeployFlyover is Script {
                 )
             )
         );
+        d.flyoverDiscoveryProxyAdmin = ProxyReader.readAdmin(
+            vm,
+            d.flyoverDiscoveryProxy
+        );
 
         // 3) PegInContract
         d.pegInImpl = address(new PegInContract());
         d.pegInProxy = address(
             new TransparentUpgradeableProxy(
                 d.pegInImpl,
-                d.proxyAdmin,
+                defaultAdmin,
                 abi.encodeCall(
                     PegInContract.initialize,
                     (
@@ -144,13 +160,14 @@ contract DeployFlyover is Script {
                 )
             )
         );
+        d.pegInProxyAdmin = ProxyReader.readAdmin(vm, d.pegInProxy);
 
         // 4) PegOutContract
         d.pegOutImpl = address(new PegOutContract());
         d.pegOutProxy = address(
             new TransparentUpgradeableProxy(
                 d.pegOutImpl,
-                d.proxyAdmin,
+                defaultAdmin,
                 abi.encodeCall(
                     PegOutContract.initialize,
                     (
@@ -165,6 +182,7 @@ contract DeployFlyover is Script {
                 )
             )
         );
+        d.pegOutProxyAdmin = ProxyReader.readAdmin(vm, d.pegOutProxy);
     }
 
     function _setupRoles(FlyoverDeployment memory d) private {
@@ -181,15 +199,25 @@ contract DeployFlyover is Script {
 
     function _log(FlyoverDeployment memory d) private pure {
         console.log("=== FLYOVER DEPLOYMENT ===");
-        console.log("ProxyAdmin:", d.proxyAdmin);
         console.log("PauseRegistry proxy:", d.pauseRegistryProxy);
+        console.log("PauseRegistry ProxyAdmin:", d.pauseRegistryProxyAdmin);
         console.log("CollateralManagement impl:", d.collateralManagementImpl);
         console.log("CollateralManagement proxy:", d.collateralManagementProxy);
+        console.log(
+            "CollateralManagement ProxyAdmin:",
+            d.collateralManagementProxyAdmin
+        );
         console.log("FlyoverDiscovery impl:", d.flyoverDiscoveryImpl);
         console.log("FlyoverDiscovery proxy:", d.flyoverDiscoveryProxy);
+        console.log(
+            "FlyoverDiscovery ProxyAdmin:",
+            d.flyoverDiscoveryProxyAdmin
+        );
         console.log("PegInContract impl:", d.pegInImpl);
         console.log("PegInContract proxy:", d.pegInProxy);
+        console.log("PegInContract ProxyAdmin:", d.pegInProxyAdmin);
         console.log("PegOutContract impl:", d.pegOutImpl);
         console.log("PegOutContract proxy:", d.pegOutProxy);
+        console.log("PegOutContract ProxyAdmin:", d.pegOutProxyAdmin);
     }
 }

--- a/script/deployment/DeployFlyoverDiscovery.s.sol
+++ b/script/deployment/DeployFlyoverDiscovery.s.sol
@@ -3,10 +3,10 @@ pragma solidity 0.8.25;
 
 import {Script, console} from "lib/forge-std/src/Script.sol";
 import {HelperConfig} from "../HelperConfig.s.sol";
+import {ProxyReader} from "../helpers/ProxyReader.sol";
 import {FlyoverDiscovery} from "../../src/FlyoverDiscovery.sol";
 import {PauseRegistry} from "../../src/PauseRegistry.sol";
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 
 /// @title DeployFlyoverDiscovery
 /// @notice Deploys the FlyoverDiscovery contract with proxy pattern
@@ -56,11 +56,10 @@ contract DeployFlyoverDiscovery is Script {
         address pauseRegistryProxy
     ) private returns (DeploymentResult memory result) {
         result.implementation = address(new FlyoverDiscovery());
-        result.admin = address(new ProxyAdmin(defaultAdmin));
         result.proxy = address(
             new TransparentUpgradeableProxy(
                 result.implementation,
-                result.admin,
+                defaultAdmin,
                 abi.encodeCall(
                     FlyoverDiscovery.initialize,
                     (
@@ -72,6 +71,7 @@ contract DeployFlyoverDiscovery is Script {
                 )
             )
         );
+        result.admin = ProxyReader.readAdmin(vm, result.proxy);
     }
 
     function _log(DeploymentResult memory r) private pure {

--- a/script/deployment/DeployPauseRegistry.s.sol
+++ b/script/deployment/DeployPauseRegistry.s.sol
@@ -3,9 +3,9 @@ pragma solidity 0.8.25;
 
 import {Script, console} from "lib/forge-std/src/Script.sol";
 import {HelperConfig} from "../HelperConfig.s.sol";
+import {ProxyReader} from "../helpers/ProxyReader.sol";
 import {PauseRegistry} from "../../src/PauseRegistry.sol";
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 
 /// @title DeployPauseRegistry
 /// @notice Deploys the PauseRegistry with proxy pattern (no dependencies)
@@ -32,14 +32,14 @@ contract DeployPauseRegistry is Script {
         address defaultAdmin
     ) private returns (DeploymentResult memory result) {
         result.implementation = address(new PauseRegistry());
-        result.admin = address(new ProxyAdmin(defaultAdmin));
         result.proxy = address(
             new TransparentUpgradeableProxy(
                 result.implementation,
-                result.admin,
+                defaultAdmin,
                 abi.encodeCall(PauseRegistry.initialize, (0, defaultAdmin))
             )
         );
+        result.admin = ProxyReader.readAdmin(vm, result.proxy);
     }
 
     function _log(DeploymentResult memory r) private pure {

--- a/script/deployment/DeployPegIn.s.sol
+++ b/script/deployment/DeployPegIn.s.sol
@@ -3,10 +3,10 @@ pragma solidity 0.8.25;
 
 import {Script, console} from "lib/forge-std/src/Script.sol";
 import {HelperConfig} from "../HelperConfig.s.sol";
+import {ProxyReader} from "../helpers/ProxyReader.sol";
 import {PegInContract} from "../../src/PegInContract.sol";
 import {PauseRegistry} from "../../src/PauseRegistry.sol";
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 
 /// @title DeployPegIn
 /// @notice Deploys the PegInContract with proxy pattern
@@ -56,11 +56,10 @@ contract DeployPegIn is Script {
         address pauseRegistryProxy
     ) private returns (DeploymentResult memory result) {
         result.implementation = address(new PegInContract());
-        result.admin = address(new ProxyAdmin(defaultAdmin));
         result.proxy = address(
             new TransparentUpgradeableProxy(
                 result.implementation,
-                result.admin,
+                defaultAdmin,
                 abi.encodeCall(
                     PegInContract.initialize,
                     (
@@ -75,6 +74,7 @@ contract DeployPegIn is Script {
                 )
             )
         );
+        result.admin = ProxyReader.readAdmin(vm, result.proxy);
     }
 
     function _log(DeploymentResult memory r) private pure {

--- a/script/deployment/DeployPegOut.s.sol
+++ b/script/deployment/DeployPegOut.s.sol
@@ -3,10 +3,10 @@ pragma solidity 0.8.25;
 
 import {Script, console} from "lib/forge-std/src/Script.sol";
 import {HelperConfig} from "../HelperConfig.s.sol";
+import {ProxyReader} from "../helpers/ProxyReader.sol";
 import {PegOutContract} from "../../src/PegOutContract.sol";
 import {PauseRegistry} from "../../src/PauseRegistry.sol";
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 
 /// @title DeployPegOut
 /// @notice Deploys the PegOutContract with proxy pattern
@@ -56,11 +56,10 @@ contract DeployPegOut is Script {
         address pauseRegistryProxy
     ) private returns (DeploymentResult memory result) {
         result.implementation = address(new PegOutContract());
-        result.admin = address(new ProxyAdmin(defaultAdmin));
         result.proxy = address(
             new TransparentUpgradeableProxy(
                 result.implementation,
-                result.admin,
+                defaultAdmin,
                 abi.encodeCall(
                     PegOutContract.initialize,
                     (
@@ -75,6 +74,7 @@ contract DeployPegOut is Script {
                 )
             )
         );
+        result.admin = ProxyReader.readAdmin(vm, result.proxy);
     }
 
     function _log(DeploymentResult memory r) private pure {

--- a/script/helpers/AddressResolver.sol
+++ b/script/helpers/AddressResolver.sol
@@ -85,7 +85,7 @@ library AddressResolverLib {
             getContractAddress(
                 vm,
                 "COLLATERAL_MANAGEMENT_ADDRESS",
-                "CollateralManagement"
+                "CollateralManagementContract"
             );
     }
 

--- a/script/helpers/ProxyReader.sol
+++ b/script/helpers/ProxyReader.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {Vm} from "lib/forge-std/src/Vm.sol";
+
+library ProxyReader {
+    bytes32 internal constant ADMIN_SLOT =
+        0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103;
+    bytes32 internal constant IMPLEMENTATION_SLOT =
+        0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+
+    function readAdmin(Vm vm, address proxy) internal view returns (address) {
+        return address(uint160(uint256(vm.load(proxy, ADMIN_SLOT))));
+    }
+
+    function readImplementation(
+        Vm vm,
+        address proxy
+    ) internal view returns (address) {
+        return address(uint160(uint256(vm.load(proxy, IMPLEMENTATION_SLOT))));
+    }
+}

--- a/script/tasks/QueryFlyoverRoles.s.sol
+++ b/script/tasks/QueryFlyoverRoles.s.sol
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import "lib/forge-std/src/Script.sol";
+import "lib/forge-std/src/console.sol";
+import {AddressResolver} from "../helpers/AddressResolver.sol";
+import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
+import {IAccessControlDefaultAdminRules} from "@openzeppelin/contracts/access/extensions/IAccessControlDefaultAdminRules.sol";
+
+/**
+ * @title QueryFlyoverRoles
+ * @notice Read-only script: Flyover role layout and which scanned addresses hold each role
+ * @dev OpenZeppelin `AccessControl` does not expose role member enumeration on-chain. This script
+ *      prints role ids, admins, default-admin state, then **only addresses that have the role**
+ *      from the scan set: each contract's `defaultAdmin()`, plus optional
+ *      `ROLE_QUERY_CHECK_ADDRESSES` (comma-separated).
+ *
+ * ## Usage
+ *   forge script script/tasks/QueryFlyoverRoles.s.sol:QueryFlyoverRoles \
+ *     --sig "queryRoles()" \
+ *     --rpc-url <rpc-url>
+ *
+ * Optional (comma-separated checks, e.g. multisig + ops):
+ *   ROLE_QUERY_CHECK_ADDRESSES="0xabc...,0xdef..." forge script ... --sig "queryRoles()" --rpc-url ...
+ *
+ * ## Environment (same resolution as AddressResolver.sol)
+ * - PAUSE_REGISTRY_ADDRESS, PEGIN_CONTRACT_ADDRESS, PEGOUT_CONTRACT_ADDRESS,
+ *   COLLATERAL_MANAGEMENT_ADDRESS, FLYOVER_DISCOVERY_ADDRESS
+ *   or entries in addresses.json with NETWORK (default rskRegtest)
+ */
+
+/// @dev PauseRegistry public role constant
+interface IPauseRegistryRoles {
+    function PAUSER_ROLE() external view returns (bytes32);
+}
+
+/// @dev CollateralManagementContract public role constants
+interface ICollateralManagementRoles {
+    function COLLATERAL_ADDER() external view returns (bytes32);
+
+    function COLLATERAL_SLASHER() external view returns (bytes32);
+}
+
+contract QueryFlyoverRoles is Script, AddressResolver {
+    bytes32 internal constant DEFAULT_ADMIN_ROLE = bytes32(0);
+
+    uint256 internal constant MAX_CHECK_ADDRS = 48;
+
+    function queryRoles() public view {
+        console.log("\n=== FLYOVER ACCESS CONTROL ROLES ===\n");
+
+        address pauseReg = getPauseRegistryAddress();
+        address pegIn = getPegInAddress();
+        address pegOut = getPegOutAddress();
+        address collateral = getCollateralManagementAddress();
+        address discovery = getFlyoverDiscoveryAddress();
+
+        address[] memory checkAddrs = _collectCheckAddresses(
+            pauseReg,
+            pegIn,
+            pegOut,
+            collateral,
+            discovery
+        );
+
+        _printContractBlock("PauseRegistry", pauseReg, checkAddrs);
+        _printRoleLine(
+            pauseReg,
+            "DEFAULT_ADMIN_ROLE",
+            DEFAULT_ADMIN_ROLE,
+            checkAddrs
+        );
+        _printRoleLine(
+            pauseReg,
+            "PAUSER_ROLE",
+            IPauseRegistryRoles(pauseReg).PAUSER_ROLE(),
+            checkAddrs
+        );
+
+        _printContractBlock("PegInContract", pegIn, checkAddrs);
+        _printRoleLine(
+            pegIn,
+            "DEFAULT_ADMIN_ROLE",
+            DEFAULT_ADMIN_ROLE,
+            checkAddrs
+        );
+
+        _printContractBlock("PegOutContract", pegOut, checkAddrs);
+        _printRoleLine(
+            pegOut,
+            "DEFAULT_ADMIN_ROLE",
+            DEFAULT_ADMIN_ROLE,
+            checkAddrs
+        );
+
+        _printContractBlock("CollateralManagement", collateral, checkAddrs);
+        _printRoleLine(
+            collateral,
+            "DEFAULT_ADMIN_ROLE",
+            DEFAULT_ADMIN_ROLE,
+            checkAddrs
+        );
+        _printRoleLine(
+            collateral,
+            "COLLATERAL_ADDER",
+            ICollateralManagementRoles(collateral).COLLATERAL_ADDER(),
+            checkAddrs
+        );
+        _printRoleLine(
+            collateral,
+            "COLLATERAL_SLASHER",
+            ICollateralManagementRoles(collateral).COLLATERAL_SLASHER(),
+            checkAddrs
+        );
+
+        _printContractBlock("FlyoverDiscovery", discovery, checkAddrs);
+        _printRoleLine(
+            discovery,
+            "DEFAULT_ADMIN_ROLE",
+            DEFAULT_ADMIN_ROLE,
+            checkAddrs
+        );
+        console.log("====================================\n");
+    }
+
+    function run() external view {
+        queryRoles();
+    }
+
+    function _collectCheckAddresses(
+        address pauseReg,
+        address pegIn,
+        address pegOut,
+        address collateral,
+        address discovery
+    ) internal view returns (address[] memory) {
+        address[MAX_CHECK_ADDRS] memory buf;
+        uint256 n = 0;
+
+        n = _pushUnique(
+            buf,
+            n,
+            IAccessControlDefaultAdminRules(pauseReg).defaultAdmin()
+        );
+        n = _pushUnique(
+            buf,
+            n,
+            IAccessControlDefaultAdminRules(pegIn).defaultAdmin()
+        );
+        n = _pushUnique(
+            buf,
+            n,
+            IAccessControlDefaultAdminRules(pegOut).defaultAdmin()
+        );
+        n = _pushUnique(
+            buf,
+            n,
+            IAccessControlDefaultAdminRules(collateral).defaultAdmin()
+        );
+        n = _pushUnique(
+            buf,
+            n,
+            IAccessControlDefaultAdminRules(discovery).defaultAdmin()
+        );
+
+        string memory extra = vm.envOr(
+            "ROLE_QUERY_CHECK_ADDRESSES",
+            string("")
+        );
+        if (bytes(extra).length != 0) {
+            string[] memory parts = vm.split(extra, ",");
+            for (uint256 i = 0; i < parts.length; i++) {
+                if (n >= MAX_CHECK_ADDRS) break;
+                string memory t = vm.trim(parts[i]);
+                if (bytes(t).length == 0) continue;
+                address a = vm.parseAddress(t);
+                n = _pushUnique(buf, n, a);
+            }
+        }
+
+        address[] memory out = new address[](n);
+        for (uint256 i = 0; i < n; i++) {
+            out[i] = buf[i];
+        }
+        return out;
+    }
+
+    function _pushUnique(
+        address[MAX_CHECK_ADDRS] memory buf,
+        uint256 n,
+        address a
+    ) internal pure returns (uint256) {
+        if (a == address(0)) return n;
+        for (uint256 i = 0; i < n; i++) {
+            if (buf[i] == a) return n;
+        }
+        require(
+            n < MAX_CHECK_ADDRS,
+            "QueryFlyoverRoles: too many check addresses"
+        );
+        buf[n] = a;
+        return n + 1;
+    }
+
+    function _printContractBlock(
+        string memory title,
+        address c,
+        address[] memory checkAddrs
+    ) internal view {
+        console.log(
+            string.concat("--- ", title, " @ ", vm.toString(c), " ---")
+        );
+        IAccessControlDefaultAdminRules ac = IAccessControlDefaultAdminRules(c);
+        address admin = ac.defaultAdmin();
+        console.log(string.concat("  defaultAdmin(): ", vm.toString(admin)));
+
+        (address pendingAdmin, uint48 acceptSchedule) = ac
+            .pendingDefaultAdmin();
+        if (acceptSchedule != 0 || pendingAdmin != address(0)) {
+            console.log(
+                string.concat(
+                    "  pendingDefaultAdmin: ",
+                    vm.toString(pendingAdmin),
+                    " acceptSchedule: ",
+                    vm.toString(uint256(acceptSchedule))
+                )
+            );
+        }
+
+        console.log(
+            string.concat(
+                "  scan set: ",
+                vm.toString(checkAddrs.length),
+                " address(es) (defaultAdmins + ROLE_QUERY_CHECK_ADDRESSES)"
+            )
+        );
+        console.log("");
+    }
+
+    function _printRoleLine(
+        address c,
+        string memory roleName,
+        bytes32 role,
+        address[] memory checkAddrs
+    ) internal view {
+        IAccessControl ac = IAccessControl(c);
+        bytes32 adminRole = ac.getRoleAdmin(role);
+        console.log(string.concat("  Role: ", roleName));
+        console.log(string.concat("    id: ", vm.toString(role)));
+        console.log(
+            string.concat("    getRoleAdmin: ", vm.toString(adminRole))
+        );
+
+        for (uint256 i = 0; i < checkAddrs.length; i++) {
+            address a = checkAddrs[i];
+            if (ac.hasRole(role, a)) {
+                console.log(string.concat("    ", vm.toString(a)));
+            }
+        }
+        console.log("");
+    }
+}

--- a/script/tasks/QueryProxyAdmin.s.sol
+++ b/script/tasks/QueryProxyAdmin.s.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import "lib/forge-std/src/Script.sol";
+import "lib/forge-std/src/console.sol";
+import {ProxyReader} from "../helpers/ProxyReader.sol";
+
+/**
+ * @title QueryProxyAdmin
+ * @notice Read-only script: reads the ERC-1967 proxy admin address for a given proxy contract
+ * @dev Uses storage slot `eip1967.proxy.admin` (EIP-1967), matching OpenZeppelin `TransparentUpgradeableProxy`
+ *      and `ERC1967Proxy`. This is the address that controls upgrades (often a `ProxyAdmin` contract).
+ *
+ * ## Usage (address argument)
+ *   forge script script/tasks/QueryProxyAdmin.s.sol:QueryProxyAdmin \
+ *     --sig "readProxyAdmin(address)" <proxy-address> \
+ *     --rpc-url <rpc-url>
+ *
+ * ## Usage (environment)
+ *   PROXY_ADDRESS=<proxy-address> forge script script/tasks/QueryProxyAdmin.s.sol:QueryProxyAdmin \
+ *     --sig "readProxyAdminFromEnv()" \
+ *     --rpc-url <rpc-url>
+ */
+
+interface IOwnable {
+    function owner() external view returns (address);
+}
+
+contract QueryProxyAdmin is Script {
+    function readProxyAdminFromEnv() external view {
+        address proxy = _proxyFromEnv();
+        readProxyAdmin(proxy);
+    }
+
+    function readProxyAdmin(address proxy) public view {
+        if (proxy == address(0)) {
+            revert("proxy address is zero");
+        }
+
+        address admin = ProxyReader.readAdmin(vm, proxy);
+
+        console.log("\n=== ERC-1967 PROXY ADMIN ===\n");
+        console.log("Proxy:", proxy);
+        console.log("Admin (from storage slot):", admin);
+        if (admin == address(0)) {
+            console.log(
+                "Note: admin slot is zero - not an ERC-1967 proxy or uninitialized."
+            );
+            return;
+        }
+
+        if (admin.code.length > 0) {
+            try IOwnable(admin).owner() returns (address own) {
+                console.log("Admin owner:", own);
+            } catch {}
+        }
+    }
+
+    function _proxyFromEnv() private view returns (address) {
+        try vm.envAddress("PROXY_ADDRESS") returns (address a) {
+            if (a != address(0)) {
+                return a;
+            }
+        } catch {}
+        revert("Set PROXY_ADDRESS to the proxy contract address.");
+    }
+}

--- a/test/deployment/DeployCollateralManagement.t.sol
+++ b/test/deployment/DeployCollateralManagement.t.sol
@@ -4,9 +4,11 @@ pragma solidity 0.8.25;
 import "lib/forge-std/src/Test.sol";
 import "lib/forge-std/src/console.sol";
 import {HelperConfig} from "../../script/HelperConfig.s.sol";
+import {ProxyReader} from "../../script/helpers/ProxyReader.sol";
 import {CollateralManagementContract} from "../../src/CollateralManagement.sol";
 import {PauseRegistry} from "../../src/PauseRegistry.sol";
-import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {TransparentUpgradeableProxy, ITransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 
 /**
@@ -60,18 +62,18 @@ contract DeployCollateralManagementTest is Test {
         CollateralManagementContract implementation = new CollateralManagementContract();
         console.log("   Implementation deployed at:", address(implementation));
 
-        console.log("\n2. Deploying Proxy Admin...");
-        ProxyAdmin admin = new ProxyAdmin(deployer);
-        console.log("   Admin deployed at:", address(admin));
-
-        console.log("\n2b. Deploying PauseRegistry...");
+        console.log("\n2. Deploying PauseRegistry proxy...");
         PauseRegistry prImpl = new PauseRegistry();
         address pauseRegistryProxy = address(
             new TransparentUpgradeableProxy(
                 address(prImpl),
-                address(admin),
+                deployer,
                 abi.encodeCall(prImpl.initialize, (0, deployer))
             )
+        );
+        address pauseRegistryProxyAdmin = ProxyReader.readAdmin(
+            vm,
+            pauseRegistryProxy
         );
 
         console.log("\n3. Preparing initializer calldata...");
@@ -91,10 +93,14 @@ contract DeployCollateralManagementTest is Test {
         console.log("\n4. Deploying Proxy...");
         TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
             address(implementation),
-            address(admin),
+            deployer,
             initData
         );
         console.log("   Proxy deployed at:", address(proxy));
+        address collateralProxyAdmin = ProxyReader.readAdmin(
+            vm,
+            address(proxy)
+        );
 
         console.log("\n5. Verifying deployment...");
         CollateralManagementContract cm = CollateralManagementContract(
@@ -117,6 +123,18 @@ contract DeployCollateralManagementTest is Test {
             "Reward percentage mismatch"
         );
 
+        assertEq(
+            Ownable(collateralProxyAdmin).owner(),
+            address(this),
+            "ProxyAdmin owner mismatch"
+        );
+
+        assertEq(
+            Ownable(pauseRegistryProxyAdmin).owner(),
+            address(this),
+            "ProxyAdmin owner mismatch"
+        );
+
         console.log("   Min Collateral:", cm.getMinCollateral());
         console.log("   Resign Delay:", cm.getResignDelayInBlocks());
         console.log("   Reward %:", cm.getRewardPercentage());
@@ -134,12 +152,11 @@ contract DeployCollateralManagementTest is Test {
         address deployer = address(this);
 
         // Inline deployment (script.run() uses private _deploy internally)
-        address admin = address(new ProxyAdmin(deployer));
         PauseRegistry prImpl = new PauseRegistry();
         address pauseRegistryProxy = address(
             new TransparentUpgradeableProxy(
                 address(prImpl),
-                admin,
+                deployer,
                 abi.encodeCall(prImpl.initialize, (0, deployer))
             )
         );
@@ -147,7 +164,7 @@ contract DeployCollateralManagementTest is Test {
         address proxy = address(
             new TransparentUpgradeableProxy(
                 impl,
-                admin,
+                deployer,
                 abi.encodeCall(
                     CollateralManagementContract.initialize,
                     (
@@ -162,14 +179,21 @@ contract DeployCollateralManagementTest is Test {
             )
         );
 
+        address proxyAdminAddr = ProxyReader.readAdmin(vm, proxy);
+
         console.log("Deployment Result:");
         console.log("  Implementation:", impl);
         console.log("  Proxy:", proxy);
-        console.log("  Admin:", admin);
+        console.log("  ProxyAdmin:", proxyAdminAddr);
 
         assertTrue(impl != address(0), "Implementation should not be zero");
         assertTrue(proxy != address(0), "Proxy should not be zero");
-        assertTrue(admin != address(0), "Admin should not be zero");
+
+        assertEq(
+            Ownable(proxyAdminAddr).owner(),
+            address(this),
+            "ProxyAdmin owner mismatch"
+        );
 
         // Verify proxy points to implementation
         CollateralManagementContract cm = CollateralManagementContract(
@@ -193,12 +217,11 @@ contract DeployCollateralManagementTest is Test {
         address deployer = address(this);
 
         // Inline deployment
-        address admin = address(new ProxyAdmin(deployer));
         PauseRegistry prImpl = new PauseRegistry();
         address pauseRegistryProxy = address(
             new TransparentUpgradeableProxy(
                 address(prImpl),
-                admin,
+                deployer,
                 abi.encodeCall(prImpl.initialize, (0, deployer))
             )
         );
@@ -206,7 +229,7 @@ contract DeployCollateralManagementTest is Test {
         address proxy = address(
             new TransparentUpgradeableProxy(
                 impl,
-                admin,
+                deployer,
                 abi.encodeCall(
                     CollateralManagementContract.initialize,
                     (
@@ -222,6 +245,17 @@ contract DeployCollateralManagementTest is Test {
         );
         CollateralManagementContract cm = CollateralManagementContract(
             payable(proxy)
+        );
+
+        assertEq(
+            Ownable(ProxyReader.readAdmin(vm, pauseRegistryProxy)).owner(),
+            deployer,
+            "PauseRegistry ProxyAdmin owner mismatch"
+        );
+        assertEq(
+            Ownable(ProxyReader.readAdmin(vm, proxy)).owner(),
+            deployer,
+            "CollateralManagement ProxyAdmin owner mismatch"
         );
 
         // Check deployer has DEFAULT_ADMIN_ROLE
@@ -246,5 +280,60 @@ contract DeployCollateralManagementTest is Test {
         );
 
         console.log("\n[PASS] Roles are set correctly!");
+    }
+
+    function test_ContractIsUpgradeable() public {
+        console.log("\n=== CONTRACT IS UPGRADEABLE ===\n");
+
+        HelperConfig.FlyoverConfig memory cfg = helperConfig.getFlyoverConfig();
+        address deployer = address(this);
+
+        // Inline deployment
+        PauseRegistry prImpl = new PauseRegistry();
+        address pauseRegistryProxy = address(
+            new TransparentUpgradeableProxy(
+                address(prImpl),
+                deployer,
+                abi.encodeCall(prImpl.initialize, (0, deployer))
+            )
+        );
+        address impl = address(new CollateralManagementContract());
+        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
+            impl,
+            deployer,
+            abi.encodeCall(
+                CollateralManagementContract.initialize,
+                (
+                    deployer,
+                    cfg.adminDelay,
+                    cfg.minimumCollateral,
+                    cfg.resignDelayBlocks,
+                    cfg.rewardPercentage,
+                    PauseRegistry(pauseRegistryProxy)
+                )
+            )
+        );
+
+        ProxyAdmin proxyAdmin = ProxyAdmin(
+            ProxyReader.readAdmin(vm, address(proxy))
+        );
+        address newImplementation = address(new CollateralManagementContract());
+        assertEq(
+            ProxyReader.readImplementation(vm, address(proxy)),
+            address(impl),
+            "Implementation mismatch"
+        );
+        proxyAdmin.upgradeAndCall(
+            ITransparentUpgradeableProxy(address(proxy)),
+            newImplementation,
+            ""
+        );
+        assertEq(
+            ProxyReader.readImplementation(vm, address(proxy)),
+            newImplementation,
+            "Implementation mismatch"
+        );
+
+        console.log("[PASS] Contract is upgradeable");
     }
 }

--- a/test/deployment/DeployFlyover.t.sol
+++ b/test/deployment/DeployFlyover.t.sol
@@ -4,13 +4,15 @@ pragma solidity 0.8.25;
 import "lib/forge-std/src/Test.sol";
 import "lib/forge-std/src/console.sol";
 import {HelperConfig} from "../../script/HelperConfig.s.sol";
+import {ProxyReader} from "../../script/helpers/ProxyReader.sol";
 import {CollateralManagementContract} from "../../src/CollateralManagement.sol";
 import {FlyoverDiscovery} from "../../src/FlyoverDiscovery.sol";
 import {PauseRegistry} from "../../src/PauseRegistry.sol";
 import {PegInContract} from "../../src/PegInContract.sol";
 import {PegOutContract} from "../../src/PegOutContract.sol";
 import {Flyover} from "../../src/libraries/Flyover.sol";
-import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {TransparentUpgradeableProxy, ITransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 import {BridgeMock} from "../../src/test-contracts/BridgeMock.sol";
 
@@ -25,15 +27,40 @@ contract DeployFlyoverTest is Test {
 
     // Deployed contracts
     address public pauseRegistryProxy;
+    address public collateralManagementImplementation;
+    address public flyoverDiscoveryImplementation;
+    address public pegInImplementation;
+    address public pegOutImplementation;
+    address public pauseRegistryImplementation;
     CollateralManagementContract public collateralManagement;
     FlyoverDiscovery public discovery;
     PegInContract public pegInContract;
     PegOutContract public pegOutContract;
-    address public proxyAdmin;
 
     function setUp() public {
         helperConfig = new HelperConfig();
         bridgeMock = new BridgeMock();
+    }
+
+    function _assertTransparentProxyAdmin(
+        address proxy,
+        address deployer_
+    ) internal view {
+        address admin = ProxyReader.readAdmin(vm, proxy);
+        assertTrue(admin != address(0), "ProxyAdmin should not be zero");
+        assertEq(
+            Ownable(admin).owner(),
+            deployer_,
+            "ProxyAdmin owner mismatch"
+        );
+    }
+
+    function _assertAllProxyAdminsOwnedBy(address deployer_) internal view {
+        _assertTransparentProxyAdmin(pauseRegistryProxy, deployer_);
+        _assertTransparentProxyAdmin(address(collateralManagement), deployer_);
+        _assertTransparentProxyAdmin(address(discovery), deployer_);
+        _assertTransparentProxyAdmin(address(pegInContract), deployer_);
+        _assertTransparentProxyAdmin(address(pegOutContract), deployer_);
     }
 
     /// @notice Deploy all contracts inline (mirrors DeployFlyover script)
@@ -41,9 +68,6 @@ contract DeployFlyoverTest is Test {
         address deployer,
         HelperConfig.FlyoverConfig memory cfg
     ) internal {
-        // Single ProxyAdmin for all contracts
-        proxyAdmin = address(new ProxyAdmin(deployer));
-
         // 1) CollateralManagement
         _deployCollateralManagement(deployer, cfg);
 
@@ -62,14 +86,16 @@ contract DeployFlyoverTest is Test {
         HelperConfig.FlyoverConfig memory cfg
     ) private {
         PauseRegistry prImpl = new PauseRegistry();
+        pauseRegistryImplementation = address(prImpl);
         pauseRegistryProxy = address(
             new TransparentUpgradeableProxy(
                 address(prImpl),
-                proxyAdmin,
+                deployer,
                 abi.encodeCall(prImpl.initialize, (0, deployer))
             )
         );
         address impl = address(new CollateralManagementContract());
+        collateralManagementImplementation = impl;
         bytes memory initData = abi.encodeCall(
             CollateralManagementContract.initialize,
             (
@@ -82,7 +108,7 @@ contract DeployFlyoverTest is Test {
             )
         );
         address proxy = address(
-            new TransparentUpgradeableProxy(impl, proxyAdmin, initData)
+            new TransparentUpgradeableProxy(impl, deployer, initData)
         );
         collateralManagement = CollateralManagementContract(payable(proxy));
     }
@@ -92,6 +118,7 @@ contract DeployFlyoverTest is Test {
         HelperConfig.FlyoverConfig memory cfg
     ) private {
         address impl = address(new FlyoverDiscovery());
+        flyoverDiscoveryImplementation = impl;
         bytes memory initData = abi.encodeCall(
             FlyoverDiscovery.initialize,
             (
@@ -102,7 +129,7 @@ contract DeployFlyoverTest is Test {
             )
         );
         address proxy = address(
-            new TransparentUpgradeableProxy(impl, proxyAdmin, initData)
+            new TransparentUpgradeableProxy(impl, deployer, initData)
         );
         discovery = FlyoverDiscovery(proxy);
     }
@@ -112,6 +139,7 @@ contract DeployFlyoverTest is Test {
         HelperConfig.FlyoverConfig memory cfg
     ) private {
         address impl = address(new PegInContract());
+        pegInImplementation = impl;
         bytes memory initData = abi.encodeCall(
             PegInContract.initialize,
             (
@@ -125,7 +153,7 @@ contract DeployFlyoverTest is Test {
             )
         );
         address proxy = address(
-            new TransparentUpgradeableProxy(impl, proxyAdmin, initData)
+            new TransparentUpgradeableProxy(impl, deployer, initData)
         );
         pegInContract = PegInContract(payable(proxy));
     }
@@ -135,6 +163,7 @@ contract DeployFlyoverTest is Test {
         HelperConfig.FlyoverConfig memory cfg
     ) private {
         address impl = address(new PegOutContract());
+        pegOutImplementation = impl;
         bytes memory initData = abi.encodeCall(
             PegOutContract.initialize,
             (
@@ -148,7 +177,7 @@ contract DeployFlyoverTest is Test {
             )
         );
         address proxy = address(
-            new TransparentUpgradeableProxy(impl, proxyAdmin, initData)
+            new TransparentUpgradeableProxy(impl, deployer, initData)
         );
         pegOutContract = PegOutContract(payable(proxy));
     }
@@ -161,6 +190,7 @@ contract DeployFlyoverTest is Test {
 
         console.log("Deploying all Flyover contracts...");
         _deployAll(deployer, cfg);
+        _assertAllProxyAdminsOwnedBy(deployer);
 
         // Verify all contracts deployed
         console.log("\n1. Verifying CollateralManagement...");
@@ -198,6 +228,7 @@ contract DeployFlyoverTest is Test {
         address deployer = address(this);
 
         _deployAll(deployer, cfg);
+        _assertAllProxyAdminsOwnedBy(deployer);
 
         bytes32 collateralAdderRole = collateralManagement.COLLATERAL_ADDER();
         bytes32 collateralSlasherRole = collateralManagement
@@ -258,6 +289,7 @@ contract DeployFlyoverTest is Test {
         address deployer = address(this);
 
         _deployAll(deployer, cfg);
+        _assertAllProxyAdminsOwnedBy(deployer);
 
         // Check CollateralManagement
         console.log("1. CollateralManagement:");
@@ -332,6 +364,7 @@ contract DeployFlyoverTest is Test {
         address deployer = address(this);
 
         _deployAll(deployer, cfg);
+        _assertAllProxyAdminsOwnedBy(deployer);
 
         // Setup roles
         bytes32 collateralAdderRole = collateralManagement.COLLATERAL_ADDER();
@@ -388,6 +421,7 @@ contract DeployFlyoverTest is Test {
         address deployer = address(this);
 
         _deployAll(deployer, cfg);
+        _assertAllProxyAdminsOwnedBy(deployer);
 
         bytes32 defaultAdminRole = collateralManagement.DEFAULT_ADMIN_ROLE();
 
@@ -420,5 +454,111 @@ contract DeployFlyoverTest is Test {
         console.log("  PegOutContract: true");
 
         console.log("\n[PASS] Deployer has admin role on all contracts!");
+    }
+
+    function test_ContractIsUpgradeable() public {
+        console.log("\n=== CONTRACT IS UPGRADEABLE ===\n");
+
+        HelperConfig.FlyoverConfig memory cfg = helperConfig.getFlyoverConfig();
+        address deployer = address(this);
+
+        _deployAll(deployer, cfg);
+
+        address cmProxy = address(collateralManagement);
+        ProxyAdmin proxyAdmin = ProxyAdmin(ProxyReader.readAdmin(vm, cmProxy));
+        address newImplementation = address(new CollateralManagementContract());
+
+        assertEq(
+            ProxyReader.readImplementation(vm, cmProxy),
+            collateralManagementImplementation,
+            "Implementation mismatch"
+        );
+        proxyAdmin.upgradeAndCall(
+            ITransparentUpgradeableProxy(cmProxy),
+            newImplementation,
+            ""
+        );
+        assertEq(
+            ProxyReader.readImplementation(vm, cmProxy),
+            newImplementation,
+            "Implementation mismatch"
+        );
+
+        address fdProxy = address(discovery);
+        proxyAdmin = ProxyAdmin(ProxyReader.readAdmin(vm, fdProxy));
+        newImplementation = address(new FlyoverDiscovery());
+        assertEq(
+            ProxyReader.readImplementation(vm, fdProxy),
+            flyoverDiscoveryImplementation,
+            "Implementation mismatch"
+        );
+        proxyAdmin.upgradeAndCall(
+            ITransparentUpgradeableProxy(fdProxy),
+            newImplementation,
+            ""
+        );
+        assertEq(
+            ProxyReader.readImplementation(vm, fdProxy),
+            newImplementation,
+            "Implementation mismatch"
+        );
+
+        address piProxy = address(pegInContract);
+        proxyAdmin = ProxyAdmin(ProxyReader.readAdmin(vm, piProxy));
+        newImplementation = address(new PegInContract());
+        assertEq(
+            ProxyReader.readImplementation(vm, piProxy),
+            pegInImplementation,
+            "Implementation mismatch"
+        );
+        proxyAdmin.upgradeAndCall(
+            ITransparentUpgradeableProxy(piProxy),
+            newImplementation,
+            ""
+        );
+        assertEq(
+            ProxyReader.readImplementation(vm, piProxy),
+            newImplementation,
+            "Implementation mismatch"
+        );
+
+        address poProxy = address(pegOutContract);
+        proxyAdmin = ProxyAdmin(ProxyReader.readAdmin(vm, poProxy));
+        newImplementation = address(new PegOutContract());
+        assertEq(
+            ProxyReader.readImplementation(vm, poProxy),
+            pegOutImplementation,
+            "Implementation mismatch"
+        );
+        proxyAdmin.upgradeAndCall(
+            ITransparentUpgradeableProxy(poProxy),
+            newImplementation,
+            ""
+        );
+        assertEq(
+            ProxyReader.readImplementation(vm, poProxy),
+            newImplementation,
+            "Implementation mismatch"
+        );
+
+        proxyAdmin = ProxyAdmin(ProxyReader.readAdmin(vm, pauseRegistryProxy));
+        newImplementation = address(new PauseRegistry());
+        assertEq(
+            ProxyReader.readImplementation(vm, pauseRegistryProxy),
+            pauseRegistryImplementation,
+            "Implementation mismatch"
+        );
+        proxyAdmin.upgradeAndCall(
+            ITransparentUpgradeableProxy(pauseRegistryProxy),
+            newImplementation,
+            ""
+        );
+        assertEq(
+            ProxyReader.readImplementation(vm, pauseRegistryProxy),
+            newImplementation,
+            "Implementation mismatch"
+        );
+
+        console.log("\n[PASS] Contracts are upgradeable");
     }
 }

--- a/test/deployment/DeployFlyoverDiscovery.t.sol
+++ b/test/deployment/DeployFlyoverDiscovery.t.sol
@@ -4,10 +4,12 @@ pragma solidity 0.8.25;
 import "lib/forge-std/src/Test.sol";
 import "lib/forge-std/src/console.sol";
 import {HelperConfig} from "../../script/HelperConfig.s.sol";
+import {ProxyReader} from "../../script/helpers/ProxyReader.sol";
 import {FlyoverDiscovery} from "../../src/FlyoverDiscovery.sol";
 import {CollateralManagementContract} from "../../src/CollateralManagement.sol";
 import {PauseRegistry} from "../../src/PauseRegistry.sol";
-import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {TransparentUpgradeableProxy, ITransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 
 /**
@@ -27,13 +29,11 @@ contract DeployFlyoverDiscoveryTest is Test {
         // Deploy PauseRegistry and CollateralManagement first (dependency)
         HelperConfig.FlyoverConfig memory cfg = helperConfig.getFlyoverConfig();
         address deployer = address(this);
-        address cmAdmin = address(new ProxyAdmin(deployer));
-
         PauseRegistry prImpl = new PauseRegistry();
         pauseRegistryProxy = address(
             new TransparentUpgradeableProxy(
                 address(prImpl),
-                cmAdmin,
+                deployer,
                 abi.encodeCall(prImpl.initialize, (0, deployer))
             )
         );
@@ -42,7 +42,7 @@ contract DeployFlyoverDiscoveryTest is Test {
         collateralManagementProxy = address(
             new TransparentUpgradeableProxy(
                 cmImpl,
-                cmAdmin,
+                deployer,
                 abi.encodeCall(
                     CollateralManagementContract.initialize,
                     (
@@ -73,11 +73,7 @@ contract DeployFlyoverDiscoveryTest is Test {
         FlyoverDiscovery implementation = new FlyoverDiscovery();
         console.log("   Implementation deployed at:", address(implementation));
 
-        console.log("\n2. Deploying Proxy Admin...");
-        ProxyAdmin admin = new ProxyAdmin(deployer);
-        console.log("   Admin deployed at:", address(admin));
-
-        console.log("\n3. Preparing initializer calldata...");
+        console.log("\n2. Preparing initializer calldata...");
         bytes memory initData = abi.encodeCall(
             FlyoverDiscovery.initialize,
             (
@@ -89,18 +85,44 @@ contract DeployFlyoverDiscoveryTest is Test {
         );
         console.log("   Init data length:", initData.length);
 
-        console.log("\n4. Deploying Proxy...");
+        console.log("\n3. Deploying Proxy...");
         TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
             address(implementation),
-            address(admin),
+            deployer,
             initData
         );
         console.log("   Proxy deployed at:", address(proxy));
+        address discoveryProxyAdmin = ProxyReader.readAdmin(vm, address(proxy));
+        console.log("   ProxyAdmin:", discoveryProxyAdmin);
 
-        console.log("\n5. Verifying deployment...");
+        console.log("\n4. Verifying deployment...");
         FlyoverDiscovery fd = FlyoverDiscovery(address(proxy));
 
         assertEq(fd.lastProviderId(), 0, "Initial provider ID should be 0");
+
+        address pauseRegistryProxyAdmin = ProxyReader.readAdmin(
+            vm,
+            pauseRegistryProxy
+        );
+        address cmProxyAdmin = ProxyReader.readAdmin(
+            vm,
+            collateralManagementProxy
+        );
+        assertEq(
+            Ownable(pauseRegistryProxyAdmin).owner(),
+            deployer,
+            "PauseRegistry ProxyAdmin owner mismatch"
+        );
+        assertEq(
+            Ownable(cmProxyAdmin).owner(),
+            deployer,
+            "CollateralManagement ProxyAdmin owner mismatch"
+        );
+        assertEq(
+            Ownable(discoveryProxyAdmin).owner(),
+            deployer,
+            "FlyoverDiscovery ProxyAdmin owner mismatch"
+        );
         console.log("   Last Provider ID:", fd.lastProviderId());
 
         console.log(
@@ -116,11 +138,10 @@ contract DeployFlyoverDiscoveryTest is Test {
 
         // Inline deployment
         address impl = address(new FlyoverDiscovery());
-        address admin = address(new ProxyAdmin(deployer));
         address proxy = address(
             new TransparentUpgradeableProxy(
                 impl,
-                admin,
+                deployer,
                 abi.encodeCall(
                     FlyoverDiscovery.initialize,
                     (
@@ -133,14 +154,19 @@ contract DeployFlyoverDiscoveryTest is Test {
             )
         );
 
+        address proxyAdminAddr = ProxyReader.readAdmin(vm, proxy);
         console.log("Deployment Result:");
         console.log("  Implementation:", impl);
         console.log("  Proxy:", proxy);
-        console.log("  Admin:", admin);
+        console.log("  ProxyAdmin:", proxyAdminAddr);
 
         assertTrue(impl != address(0), "Implementation should not be zero");
         assertTrue(proxy != address(0), "Proxy should not be zero");
-        assertTrue(admin != address(0), "Admin should not be zero");
+        assertEq(
+            Ownable(proxyAdminAddr).owner(),
+            deployer,
+            "ProxyAdmin owner mismatch"
+        );
 
         // Verify contract is initialized
         FlyoverDiscovery fd = FlyoverDiscovery(proxy);
@@ -157,11 +183,10 @@ contract DeployFlyoverDiscoveryTest is Test {
 
         // Deploy FlyoverDiscovery
         address impl = address(new FlyoverDiscovery());
-        address admin = address(new ProxyAdmin(deployer));
         address fdProxy = address(
             new TransparentUpgradeableProxy(
                 impl,
-                admin,
+                deployer,
                 abi.encodeCall(
                     FlyoverDiscovery.initialize,
                     (
@@ -188,6 +213,12 @@ contract DeployFlyoverDiscoveryTest is Test {
             "FlyoverDiscovery should have COLLATERAL_ADDER"
         );
 
+        assertEq(
+            Ownable(ProxyReader.readAdmin(vm, fdProxy)).owner(),
+            deployer,
+            "FlyoverDiscovery ProxyAdmin owner mismatch"
+        );
+
         console.log("\n[PASS] Integration with CollateralManagement verified!");
     }
 
@@ -199,11 +230,10 @@ contract DeployFlyoverDiscoveryTest is Test {
 
         // Inline deployment
         address impl = address(new FlyoverDiscovery());
-        address admin = address(new ProxyAdmin(deployer));
         address proxy = address(
             new TransparentUpgradeableProxy(
                 impl,
-                admin,
+                deployer,
                 abi.encodeCall(
                     FlyoverDiscovery.initialize,
                     (
@@ -225,8 +255,58 @@ contract DeployFlyoverDiscoveryTest is Test {
             "Deployer should have DEFAULT_ADMIN_ROLE"
         );
 
+        assertEq(
+            Ownable(ProxyReader.readAdmin(vm, proxy)).owner(),
+            deployer,
+            "FlyoverDiscovery ProxyAdmin owner mismatch"
+        );
+
         console.log("  Deployer has DEFAULT_ADMIN_ROLE: true");
 
         console.log("\n[PASS] Roles are set correctly!");
+    }
+
+    function test_ContractIsUpgradeable() public {
+        console.log("\n=== CONTRACT IS UPGRADEABLE ===\n");
+
+        HelperConfig.FlyoverConfig memory cfg = helperConfig.getFlyoverConfig();
+        address deployer = address(this);
+
+        address impl = address(new FlyoverDiscovery());
+        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
+            impl,
+            deployer,
+            abi.encodeCall(
+                FlyoverDiscovery.initialize,
+                (
+                    deployer,
+                    cfg.adminDelay,
+                    collateralManagementProxy,
+                    PauseRegistry(pauseRegistryProxy)
+                )
+            )
+        );
+
+        ProxyAdmin proxyAdmin = ProxyAdmin(
+            ProxyReader.readAdmin(vm, address(proxy))
+        );
+        address newImplementation = address(new FlyoverDiscovery());
+        assertEq(
+            ProxyReader.readImplementation(vm, address(proxy)),
+            impl,
+            "Implementation mismatch"
+        );
+        proxyAdmin.upgradeAndCall(
+            ITransparentUpgradeableProxy(address(proxy)),
+            newImplementation,
+            ""
+        );
+        assertEq(
+            ProxyReader.readImplementation(vm, address(proxy)),
+            newImplementation,
+            "Implementation mismatch"
+        );
+
+        console.log("\n[PASS] Contract is upgradeable");
     }
 }

--- a/test/deployment/DeployPegIn.t.sol
+++ b/test/deployment/DeployPegIn.t.sol
@@ -4,11 +4,13 @@ pragma solidity 0.8.25;
 import "lib/forge-std/src/Test.sol";
 import "lib/forge-std/src/console.sol";
 import {HelperConfig} from "../../script/HelperConfig.s.sol";
+import {ProxyReader} from "../../script/helpers/ProxyReader.sol";
 import {PegInContract} from "../../src/PegInContract.sol";
 import {CollateralManagementContract} from "../../src/CollateralManagement.sol";
 import {PauseRegistry} from "../../src/PauseRegistry.sol";
 import {BridgeMock} from "../../src/test-contracts/BridgeMock.sol";
-import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {TransparentUpgradeableProxy, ITransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 
 /**
@@ -28,12 +30,11 @@ contract DeployPegInTest is Test {
         HelperConfig.FlyoverConfig memory cfg = helperConfig.getFlyoverConfig();
         address deployer = address(this);
 
-        address cmAdmin = address(new ProxyAdmin(deployer));
         PauseRegistry prImpl = new PauseRegistry();
         pauseRegistryProxy = address(
             new TransparentUpgradeableProxy(
                 address(prImpl),
-                cmAdmin,
+                deployer,
                 abi.encodeCall(prImpl.initialize, (0, deployer))
             )
         );
@@ -50,7 +51,19 @@ contract DeployPegInTest is Test {
             )
         );
         collateralManagementProxy = address(
-            new TransparentUpgradeableProxy(cmImpl, cmAdmin, cmInitData)
+            new TransparentUpgradeableProxy(cmImpl, deployer, cmInitData)
+        );
+
+        assertEq(
+            Ownable(ProxyReader.readAdmin(vm, pauseRegistryProxy)).owner(),
+            deployer,
+            "PauseRegistry ProxyAdmin owner mismatch"
+        );
+        assertEq(
+            Ownable(ProxyReader.readAdmin(vm, collateralManagementProxy))
+                .owner(),
+            deployer,
+            "CollateralManagement ProxyAdmin owner mismatch"
         );
     }
 
@@ -58,7 +71,6 @@ contract DeployPegInTest is Test {
         address deployer,
         HelperConfig.FlyoverConfig memory cfg
     ) internal returns (address) {
-        address admin = address(new ProxyAdmin(deployer));
         address impl = address(new PegInContract());
         bytes memory initData = abi.encodeCall(
             PegInContract.initialize,
@@ -72,7 +84,8 @@ contract DeployPegInTest is Test {
                 PauseRegistry(pauseRegistryProxy)
             )
         );
-        return address(new TransparentUpgradeableProxy(impl, admin, initData));
+        return
+            address(new TransparentUpgradeableProxy(impl, deployer, initData));
     }
 
     function test_DeploymentFlow() public {
@@ -88,6 +101,12 @@ contract DeployPegInTest is Test {
             cfg.dustThreshold,
             "Dust threshold mismatch"
         );
+
+        assertEq(
+            Ownable(ProxyReader.readAdmin(vm, proxy)).owner(),
+            deployer,
+            "PegInContract ProxyAdmin owner mismatch"
+        );
     }
 
     function test_DeployUsingInlineDeployment() public {
@@ -100,6 +119,12 @@ contract DeployPegInTest is Test {
 
         PegInContract pegIn = PegInContract(payable(proxy));
         assertEq(pegIn.getMinPegIn(), cfg.minimumPegIn, "Min PegIn mismatch");
+
+        assertEq(
+            Ownable(ProxyReader.readAdmin(vm, proxy)).owner(),
+            deployer,
+            "PegInContract ProxyAdmin owner mismatch"
+        );
     }
 
     function test_IntegrationWithCollateralManagement() public {
@@ -118,6 +143,12 @@ contract DeployPegInTest is Test {
             cm.hasRole(collateralSlasherRole, piProxy),
             "PegIn should have COLLATERAL_SLASHER"
         );
+
+        assertEq(
+            Ownable(ProxyReader.readAdmin(vm, piProxy)).owner(),
+            deployer,
+            "PegInContract ProxyAdmin owner mismatch"
+        );
     }
 
     function test_RolesAreSetCorrectly() public {
@@ -132,5 +163,58 @@ contract DeployPegInTest is Test {
             pegIn.hasRole(defaultAdminRole, deployer),
             "Deployer should have DEFAULT_ADMIN_ROLE"
         );
+
+        assertEq(
+            Ownable(ProxyReader.readAdmin(vm, proxy)).owner(),
+            deployer,
+            "PegInContract ProxyAdmin owner mismatch"
+        );
+    }
+
+    function test_ContractIsUpgradeable() public {
+        console.log("\n=== CONTRACT IS UPGRADEABLE ===\n");
+
+        HelperConfig.FlyoverConfig memory cfg = helperConfig.getFlyoverConfig();
+        address deployer = address(this);
+
+        address impl = address(new PegInContract());
+        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
+            impl,
+            deployer,
+            abi.encodeCall(
+                PegInContract.initialize,
+                (
+                    deployer,
+                    payable(address(bridgeMock)),
+                    cfg.dustThreshold,
+                    cfg.minimumPegIn,
+                    collateralManagementProxy,
+                    cfg.mainnet,
+                    PauseRegistry(pauseRegistryProxy)
+                )
+            )
+        );
+
+        ProxyAdmin proxyAdmin = ProxyAdmin(
+            ProxyReader.readAdmin(vm, address(proxy))
+        );
+        address newImplementation = address(new PegInContract());
+        assertEq(
+            ProxyReader.readImplementation(vm, address(proxy)),
+            impl,
+            "Implementation mismatch"
+        );
+        proxyAdmin.upgradeAndCall(
+            ITransparentUpgradeableProxy(address(proxy)),
+            newImplementation,
+            ""
+        );
+        assertEq(
+            ProxyReader.readImplementation(vm, address(proxy)),
+            newImplementation,
+            "Implementation mismatch"
+        );
+
+        console.log("\n[PASS] Contract is upgradeable");
     }
 }

--- a/test/deployment/DeployPegOut.t.sol
+++ b/test/deployment/DeployPegOut.t.sol
@@ -4,11 +4,13 @@ pragma solidity 0.8.25;
 import "lib/forge-std/src/Test.sol";
 import "lib/forge-std/src/console.sol";
 import {HelperConfig} from "../../script/HelperConfig.s.sol";
+import {ProxyReader} from "../../script/helpers/ProxyReader.sol";
 import {PegOutContract} from "../../src/PegOutContract.sol";
 import {CollateralManagementContract} from "../../src/CollateralManagement.sol";
 import {PauseRegistry} from "../../src/PauseRegistry.sol";
 import {BridgeMock} from "../../src/test-contracts/BridgeMock.sol";
-import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {TransparentUpgradeableProxy, ITransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 
 /**
@@ -28,12 +30,11 @@ contract DeployPegOutTest is Test {
         HelperConfig.FlyoverConfig memory cfg = helperConfig.getFlyoverConfig();
         address deployer = address(this);
 
-        address cmAdmin = address(new ProxyAdmin(deployer));
         PauseRegistry prImpl = new PauseRegistry();
         pauseRegistryProxy = address(
             new TransparentUpgradeableProxy(
                 address(prImpl),
-                cmAdmin,
+                deployer,
                 abi.encodeCall(prImpl.initialize, (0, deployer))
             )
         );
@@ -50,7 +51,19 @@ contract DeployPegOutTest is Test {
             )
         );
         collateralManagementProxy = address(
-            new TransparentUpgradeableProxy(cmImpl, cmAdmin, cmInitData)
+            new TransparentUpgradeableProxy(cmImpl, deployer, cmInitData)
+        );
+
+        assertEq(
+            Ownable(ProxyReader.readAdmin(vm, pauseRegistryProxy)).owner(),
+            deployer,
+            "PauseRegistry ProxyAdmin owner mismatch"
+        );
+        assertEq(
+            Ownable(ProxyReader.readAdmin(vm, collateralManagementProxy))
+                .owner(),
+            deployer,
+            "CollateralManagement ProxyAdmin owner mismatch"
         );
     }
 
@@ -59,7 +72,6 @@ contract DeployPegOutTest is Test {
         HelperConfig.FlyoverConfig memory cfg
     ) internal returns (address) {
         address impl = address(new PegOutContract());
-        address admin = address(new ProxyAdmin(deployer));
         bytes memory initData = abi.encodeCall(
             PegOutContract.initialize,
             (
@@ -72,7 +84,8 @@ contract DeployPegOutTest is Test {
                 PauseRegistry(pauseRegistryProxy)
             )
         );
-        return address(new TransparentUpgradeableProxy(impl, admin, initData));
+        return
+            address(new TransparentUpgradeableProxy(impl, deployer, initData));
     }
 
     function test_DeploymentFlow() public {
@@ -92,6 +105,12 @@ contract DeployPegOutTest is Test {
             cfg.btcBlockTime,
             "BTC block time mismatch"
         );
+
+        assertEq(
+            Ownable(ProxyReader.readAdmin(vm, proxy)).owner(),
+            deployer,
+            "PegOutContract ProxyAdmin owner mismatch"
+        );
     }
 
     function test_DeployUsingInlineDeployment() public {
@@ -107,6 +126,12 @@ contract DeployPegOutTest is Test {
             pegOut.btcBlockTime(),
             cfg.btcBlockTime,
             "BTC block time mismatch"
+        );
+
+        assertEq(
+            Ownable(ProxyReader.readAdmin(vm, proxy)).owner(),
+            deployer,
+            "PegOutContract ProxyAdmin owner mismatch"
         );
     }
 
@@ -126,6 +151,12 @@ contract DeployPegOutTest is Test {
             cm.hasRole(collateralSlasherRole, poProxy),
             "PegOut should have COLLATERAL_SLASHER"
         );
+
+        assertEq(
+            Ownable(ProxyReader.readAdmin(vm, poProxy)).owner(),
+            deployer,
+            "PegOutContract ProxyAdmin owner mismatch"
+        );
     }
 
     function test_RolesAreSetCorrectly() public {
@@ -140,5 +171,58 @@ contract DeployPegOutTest is Test {
             pegOut.hasRole(defaultAdminRole, deployer),
             "Deployer should have DEFAULT_ADMIN_ROLE"
         );
+
+        assertEq(
+            Ownable(ProxyReader.readAdmin(vm, proxy)).owner(),
+            deployer,
+            "PegOutContract ProxyAdmin owner mismatch"
+        );
+    }
+
+    function test_ContractIsUpgradeable() public {
+        console.log("\n=== CONTRACT IS UPGRADEABLE ===\n");
+
+        HelperConfig.FlyoverConfig memory cfg = helperConfig.getFlyoverConfig();
+        address deployer = address(this);
+
+        address impl = address(new PegOutContract());
+        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
+            impl,
+            deployer,
+            abi.encodeCall(
+                PegOutContract.initialize,
+                (
+                    deployer,
+                    payable(address(bridgeMock)),
+                    cfg.dustThreshold,
+                    collateralManagementProxy,
+                    cfg.mainnet,
+                    cfg.btcBlockTime,
+                    PauseRegistry(pauseRegistryProxy)
+                )
+            )
+        );
+
+        ProxyAdmin proxyAdmin = ProxyAdmin(
+            ProxyReader.readAdmin(vm, address(proxy))
+        );
+        address newImplementation = address(new PegOutContract());
+        assertEq(
+            ProxyReader.readImplementation(vm, address(proxy)),
+            impl,
+            "Implementation mismatch"
+        );
+        proxyAdmin.upgradeAndCall(
+            ITransparentUpgradeableProxy(address(proxy)),
+            newImplementation,
+            ""
+        );
+        assertEq(
+            ProxyReader.readImplementation(vm, address(proxy)),
+            newImplementation,
+            "Implementation mismatch"
+        );
+
+        console.log("\n[PASS] Contract is upgradeable");
     }
 }

--- a/test/helpers/FlyoverTestBase.sol
+++ b/test/helpers/FlyoverTestBase.sol
@@ -18,7 +18,6 @@ import {Flyover} from "../../src/libraries/Flyover.sol";
 
 // OpenZeppelin
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 
 // Config
 import {HelperConfig} from "../../script/HelperConfig.s.sol";
@@ -121,11 +120,10 @@ abstract contract FlyoverTestBase is Test {
     /// @notice Deploy PauseRegistry (used by all pausable contracts)
     function _deployPauseRegistry() internal {
         PauseRegistry prImpl = new PauseRegistry();
-        address admin = address(new ProxyAdmin(owner));
         address proxy = address(
             new TransparentUpgradeableProxy(
                 address(prImpl),
-                admin,
+                owner,
                 abi.encodeCall(prImpl.initialize, (0, owner))
             )
         );
@@ -141,11 +139,10 @@ abstract contract FlyoverTestBase is Test {
         _deployPauseRegistry();
 
         address impl = address(new CollateralManagementContract());
-        address admin = address(new ProxyAdmin(owner));
         address proxy = address(
             new TransparentUpgradeableProxy(
                 impl,
-                admin,
+                owner,
                 abi.encodeCall(
                     CollateralManagementContract.initialize,
                     (
@@ -170,11 +167,10 @@ abstract contract FlyoverTestBase is Test {
         HelperConfig.FlyoverConfig memory cfg = _getTestConfig();
 
         address impl = address(new FlyoverDiscovery());
-        address admin = address(new ProxyAdmin(owner));
         address proxy = address(
             new TransparentUpgradeableProxy(
                 impl,
-                admin,
+                owner,
                 abi.encodeCall(
                     FlyoverDiscovery.initialize,
                     (
@@ -212,7 +208,6 @@ abstract contract FlyoverTestBase is Test {
 
         // Inline deployment - split to avoid stack too deep
         address impl = address(new PegInContract());
-        address admin = address(new ProxyAdmin(owner));
         bytes memory initData = abi.encodeCall(
             PegInContract.initialize,
             (
@@ -226,7 +221,7 @@ abstract contract FlyoverTestBase is Test {
             )
         );
         address proxy = address(
-            new TransparentUpgradeableProxy(impl, admin, initData)
+            new TransparentUpgradeableProxy(impl, owner, initData)
         );
 
         pegInContract = PegInContract(payable(proxy));
@@ -249,7 +244,6 @@ abstract contract FlyoverTestBase is Test {
 
         // Inline deployment - split to avoid stack too deep
         address impl = address(new PegOutContract());
-        address admin = address(new ProxyAdmin(owner));
         bytes memory initData = abi.encodeCall(
             PegOutContract.initialize,
             (
@@ -263,7 +257,7 @@ abstract contract FlyoverTestBase is Test {
             )
         );
         address proxy = address(
-            new TransparentUpgradeableProxy(impl, admin, initData)
+            new TransparentUpgradeableProxy(impl, owner, initData)
         );
 
         pegOutContract = PegOutContract(payable(proxy));
@@ -288,14 +282,12 @@ abstract contract FlyoverTestBase is Test {
 
         HelperConfig.FlyoverConfig memory cfg = _getTestConfig();
 
-        address proxyAdmin = address(new ProxyAdmin(owner));
-
         // 0) PauseRegistry
         PauseRegistry prImpl = new PauseRegistry();
         address prProxy = address(
             new TransparentUpgradeableProxy(
                 address(prImpl),
-                proxyAdmin,
+                owner,
                 abi.encodeCall(prImpl.initialize, (0, owner))
             )
         );
@@ -306,7 +298,7 @@ abstract contract FlyoverTestBase is Test {
         address cmProxy = address(
             new TransparentUpgradeableProxy(
                 cmImpl,
-                proxyAdmin,
+                owner,
                 abi.encodeCall(
                     CollateralManagementContract.initialize,
                     (
@@ -327,7 +319,7 @@ abstract contract FlyoverTestBase is Test {
         address fdProxy = address(
             new TransparentUpgradeableProxy(
                 fdImpl,
-                proxyAdmin,
+                owner,
                 abi.encodeCall(
                     FlyoverDiscovery.initialize,
                     (owner, cfg.adminDelay, cmProxy, IPauseRegistry(prProxy))
@@ -352,7 +344,7 @@ abstract contract FlyoverTestBase is Test {
                 )
             );
             address piProxy = address(
-                new TransparentUpgradeableProxy(piImpl, proxyAdmin, piInitData)
+                new TransparentUpgradeableProxy(piImpl, owner, piInitData)
             );
             pegInContract = PegInContract(payable(piProxy));
         }
@@ -373,7 +365,7 @@ abstract contract FlyoverTestBase is Test {
                 )
             );
             address poProxy = address(
-                new TransparentUpgradeableProxy(poImpl, proxyAdmin, poInitData)
+                new TransparentUpgradeableProxy(poImpl, owner, poInitData)
             );
             pegOutContract = PegOutContract(payable(poProxy));
         }


### PR DESCRIPTION
## What
- Add task to query contract roles
- Add task to query proxy admin of a contract
- Update deployment scripts to avoid passing a shared proxy admin

## Why
In the current version of the OZ library the proxies create their own admin inside the constructor

## Task
https://rsklabs.atlassian.net/browse/FLY-2288