### PR TITLE
Fix/FLY-2299 - Limit provider data

### DIFF
--- a/src/FlyoverDiscovery.sol
+++ b/src/FlyoverDiscovery.sol
@@ -246,6 +246,10 @@ contract FlyoverDiscovery is
         return _liquidityProviders[providerId];
     }
 
+    /// @notice Validates provider metadata fields
+    /// @dev Requires `name` and `apiBaseUrl` to be non-empty and within their configured max lengths
+    /// @param name The provider display name to validate
+    /// @param apiBaseUrl The provider API base URL to validate
     function _validateProviderData(string memory name, string memory apiBaseUrl) private pure {
         if (
             bytes(name).length < 1 ||

--- a/src/FlyoverDiscovery.sol
+++ b/src/FlyoverDiscovery.sol
@@ -22,6 +22,8 @@ contract FlyoverDiscovery is
 {
     /// @notice The version of the contract
     string constant public VERSION = "1.0.0";
+    uint256 constant private _MAX_PROVIDER_NAME_LENGTH = 256;
+    uint256 constant private _MAX_PROVIDER_API_BASE_URL_LENGTH = 512;
 
     // ------------------------------------------------------------
     // FlyoverDiscovery State Variables
@@ -104,7 +106,7 @@ contract FlyoverDiscovery is
 
     /// @inheritdoc IFlyoverDiscovery
     function updateProvider(string calldata name, string calldata apiBaseUrl) external whenNotPaused {
-        if (bytes(name).length < 1 || bytes(apiBaseUrl).length < 1) revert InvalidProviderData(name, apiBaseUrl);
+        _validateProviderData(name, apiBaseUrl);
         address providerAddress = msg.sender;
         uint providerId = _providerIdByAddress[providerAddress];
         if (providerId == 0) revert Flyover.ProviderNotRegistered(providerAddress);
@@ -209,12 +211,7 @@ contract FlyoverDiscovery is
             msg.sender != tx.origin // solhint-disable-line avoid-tx-origin
         ) revert NotEOA(providerAddress);
 
-        if (
-            bytes(name).length < 1 ||
-            bytes(apiBaseUrl).length < 1
-        ) {
-            revert InvalidProviderData(name, apiBaseUrl);
-        }
+        _validateProviderData(name, apiBaseUrl);
 
         if (providerType > type(Flyover.ProviderType).max) revert InvalidProviderType(providerType);
 
@@ -247,5 +244,16 @@ contract FlyoverDiscovery is
         uint providerId = _providerIdByAddress[providerAddress];
         if (providerId == 0) revert Flyover.ProviderNotRegistered(providerAddress);
         return _liquidityProviders[providerId];
+    }
+
+    function _validateProviderData(string memory name, string memory apiBaseUrl) private pure {
+        if (
+            bytes(name).length < 1 ||
+            bytes(name).length > _MAX_PROVIDER_NAME_LENGTH ||
+            bytes(apiBaseUrl).length < 1 ||
+            bytes(apiBaseUrl).length > _MAX_PROVIDER_API_BASE_URL_LENGTH
+        ) {
+            revert InvalidProviderData(name, apiBaseUrl);
+        }
     }
 }

--- a/src/FlyoverDiscovery.sol
+++ b/src/FlyoverDiscovery.sol
@@ -251,13 +251,20 @@ contract FlyoverDiscovery is
     /// @param name The provider display name to validate
     /// @param apiBaseUrl The provider API base URL to validate
     function _validateProviderData(string memory name, string memory apiBaseUrl) private pure {
+        uint256 nameLength = bytes(name).length;
+        uint256 apiBaseUrlLength = bytes(apiBaseUrl).length;
         if (
-            bytes(name).length < 1 ||
-            bytes(name).length > _MAX_PROVIDER_NAME_LENGTH ||
-            bytes(apiBaseUrl).length < 1 ||
-            bytes(apiBaseUrl).length > _MAX_PROVIDER_API_BASE_URL_LENGTH
+            nameLength < 1 ||
+            nameLength > _MAX_PROVIDER_NAME_LENGTH ||
+            apiBaseUrlLength < 1 ||
+            apiBaseUrlLength > _MAX_PROVIDER_API_BASE_URL_LENGTH
         ) {
-            revert InvalidProviderData(name, apiBaseUrl);
+             revert IFlyoverDiscovery.ProviderDataLengthOutOfBounds(
+                 nameLength,
+                 apiBaseUrlLength,
+                 _MAX_PROVIDER_NAME_LENGTH,
+                 _MAX_PROVIDER_API_BASE_URL_LENGTH
+             );
         }
     }
 }

