### PR TITLE
fix: allow only providers with min collateral in depositPegout and getProviders

### DIFF
--- a/src/CollateralManagement.sol
+++ b/src/CollateralManagement.sol
@@ -116,7 +116,7 @@ contract CollateralManagementContract is
         if (rewardPercentage > TOTAL_REWARD_PERCENTAGE) {
             revert InvalidRewardPercentage(TOTAL_REWARD_PERCENTAGE, rewardPercentage);
         }
-        if (minCollateral < 1) revert InvalidMinCollateral(minCollateral);
+        if (minCollateral < 1) revert MinCollateralTooLow(minCollateral);
         if (address(pauseRegistry).code.length == 0) revert Flyover.NoContract(address(pauseRegistry));
         __AccessControlDefaultAdminRules_init(initialDelay, defaultAdmin);
         __ReentrancyGuard_init();
@@ -130,7 +130,7 @@ contract CollateralManagementContract is
     /// @param minCollateral The new minimum collateral
     // solhint-disable-next-line comprehensive-interface
     function setMinCollateral(uint minCollateral) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        if (minCollateral < 1) revert InvalidMinCollateral(minCollateral);
+        if (minCollateral < 1) revert MinCollateralTooLow(minCollateral);
         emit MinCollateralSet(_minCollateral, minCollateral);
         _minCollateral = minCollateral;
     }

--- a/src/CollateralManagement.sol
+++ b/src/CollateralManagement.sol
@@ -116,6 +116,7 @@ contract CollateralManagementContract is
         if (rewardPercentage > TOTAL_REWARD_PERCENTAGE) {
             revert InvalidRewardPercentage(TOTAL_REWARD_PERCENTAGE, rewardPercentage);
         }
+        if (minCollateral < 1) revert InvalidMinCollateral(minCollateral);
         if (address(pauseRegistry).code.length == 0) revert Flyover.NoContract(address(pauseRegistry));
         __AccessControlDefaultAdminRules_init(initialDelay, defaultAdmin);
         __ReentrancyGuard_init();
@@ -129,6 +130,7 @@ contract CollateralManagementContract is
     /// @param minCollateral The new minimum collateral
     // solhint-disable-next-line comprehensive-interface
     function setMinCollateral(uint minCollateral) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (minCollateral < 1) revert InvalidMinCollateral(minCollateral);
         emit MinCollateralSet(_minCollateral, minCollateral);
         _minCollateral = minCollateral;
     }

--- a/src/FlyoverDiscovery.sol
+++ b/src/FlyoverDiscovery.sol
@@ -183,7 +183,7 @@ contract FlyoverDiscovery is
     }
 
     /// @notice Checks if a liquidity provider should be listed in the public provider list
