### PR TITLE
Feature/FLY-2295 - Validate pegout refund address

### DIFF
--- a/src/PegOutContract.sol
+++ b/src/PegOutContract.sol
@@ -349,6 +349,10 @@ contract PegOutContract is
             quote.expireBlock > block.number + _NATIVE_PEGOUT_BLOCKS ||
             quote.expireDate > block.timestamp + _NATIVE_PEGOUT_SECONDS
         ) revert UnfairQuote();
+
+        if (quote.rskRefundAddress == address(0)) {
+            revert Flyover.InvalidAddress(quote.rskRefundAddress);
+        }
     }
 
     /// @notice This function is used to check if a quote has been completed (refunded by any party)

--- a/test/pegout/Deposit.t.sol
+++ b/test/pegout/Deposit.t.sol
@@ -76,15 +76,9 @@ contract DepositTest is PegOutTestBase {
 
         vm.prank(user);
         vm.expectRevert(
-            abi.encodeWithSelector(
-                Flyover.InvalidAddress.selector,
-                address(0)
-            )
+            abi.encodeWithSelector(Flyover.InvalidAddress.selector, address(0))
         );
-        pegOutContract.depositPegOut{value: getTotalValue(quote)}(
-            quote,
-            ""
-        );
+        pegOutContract.depositPegOut{value: getTotalValue(quote)}(quote, "");
     }
 
     function test_DepositPegOut_RevertsIfAmountIsNotEnough() public {

--- a/test/pegout/Deposit.t.sol
+++ b/test/pegout/Deposit.t.sol
@@ -67,6 +67,26 @@ contract DepositTest is PegOutTestBase {
         );
     }
 
+    function test_DepositPegOut_RevertsIfRskRefundAddressIsZero() public {
+        Quotes.PegOutQuote memory quote = createTestPegOutQuote(
+            1.03 ether,
+            fullLp
+        );
+        quote.rskRefundAddress = address(0);
+
+        vm.prank(user);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Flyover.InvalidAddress.selector,
+                address(0)
+            )
+        );
+        pegOutContract.depositPegOut{value: getTotalValue(quote)}(
+            quote,
+            ""
+        );
+    }
+
     function test_DepositPegOut_RevertsIfAmountIsNotEnough() public {
         Quotes.PegOutQuote memory quote = createTestPegOutQuote(
             1.03 ether,

--- a/test/pegout/Hashing.t.sol
+++ b/test/pegout/Hashing.t.sol
@@ -57,6 +57,34 @@ contract HashingTest is PegOutTestBase {
         pegOutContract.hashPegOutQuote(quote);
     }
 
+    function test_HashPegOutQuote_RevertsIfRskRefundAddressIsZero() public {
+        Quotes.PegOutQuote memory quote = createSpecificPegOutQuote1();
+        quote.lbcAddress = address(pegOutContract);
+        quote.rskRefundAddress = address(0);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Flyover.InvalidAddress.selector,
+                address(0)
+            )
+        );
+        pegOutContract.hashPegOutQuote(quote);
+    }
+
+    function test_HashPegOutQuoteEIP712_RevertsIfRskRefundAddressIsZero() public {
+        Quotes.PegOutQuote memory quote = createSpecificPegOutQuote1();
+        quote.lbcAddress = address(pegOutContract);
+        quote.rskRefundAddress = address(0);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Flyover.InvalidAddress.selector,
+                address(0)
+            )
+        );
+        pegOutContract.hashPegOutQuoteEIP712(quote);
+    }
+
     function test_HashPegOutQuote_AcceptsQuoteWithinNativePegoutLimits()
         public
         view

--- a/test/pegout/Hashing.t.sol
+++ b/test/pegout/Hashing.t.sol
@@ -63,24 +63,20 @@ contract HashingTest is PegOutTestBase {
         quote.rskRefundAddress = address(0);
 
         vm.expectRevert(
-            abi.encodeWithSelector(
-                Flyover.InvalidAddress.selector,
-                address(0)
-            )
+            abi.encodeWithSelector(Flyover.InvalidAddress.selector, address(0))
         );
         pegOutContract.hashPegOutQuote(quote);
     }
 
-    function test_HashPegOutQuoteEIP712_RevertsIfRskRefundAddressIsZero() public {
+    function test_HashPegOutQuoteEIP712_RevertsIfRskRefundAddressIsZero()
+        public
+    {
         Quotes.PegOutQuote memory quote = createSpecificPegOutQuote1();
         quote.lbcAddress = address(pegOutContract);
         quote.rskRefundAddress = address(0);
 
         vm.expectRevert(
-            abi.encodeWithSelector(
-                Flyover.InvalidAddress.selector,
-                address(0)
-            )
+            abi.encodeWithSelector(Flyover.InvalidAddress.selector, address(0))
         );
         pegOutContract.hashPegOutQuoteEIP712(quote);
     }


### PR DESCRIPTION
## What
Validate pegout refund address is not the zero address

## Why 
To harden the verifications done for the pegout quote

## Task
https://rsklabs.atlassian.net/browse/FLY-2295