--- a/src/interfaces/IFlyoverDiscovery.sol
+++ b/src/interfaces/IFlyoverDiscovery.sol
@@ -11,10 +11,20 @@ interface IFlyoverDiscovery is IPausable {
 
     error NotAuthorized(address from);
     error NotEOA(address from);
-    error InvalidProviderData(string name, string apiBaseUrl);
     error InvalidProviderType(Flyover.ProviderType providerType);
     error AlreadyRegistered(address from);
     error InsufficientCollateral(uint amount);
+    /// @notice Reverts when provider metadata lengths are empty or exceed configured bounds
+     /// @param nameLength The observed provider name length
+     /// @param apiBaseUrlLength The observed API base URL length
+     /// @param maxNameLength The maximum allowed provider name length
+     /// @param maxApiBaseUrlLength The maximum allowed API base URL length
+     error ProviderDataLengthOutOfBounds(
+         uint256 nameLength,
+         uint256 apiBaseUrlLength,
+         uint256 maxNameLength,
+         uint256 maxApiBaseUrlLength
+     );
 
     /// @notice Registers the caller as a Liquidity Provider
     /// @dev Reverts if caller is not an EOA, already resigned, provides invalid data,

--- a/test/discovery/DiscoveryTestBase.sol
+++ b/test/discovery/DiscoveryTestBase.sol
@@ -8,6 +8,7 @@ import {ICollateralManagement} from "../../src/interfaces/ICollateralManagement.
 import {PauseRegistry} from "../../src/PauseRegistry.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {Flyover} from "../../src/libraries/Flyover.sol";
+import {IFlyoverDiscovery} from "../../src/interfaces/IFlyoverDiscovery.sol";
 
 /// @title Base contract for FlyoverDiscovery tests
 /// @notice Provides shared deployment and setup logic
@@ -46,6 +47,21 @@ abstract contract DiscoveryTestBase is Test {
             }
         }
         return string(b);
+    }
+
+    /// @notice ABI-encoded revert data for `IFlyoverDiscovery.ProviderDataLengthOutOfBounds`
+    function providerDataLengthOutOfBoundsData(
+        uint256 nameLength,
+        uint256 apiBaseUrlLength
+    ) internal pure returns (bytes memory) {
+        return
+            abi.encodeWithSelector(
+                IFlyoverDiscovery.ProviderDataLengthOutOfBounds.selector,
+                nameLength,
+                apiBaseUrlLength,
+                MAX_PROVIDER_NAME_LENGTH,
+                MAX_PROVIDER_API_BASE_URL_LENGTH
+            );
     }
 
     /// @notice Deploy Discovery and CollateralManagement (equivalent to deployDiscoveryFixture)