-    /// @dev A provider is listed if it is registered and has status enabled
+    /// @dev A provider is listed if it is registered, has the min collateral, and has status enabled
     /// @param lp The liquidity provider storage reference
     /// @return True if the provider should be listed, false otherwise
     function _shouldBeListed(Flyover.LiquidityProvider storage lp) private view returns(bool){

--- a/src/FlyoverDiscovery.sol
+++ b/src/FlyoverDiscovery.sol
@@ -187,7 +187,7 @@ contract FlyoverDiscovery is
     /// @param lp The liquidity provider storage reference
     /// @return True if the provider should be listed, false otherwise
     function _shouldBeListed(Flyover.LiquidityProvider storage lp) private view returns(bool){
-        return _collateralManagement.isRegistered(lp.providerType, lp.providerAddress) && lp.status;
+        return _collateralManagement.isCollateralSufficient(lp.providerType, lp.providerAddress) && lp.status;
     }
 
     /// @notice Validates registration parameters and requirements

--- a/src/PegOutContract.sol
+++ b/src/PegOutContract.sol
@@ -90,7 +90,7 @@ contract PegOutContract is
         Quotes.PegOutQuote calldata quote,
         bytes calldata signature
     ) external payable nonReentrant whenNotPaused override {
-        if(!_collateralManagement.isRegistered(_PEG_TYPE, quote.lpRskAddress)) {
+        if(!_collateralManagement.isCollateralSufficient(_PEG_TYPE, quote.lpRskAddress)) {
             revert Flyover.ProviderNotRegistered(quote.lpRskAddress);
         }
         uint256 requiredAmount = quote.value + quote.callFee + quote.gasFee;

--- a/src/interfaces/ICollateralManagement.sol
+++ b/src/interfaces/ICollateralManagement.sol
@@ -83,6 +83,10 @@ interface ICollateralManagement is IPausable {
     /// @param passedRewardPercentage The provided reward percentage (basis points)
     error InvalidRewardPercentage(uint256 maxRewardPercentage, uint256 passedRewardPercentage);
 
+    /// @notice Emitted when the minimum collateral is invalid
+    /// @param minCollateral The minimum collateral that was invalid
+    error InvalidMinCollateral(uint256 minCollateral);
+
     /// @notice Adds peg in collateral to an account
     /// @param addr The address of the account
     /// @dev This function requires the COLLATERAL_ADDER role

--- a/src/interfaces/ICollateralManagement.sol
+++ b/src/interfaces/ICollateralManagement.sol
@@ -83,9 +83,9 @@ interface ICollateralManagement is IPausable {
     /// @param passedRewardPercentage The provided reward percentage (basis points)
     error InvalidRewardPercentage(uint256 maxRewardPercentage, uint256 passedRewardPercentage);
 
-    /// @notice Emitted when the minimum collateral is invalid
+    /// @notice Emitted when the minimum collateral is lower than the minimum allowed
     /// @param minCollateral The minimum collateral that was invalid
-    error InvalidMinCollateral(uint256 minCollateral);
+    error MinCollateralTooLow(uint256 minCollateral);
 
     /// @notice Adds peg in collateral to an account
     /// @param addr The address of the account

--- a/test/collateral/Configuration.t.sol
+++ b/test/collateral/Configuration.t.sol
@@ -155,7 +155,7 @@ contract ConfigurationTest is CollateralTestBase {
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                ICollateralManagement.InvalidMinCollateral.selector,
+                ICollateralManagement.MinCollateralTooLow.selector,
                 uint256(0)
             )
         );
@@ -375,7 +375,7 @@ contract ConfigurationTest is CollateralTestBase {
         vm.prank(owner);
         vm.expectRevert(
             abi.encodeWithSelector(
-                ICollateralManagement.InvalidMinCollateral.selector,
+                ICollateralManagement.MinCollateralTooLow.selector,
                 uint256(0)
             )
         );

--- a/test/collateral/Configuration.t.sol
+++ b/test/collateral/Configuration.t.sol
@@ -139,6 +139,54 @@ contract ConfigurationTest is CollateralTestBase {
         new ERC1967Proxy(address(implementation), initData);
     }
 
+    function test_Initialize_RevertsWhenMinCollateralIsZero() public {
+        CollateralManagementContract implementation = new CollateralManagementContract();
+        bytes memory initData = abi.encodeCall(
+            CollateralManagementContract.initialize,
+            (
+                owner,
+                TEST_DEFAULT_ADMIN_DELAY,
+                0,
+                TEST_RESIGN_DELAY_BLOCKS,
+                TEST_REWARD_PERCENTAGE,
+                pauseRegistry
+            )
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ICollateralManagement.InvalidMinCollateral.selector,
+                uint256(0)
+            )
+        );
+        new ERC1967Proxy(address(implementation), initData);
+    }
+
+    function test_Initialize_AllowsMinimumBoundaryMinCollateral() public {
+        CollateralManagementContract implementation = new CollateralManagementContract();
+        uint256 minOneWei = 1;
+        bytes memory initData = abi.encodeCall(
+            CollateralManagementContract.initialize,
+            (
+                owner,
+                TEST_DEFAULT_ADMIN_DELAY,
+                minOneWei,
+                TEST_RESIGN_DELAY_BLOCKS,
+                TEST_REWARD_PERCENTAGE,
+                pauseRegistry
+            )
+        );
+
+        ERC1967Proxy proxy = new ERC1967Proxy(
+            address(implementation),
+            initData
+        );
+        CollateralManagementContract cm = CollateralManagementContract(
+            payable(address(proxy))
+        );
+        assertEq(cm.getMinCollateral(), minOneWei);
+    }
+
     function test_Initialize_AllowsMaximumBoundary() public {
         uint256 maxRewardPercentage = collateralManagement
             .TOTAL_REWARD_PERCENTAGE();
@@ -319,5 +367,30 @@ contract ConfigurationTest is CollateralTestBase {
             newMinCollateral,
             "MinCollateral should be updated"
         );
+    }
+
+    function test_SetMinCollateral_RevertsWhenMinCollateralIsZero() public {
+        uint256 currentMin = collateralManagement.getMinCollateral();
+
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ICollateralManagement.InvalidMinCollateral.selector,
+                uint256(0)
+            )
+        );
+        collateralManagement.setMinCollateral(0);
+
+        assertEq(
+            collateralManagement.getMinCollateral(),
+            currentMin,
+            "MinCollateral should be unchanged after revert"
+        );
+    }
+
+    function test_SetMinCollateral_AllowsMinimumBoundary() public {
+        vm.prank(owner);
+        collateralManagement.setMinCollateral(1);
+        assertEq(collateralManagement.getMinCollateral(), 1);
     }
 }

--- a/test/discovery/ListingFilter.t.sol
+++ b/test/discovery/ListingFilter.t.sol
@@ -32,6 +32,33 @@ contract ListingFilterTest is DiscoveryTestBase {
         assertEq(providers[1].id, 3, "Provider 3 ID");
     }
 
+    /// @notice getProviders lists only LPs whose collateral meets the current minimum (not only > 0)
+    function test_GetProviders_ExcludesProvidersWhenCollateralBelowMinimum() public {
+        setupProviders();
+        assertEq(discovery.getProviders().length, 3);
+
+        vm.prank(owner);
+        collateralManagement.setMinCollateral(1 ether);
+
+        assertTrue(
+            collateralManagement.isRegistered(
+                Flyover.ProviderType.PegIn,
+                pegInLp
+            ),
+            "peg-in LP should still be registered with non-zero collateral"
+        );
+        assertFalse(
+            collateralManagement.isCollateralSufficient(
+                Flyover.ProviderType.PegIn,
+                pegInLp
+            ),
+            "peg-in LP collateral is below the new minimum"
+        );
+
+        Flyover.LiquidityProvider[] memory providers = discovery.getProviders();
+        assertEq(providers.length, 0, "No provider meets the raised minimum while staying listed");
+    }
+
     // ============ Listing edge cases tests ============
 
     function test_GetProviders_ListsProvidersImmediatelyAfterRegistration()

--- a/test/discovery/ListingFilter.t.sol
+++ b/test/discovery/ListingFilter.t.sol
@@ -33,7 +33,9 @@ contract ListingFilterTest is DiscoveryTestBase {
     }
 
     /// @notice getProviders lists only LPs whose collateral meets the current minimum (not only > 0)
-    function test_GetProviders_ExcludesProvidersWhenCollateralBelowMinimum() public {
+    function test_GetProviders_ExcludesProvidersWhenCollateralBelowMinimum()
+        public
+    {
         setupProviders();
         assertEq(discovery.getProviders().length, 3);
 
@@ -56,7 +58,11 @@ contract ListingFilterTest is DiscoveryTestBase {
         );
 
         Flyover.LiquidityProvider[] memory providers = discovery.getProviders();
-        assertEq(providers.length, 0, "No provider meets the raised minimum while staying listed");
+        assertEq(
+            providers.length,
+            0,
+            "No provider meets the raised minimum while staying listed"
+        );
     }
 
     // ============ Listing edge cases tests ============

--- a/test/pegout/Deposit.t.sol
+++ b/test/pegout/Deposit.t.sol
@@ -68,12 +68,17 @@ contract DepositTest is PegOutTestBase {
     }
 
     /// @notice depositPegOut requires sufficient peg-out collateral vs minimum, not merely a positive balance
-    function test_DepositPegOut_RevertsIfLPPegOutCollateralBelowMinimum() public {
+    function test_DepositPegOut_RevertsIfLPPegOutCollateralBelowMinimum()
+        public
+    {
         vm.prank(owner);
         collateralManagement.setMinCollateral(1 ether);
 
         assertTrue(
-            collateralManagement.isRegistered(Flyover.ProviderType.PegOut, pegOutLp),
+            collateralManagement.isRegistered(
+                Flyover.ProviderType.PegOut,
+                pegOutLp
+            ),
             "LP should still count as registered with non-zero collateral"
         );
         assertFalse(
@@ -84,7 +89,10 @@ contract DepositTest is PegOutTestBase {
             "LP should be below the new minimum peg-out collateral"
         );
 
-        Quotes.PegOutQuote memory quote = createTestPegOutQuote(1 ether, pegOutLp);
+        Quotes.PegOutQuote memory quote = createTestPegOutQuote(
+            1 ether,
+            pegOutLp
+        );
         bytes memory signature = signQuote(pegOutLp, quote);
 
         vm.prank(user);

--- a/test/pegout/Deposit.t.sol
+++ b/test/pegout/Deposit.t.sol
@@ -67,6 +67,39 @@ contract DepositTest is PegOutTestBase {
         );
     }
 
+    /// @notice depositPegOut requires sufficient peg-out collateral vs minimum, not merely a positive balance
+    function test_DepositPegOut_RevertsIfLPPegOutCollateralBelowMinimum() public {
+        vm.prank(owner);
+        collateralManagement.setMinCollateral(1 ether);
+
+        assertTrue(
+            collateralManagement.isRegistered(Flyover.ProviderType.PegOut, pegOutLp),
+            "LP should still count as registered with non-zero collateral"
+        );
+        assertFalse(
+            collateralManagement.isCollateralSufficient(
+                Flyover.ProviderType.PegOut,
+                pegOutLp
+            ),
+            "LP should be below the new minimum peg-out collateral"
+        );
+
+        Quotes.PegOutQuote memory quote = createTestPegOutQuote(1 ether, pegOutLp);
+        bytes memory signature = signQuote(pegOutLp, quote);
+
+        vm.prank(user);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Flyover.ProviderNotRegistered.selector,
+                pegOutLp
+            )
+        );
+        pegOutContract.depositPegOut{value: getTotalValue(quote)}(
+            quote,
+            signature
+        );
+    }
+
     function test_DepositPegOut_RevertsIfAmountIsNotEnough() public {
         Quotes.PegOutQuote memory quote = createTestPegOutQuote(
             1.03 ether,


### PR DESCRIPTION
## What
Make more strict the LP verification on `getProviders` and `depositPegout`

## Why
To prevent listing or starting pegouts with LPs with small amounts of collateral

## Task
https://rsklabs.atlassian.net/browse/FLY-2296