--- a/test/discovery/DiscoveryTestBase.sol
+++ b/test/discovery/DiscoveryTestBase.sol
@@ -30,6 +30,22 @@ abstract contract DiscoveryTestBase is Test {
 
     uint256 constant MIN_COLLATERAL = 0.6 ether;
 
+    /// @dev Must match FlyoverDiscovery provider metadata limits
+    uint256 constant MAX_PROVIDER_NAME_LENGTH = 256;
+    uint256 constant MAX_PROVIDER_API_BASE_URL_LENGTH = 512;
+
+    /// @notice Builds an ASCII string of exactly `len` bytes (for max-length validation tests)
+    function makeStringOfLength(uint256 len) internal pure returns (string memory) {
+        bytes memory b = new bytes(len);
+        for (uint256 i; i < len; ) {
+            b[i] = bytes1(uint8(97 + (i % 26)));
+            unchecked {
+                ++i;
+            }
+        }
+        return string(b);
+    }
+
     /// @notice Deploy Discovery and CollateralManagement (equivalent to deployDiscoveryFixture)
     function deployDiscovery() internal {
         // Create test account

--- a/test/discovery/DiscoveryTestBase.sol
+++ b/test/discovery/DiscoveryTestBase.sol
@@ -35,7 +35,9 @@ abstract contract DiscoveryTestBase is Test {
     uint256 constant MAX_PROVIDER_API_BASE_URL_LENGTH = 512;
 
     /// @notice Builds an ASCII string of exactly `len` bytes (for max-length validation tests)
-    function makeStringOfLength(uint256 len) internal pure returns (string memory) {
+    function makeStringOfLength(
+        uint256 len
+    ) internal pure returns (string memory) {
         bytes memory b = new bytes(len);
         for (uint256 i; i < len; ) {
             b[i] = bytes1(uint8(97 + (i % 26)));

--- a/test/discovery/Registration.t.sol
+++ b/test/discovery/Registration.t.sol
@@ -81,10 +81,9 @@ contract RegistrationTest is DiscoveryTestBase {
         // Empty name
         vm.prank(lp, lp);
         vm.expectRevert(
-            abi.encodeWithSelector(
-                IFlyoverDiscovery.InvalidProviderData.selector,
-                "",
-                "http://localhost/api"
+            providerDataLengthOutOfBoundsData(
+                0,
+                bytes("http://localhost/api").length
             )
         );
         discovery.register{value: MIN_COLLATERAL}(
@@ -97,11 +96,7 @@ contract RegistrationTest is DiscoveryTestBase {
         // Empty URL
         vm.prank(lp, lp);
         vm.expectRevert(
-            abi.encodeWithSelector(
-                IFlyoverDiscovery.InvalidProviderData.selector,
-                "LP",
-                ""
-            )
+            providerDataLengthOutOfBoundsData(bytes("LP").length, 0)
         );
         discovery.register{value: MIN_COLLATERAL}(
             "LP",
@@ -122,10 +117,9 @@ contract RegistrationTest is DiscoveryTestBase {
 
         vm.prank(lp, lp);
         vm.expectRevert(
-            abi.encodeWithSelector(
-                IFlyoverDiscovery.InvalidProviderData.selector,
-                tooLongName,
-                validUrl
+            providerDataLengthOutOfBoundsData(
+                MAX_PROVIDER_NAME_LENGTH + 1,
+                bytes(validUrl).length
             )
         );
         discovery.register{value: MIN_COLLATERAL}(
@@ -149,10 +143,9 @@ contract RegistrationTest is DiscoveryTestBase {
 
         vm.prank(lp, lp);
         vm.expectRevert(
-            abi.encodeWithSelector(
-                IFlyoverDiscovery.InvalidProviderData.selector,
-                validName,
-                tooLongUrl
+            providerDataLengthOutOfBoundsData(
+                bytes(validName).length,
+                MAX_PROVIDER_API_BASE_URL_LENGTH + 1
             )
         );
         discovery.register{value: MIN_COLLATERAL}(

--- a/test/discovery/Registration.t.sol
+++ b/test/discovery/Registration.t.sol
@@ -115,7 +115,9 @@ contract RegistrationTest is DiscoveryTestBase {
         address lp = makeAddr("lpLongName");
         vm.deal(lp, 100 ether);
 
-        string memory tooLongName = makeStringOfLength(MAX_PROVIDER_NAME_LENGTH + 1);
+        string memory tooLongName = makeStringOfLength(
+            MAX_PROVIDER_NAME_LENGTH + 1
+        );
         string memory validUrl = "u";
 
         vm.prank(lp, lp);
@@ -134,12 +136,16 @@ contract RegistrationTest is DiscoveryTestBase {
         );
     }
 
-    function test_Register_RevertsWhenProviderApiBaseUrlExceedsMaxLength() public {
+    function test_Register_RevertsWhenProviderApiBaseUrlExceedsMaxLength()
+        public
+    {
         address lp = makeAddr("lpLongUrl");
         vm.deal(lp, 100 ether);
 
         string memory validName = "n";
-        string memory tooLongUrl = makeStringOfLength(MAX_PROVIDER_API_BASE_URL_LENGTH + 1);
+        string memory tooLongUrl = makeStringOfLength(
+            MAX_PROVIDER_API_BASE_URL_LENGTH + 1
+        );
 
         vm.prank(lp, lp);
         vm.expectRevert(
@@ -162,7 +168,9 @@ contract RegistrationTest is DiscoveryTestBase {
         vm.deal(lp, 100 ether);
 
         string memory name = makeStringOfLength(MAX_PROVIDER_NAME_LENGTH);
-        string memory url = makeStringOfLength(MAX_PROVIDER_API_BASE_URL_LENGTH);
+        string memory url = makeStringOfLength(
+            MAX_PROVIDER_API_BASE_URL_LENGTH
+        );
 
         vm.prank(lp, lp);
         discovery.register{value: MIN_COLLATERAL}(

--- a/test/discovery/Registration.t.sol
+++ b/test/discovery/Registration.t.sol
@@ -111,6 +111,72 @@ contract RegistrationTest is DiscoveryTestBase {
         );
     }
 
+    function test_Register_RevertsWhenProviderNameExceedsMaxLength() public {
+        address lp = makeAddr("lpLongName");
+        vm.deal(lp, 100 ether);
+
+        string memory tooLongName = makeStringOfLength(MAX_PROVIDER_NAME_LENGTH + 1);
+        string memory validUrl = "u";
+
+        vm.prank(lp, lp);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IFlyoverDiscovery.InvalidProviderData.selector,
+                tooLongName,
+                validUrl
+            )
+        );
+        discovery.register{value: MIN_COLLATERAL}(
+            tooLongName,
+            validUrl,
+            true,
+            Flyover.ProviderType.PegIn
+        );
+    }
+
+    function test_Register_RevertsWhenProviderApiBaseUrlExceedsMaxLength() public {
+        address lp = makeAddr("lpLongUrl");
+        vm.deal(lp, 100 ether);
+
+        string memory validName = "n";
+        string memory tooLongUrl = makeStringOfLength(MAX_PROVIDER_API_BASE_URL_LENGTH + 1);
+
+        vm.prank(lp, lp);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IFlyoverDiscovery.InvalidProviderData.selector,
+                validName,
+                tooLongUrl
+            )
+        );
+        discovery.register{value: MIN_COLLATERAL}(
+            validName,
+            tooLongUrl,
+            true,
+            Flyover.ProviderType.PegIn
+        );
+    }
+
+    function test_Register_AcceptsProviderDataAtMaxLength() public {
+        address lp = makeAddr("lpMaxLen");
+        vm.deal(lp, 100 ether);
+
+        string memory name = makeStringOfLength(MAX_PROVIDER_NAME_LENGTH);
+        string memory url = makeStringOfLength(MAX_PROVIDER_API_BASE_URL_LENGTH);
+
+        vm.prank(lp, lp);
+        discovery.register{value: MIN_COLLATERAL}(
+            name,
+            url,
+            true,
+            Flyover.ProviderType.PegIn
+        );
+
+        Flyover.LiquidityProvider memory p = discovery.getProvider(lp);
+        assertEq(bytes(p.name).length, MAX_PROVIDER_NAME_LENGTH);
+        assertEq(bytes(p.apiBaseUrl).length, MAX_PROVIDER_API_BASE_URL_LENGTH);
+    }
+
     function test_Register_RevertsOnInsufficientCollateralDependingOnProviderType()
         public
     {

--- a/test/discovery/Update.t.sol
+++ b/test/discovery/Update.t.sol
@@ -62,7 +62,9 @@ contract UpdateTest is DiscoveryTestBase {
     }
 
     function test_UpdateProvider_RevertsWhenNameExceedsMaxLength() public {
-        string memory tooLongName = makeStringOfLength(MAX_PROVIDER_NAME_LENGTH + 1);
+        string memory tooLongName = makeStringOfLength(
+            MAX_PROVIDER_NAME_LENGTH + 1
+        );
         string memory validUrl = "x";
 
         vm.prank(fullLp);
@@ -76,9 +78,13 @@ contract UpdateTest is DiscoveryTestBase {
         discovery.updateProvider(tooLongName, validUrl);
     }
 
-    function test_UpdateProvider_RevertsWhenApiBaseUrlExceedsMaxLength() public {
+    function test_UpdateProvider_RevertsWhenApiBaseUrlExceedsMaxLength()
+        public
+    {
         string memory validName = "x";
-        string memory tooLongUrl = makeStringOfLength(MAX_PROVIDER_API_BASE_URL_LENGTH + 1);
+        string memory tooLongUrl = makeStringOfLength(
+            MAX_PROVIDER_API_BASE_URL_LENGTH + 1
+        );
 
         vm.prank(fullLp);
         vm.expectRevert(
@@ -93,7 +99,9 @@ contract UpdateTest is DiscoveryTestBase {
 
     function test_UpdateProvider_AcceptsDataAtMaxLength() public {
         string memory name = makeStringOfLength(MAX_PROVIDER_NAME_LENGTH);
-        string memory url = makeStringOfLength(MAX_PROVIDER_API_BASE_URL_LENGTH);
+        string memory url = makeStringOfLength(
+            MAX_PROVIDER_API_BASE_URL_LENGTH
+        );
 
         vm.prank(fullLp);
         discovery.updateProvider(name, url);

--- a/test/discovery/Update.t.sol
+++ b/test/discovery/Update.t.sol
@@ -61,6 +61,48 @@ contract UpdateTest is DiscoveryTestBase {
         discovery.updateProvider("x", "");
     }
 
+    function test_UpdateProvider_RevertsWhenNameExceedsMaxLength() public {
+        string memory tooLongName = makeStringOfLength(MAX_PROVIDER_NAME_LENGTH + 1);
+        string memory validUrl = "x";
+
+        vm.prank(fullLp);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IFlyoverDiscovery.InvalidProviderData.selector,
+                tooLongName,
+                validUrl
+            )
+        );
+        discovery.updateProvider(tooLongName, validUrl);
+    }
+
+    function test_UpdateProvider_RevertsWhenApiBaseUrlExceedsMaxLength() public {
+        string memory validName = "x";
+        string memory tooLongUrl = makeStringOfLength(MAX_PROVIDER_API_BASE_URL_LENGTH + 1);
+
+        vm.prank(fullLp);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IFlyoverDiscovery.InvalidProviderData.selector,
+                validName,
+                tooLongUrl
+            )
+        );
+        discovery.updateProvider(validName, tooLongUrl);
+    }
+
+    function test_UpdateProvider_AcceptsDataAtMaxLength() public {
+        string memory name = makeStringOfLength(MAX_PROVIDER_NAME_LENGTH);
+        string memory url = makeStringOfLength(MAX_PROVIDER_API_BASE_URL_LENGTH);
+
+        vm.prank(fullLp);
+        discovery.updateProvider(name, url);
+
+        Flyover.LiquidityProvider memory p = discovery.getProvider(fullLp);
+        assertEq(bytes(p.name).length, MAX_PROVIDER_NAME_LENGTH);
+        assertEq(bytes(p.apiBaseUrl).length, MAX_PROVIDER_API_BASE_URL_LENGTH);
+    }
+
     function test_UpdateProvider_RevertsIfUnregisteredAddressCallsUpdate()
         public
     {

--- a/test/discovery/Update.t.sol
+++ b/test/discovery/Update.t.sol
@@ -41,22 +41,14 @@ contract UpdateTest is DiscoveryTestBase {
         // Empty name
         vm.prank(fullLp);
         vm.expectRevert(
-            abi.encodeWithSelector(
-                IFlyoverDiscovery.InvalidProviderData.selector,
-                "",
-                "x"
-            )
+            providerDataLengthOutOfBoundsData(0, bytes("x").length)
         );
         discovery.updateProvider("", "x");
 
         // Empty URL
         vm.prank(fullLp);
         vm.expectRevert(
-            abi.encodeWithSelector(
-                IFlyoverDiscovery.InvalidProviderData.selector,
-                "x",
-                ""
-            )
+            providerDataLengthOutOfBoundsData(bytes("x").length, 0)
         );
         discovery.updateProvider("x", "");
     }
@@ -69,10 +61,9 @@ contract UpdateTest is DiscoveryTestBase {
 
         vm.prank(fullLp);
         vm.expectRevert(
-            abi.encodeWithSelector(
-                IFlyoverDiscovery.InvalidProviderData.selector,
-                tooLongName,
-                validUrl
+            providerDataLengthOutOfBoundsData(
+                MAX_PROVIDER_NAME_LENGTH + 1,
+                bytes(validUrl).length
             )
         );
         discovery.updateProvider(tooLongName, validUrl);
@@ -88,10 +79,9 @@ contract UpdateTest is DiscoveryTestBase {
 
         vm.prank(fullLp);
         vm.expectRevert(
-            abi.encodeWithSelector(
-                IFlyoverDiscovery.InvalidProviderData.selector,
-                validName,
-                tooLongUrl
+            providerDataLengthOutOfBoundsData(
+                bytes(validName).length,
+                MAX_PROVIDER_API_BASE_URL_LENGTH + 1
             )
         );
         discovery.updateProvider(validName, tooLongUrl);


### PR DESCRIPTION
## What
Add limits to provider metadata

## Why
To prevent abuse of the storage that might derivate later in expensive views if called from another contract

## Task
https://rsklabs.atlassian.net/browse/FLY-2299