### PR TITLE
Feature/FLY-2300 - Allow pegout refunds for non-penalization cases

### DIFF
--- a/src/PegOutContract.sol
+++ b/src/PegOutContract.sol
@@ -226,6 +226,10 @@ contract PegOutContract is
         emit PegOutRefunded(quoteHash);
 
         if (_shouldPenalize(quote, quoteHash, btcBlockHeaderHash)) {
+            uint256 collateral = _collateralManagement.getPegOutCollateral(quote.lpRskAddress);
+            if (collateral < quote.penaltyFee) {
+                revert IPegOut.InsufficientCollateral(quote.penaltyFee);
+            }
             _collateralManagement.slashPegOutCollateral(msg.sender, quote, quoteHash);
         }
 
@@ -403,9 +407,6 @@ contract PegOutContract is
         bytes32 quoteHash,
         bytes calldata btcTx
     ) private view returns (Quotes.PegOutQuote memory quote) {
-        if(!_collateralManagement.isRegistered(_PEG_TYPE, msg.sender)) {
-            revert Flyover.ProviderNotRegistered(msg.sender);
-        }
         if (_isQuoteCompleted(quoteHash)) revert QuoteAlreadyCompleted(quoteHash);
 
         quote = _pegOutQuotes[quoteHash];

--- a/src/PegOutContract.sol
+++ b/src/PegOutContract.sol
@@ -228,7 +228,7 @@ contract PegOutContract is
         if (_shouldPenalize(quote, quoteHash, btcBlockHeaderHash)) {
             uint256 collateral = _collateralManagement.getPegOutCollateral(quote.lpRskAddress);
             if (collateral < quote.penaltyFee) {
-                revert IPegOut.InsufficientCollateral(quote.penaltyFee);
+                revert IPegOut.InsufficientCollateral(collateral);
             }
             _collateralManagement.slashPegOutCollateral(msg.sender, quote, quoteHash);
         }

--- a/src/interfaces/IPegOut.sol
+++ b/src/interfaces/IPegOut.sol
@@ -116,6 +116,10 @@ interface IPegOut is IPausable, IERC5267 {
     /// - The expiration date of the quote is more than the native peg out seconds
     error UnfairQuote();
 
+    /// @notice This error is emitted when the collateral is insufficient to cover the penalty fee
+    /// @param amount the amount of collateral that is insufficient
+    error InsufficientCollateral(uint amount);
+
 
     /// @notice This function is used to withdraw funds from the contract
     /// @dev This is usually used if some payment failed and the funds need to be returned to a different address.

--- a/test/pegout/LpRefund.t.sol
+++ b/test/pegout/LpRefund.t.sol
@@ -102,11 +102,12 @@ contract LpRefundTest is PegOutTestBase {
 
         bytes memory btcTx = generateBtcTx(quote, quoteHash);
 
+        uint256 collateral = collateralManagement.getPegOutCollateral(pegOutLp);
         vm.prank(pegOutLp);
         vm.expectRevert(
             abi.encodeWithSelector(
                 IPegOut.InsufficientCollateral.selector,
-                quote.penaltyFee
+                collateral
             )
         );
         pegOutContract.refundPegOut(
@@ -573,11 +574,12 @@ contract LpRefundTest is PegOutTestBase {
 
         bytes memory btcTx = generateBtcTx(quote, quoteHash);
 
+        uint256 collateral = collateralManagement.getPegOutCollateral(pegOutLp);
         vm.prank(pegOutLp);
         vm.expectRevert(
             abi.encodeWithSelector(
                 IPegOut.InsufficientCollateral.selector,
-                quote.penaltyFee
+                collateral
             )
         );
         pegOutContract.refundPegOut(

--- a/test/pegout/LpRefund.t.sol
+++ b/test/pegout/LpRefund.t.sol
@@ -29,7 +29,9 @@ contract LpRefundTest is PegOutTestBase {
 
     // ============ refundPegOut function tests ============
 
-    function test_RefundPegOut_SucceedsAfterLPResignedWhenNotPenalized() public {
+    function test_RefundPegOut_SucceedsAfterLPResignedWhenNotPenalized()
+        public
+    {
         Quotes.PegOutQuote memory quote = createAndDepositQuote();
         bytes32 quoteHash = pegOutContract.hashPegOutQuote(quote);
 
@@ -66,7 +68,10 @@ contract LpRefundTest is PegOutTestBase {
     function test_RefundPegOut_RevertsWhenPenalizedIfLpResignedInsufficientCollateralForPenalty()
         public
     {
-        Quotes.PegOutQuote memory quote = createTestPegOutQuote(1 ether, pegOutLp);
+        Quotes.PegOutQuote memory quote = createTestPegOutQuote(
+            1 ether,
+            pegOutLp
+        );
         quote.penaltyFee = 1 ether;
         bytes32 quoteHash = pegOutContract.hashPegOutQuote(quote);
         bytes memory signature = signQuote(pegOutLp, quote);
@@ -87,7 +92,9 @@ contract LpRefundTest is PegOutTestBase {
         vm.warp(quote.expireDate + 1);
         vm.roll(quote.expireBlock + 1);
 
-        bytes memory header = createBtcBlockHeader(uint32(quote.expireDate + 1));
+        bytes memory header = createBtcBlockHeader(
+            uint32(quote.expireDate + 1)
+        );
         bridgeMock.setHeaderByHash(BLOCK_HEADER_HASH, header);
         bridgeMock.setConfirmations(
             int256(uint256(quote.transferConfirmations))
@@ -539,7 +546,10 @@ contract LpRefundTest is PegOutTestBase {
     function test_RefundPegOut_RevertsWhenPenalizedAndPegOutCollateralBelowPenaltyFee()
         public
     {
-        Quotes.PegOutQuote memory quote = createTestPegOutQuote(1 ether, pegOutLp);
+        Quotes.PegOutQuote memory quote = createTestPegOutQuote(
+            1 ether,
+            pegOutLp
+        );
         quote.penaltyFee = 1 ether;
         bytes32 quoteHash = pegOutContract.hashPegOutQuote(quote);
         bytes memory signature = signQuote(pegOutLp, quote);
@@ -553,7 +563,9 @@ contract LpRefundTest is PegOutTestBase {
         vm.warp(quote.expireDate + 1);
         vm.roll(quote.expireBlock + 1);
 
-        bytes memory header = createBtcBlockHeader(uint32(quote.expireDate + 1));
+        bytes memory header = createBtcBlockHeader(
+            uint32(quote.expireDate + 1)
+        );
         bridgeMock.setHeaderByHash(BLOCK_HEADER_HASH, header);
         bridgeMock.setConfirmations(
             int256(uint256(quote.transferConfirmations))
@@ -580,7 +592,10 @@ contract LpRefundTest is PegOutTestBase {
     function test_RefundPegOut_SucceedsWhenNotPenalizedEvenIfPegOutCollateralBelowPenaltyFee()
         public
     {
-        Quotes.PegOutQuote memory quote = createTestPegOutQuote(1 ether, pegOutLp);
+        Quotes.PegOutQuote memory quote = createTestPegOutQuote(
+            1 ether,
+            pegOutLp
+        );
         quote.penaltyFee = 1 ether;
         bytes32 quoteHash = pegOutContract.hashPegOutQuote(quote);
         bytes memory signature = signQuote(pegOutLp, quote);

--- a/test/pegout/LpRefund.t.sol
+++ b/test/pegout/LpRefund.t.sol
@@ -29,23 +29,77 @@ contract LpRefundTest is PegOutTestBase {
 
     // ============ refundPegOut function tests ============
 
-    function test_RefundPegOut_RevertsIfLPResigned() public {
-        // First, deposit a quote
+    function test_RefundPegOut_SucceedsAfterLPResignedWhenNotPenalized() public {
         Quotes.PegOutQuote memory quote = createAndDepositQuote();
         bytes32 quoteHash = pegOutContract.hashPegOutQuote(quote);
 
-        // LP resigns
         vm.prank(pegOutLp);
         collateralManagement.resign();
 
-        // Try to refund - should fail
+        bytes memory header = createBtcBlockHeader(
+            uint32(block.timestamp + 100)
+        );
+        bridgeMock.setHeaderByHash(BLOCK_HEADER_HASH, header);
+        bridgeMock.setConfirmations(
+            int256(uint256(quote.transferConfirmations))
+        );
+
+        bytes memory btcTx = generateBtcTx(quote, quoteHash);
+
+        vm.prank(pegOutLp);
+        pegOutContract.refundPegOut(
+            quoteHash,
+            btcTx,
+            BLOCK_HEADER_HASH,
+            PARTIAL_MERKLE_TREE,
+            merkleHashes
+        );
+
+        assertTrue(
+            pegOutContract.isQuoteCompleted(quoteHash),
+            "Quote should complete; refund no longer requires peg-out registration"
+        );
+    }
+
+    /// @notice After resign, peg-out collateral remains locked until withdraw; a penalized refund still
+    /// requires collateral >= penaltyFee, otherwise the contract reverts with InsufficientCollateral.
+    function test_RefundPegOut_RevertsWhenPenalizedIfLpResignedInsufficientCollateralForPenalty()
+        public
+    {
+        Quotes.PegOutQuote memory quote = createTestPegOutQuote(1 ether, pegOutLp);
+        quote.penaltyFee = 1 ether;
+        bytes32 quoteHash = pegOutContract.hashPegOutQuote(quote);
+        bytes memory signature = signQuote(pegOutLp, quote);
+
+        vm.prank(user);
+        pegOutContract.depositPegOut{value: getTotalValue(quote)}(
+            quote,
+            signature
+        );
+
+        vm.prank(pegOutLp);
+        collateralManagement.resign();
+        assertTrue(
+            collateralManagement.getResignationBlock(pegOutLp) != 0,
+            "LP should be in resigned state (collateral not withdrawn yet)"
+        );
+
+        vm.warp(quote.expireDate + 1);
+        vm.roll(quote.expireBlock + 1);
+
+        bytes memory header = createBtcBlockHeader(uint32(quote.expireDate + 1));
+        bridgeMock.setHeaderByHash(BLOCK_HEADER_HASH, header);
+        bridgeMock.setConfirmations(
+            int256(uint256(quote.transferConfirmations))
+        );
+
         bytes memory btcTx = generateBtcTx(quote, quoteHash);
 
         vm.prank(pegOutLp);
         vm.expectRevert(
             abi.encodeWithSelector(
-                Flyover.ProviderNotRegistered.selector,
-                pegOutLp
+                IPegOut.InsufficientCollateral.selector,
+                quote.penaltyFee
             )
         );
         pegOutContract.refundPegOut(
@@ -482,6 +536,83 @@ contract LpRefundTest is PegOutTestBase {
         );
     }
 
+    function test_RefundPegOut_RevertsWhenPenalizedAndPegOutCollateralBelowPenaltyFee()
+        public
+    {
+        Quotes.PegOutQuote memory quote = createTestPegOutQuote(1 ether, pegOutLp);
+        quote.penaltyFee = 1 ether;
+        bytes32 quoteHash = pegOutContract.hashPegOutQuote(quote);
+        bytes memory signature = signQuote(pegOutLp, quote);
+
+        vm.prank(user);
+        pegOutContract.depositPegOut{value: getTotalValue(quote)}(
+            quote,
+            signature
+        );
+
+        vm.warp(quote.expireDate + 1);
+        vm.roll(quote.expireBlock + 1);
+
+        bytes memory header = createBtcBlockHeader(uint32(quote.expireDate + 1));
+        bridgeMock.setHeaderByHash(BLOCK_HEADER_HASH, header);
+        bridgeMock.setConfirmations(
+            int256(uint256(quote.transferConfirmations))
+        );
+
+        bytes memory btcTx = generateBtcTx(quote, quoteHash);
+
+        vm.prank(pegOutLp);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegOut.InsufficientCollateral.selector,
+                quote.penaltyFee
+            )
+        );
+        pegOutContract.refundPegOut(
+            quoteHash,
+            btcTx,
+            BLOCK_HEADER_HASH,
+            PARTIAL_MERKLE_TREE,
+            merkleHashes
+        );
+    }
+
+    function test_RefundPegOut_SucceedsWhenNotPenalizedEvenIfPegOutCollateralBelowPenaltyFee()
+        public
+    {
+        Quotes.PegOutQuote memory quote = createTestPegOutQuote(1 ether, pegOutLp);
+        quote.penaltyFee = 1 ether;
+        bytes32 quoteHash = pegOutContract.hashPegOutQuote(quote);
+        bytes memory signature = signQuote(pegOutLp, quote);
+
+        vm.prank(user);
+        pegOutContract.depositPegOut{value: getTotalValue(quote)}(
+            quote,
+            signature
+        );
+
+        bytes memory header = createBtcBlockHeader(
+            uint32(block.timestamp + 100)
+        );
+        bridgeMock.setHeaderByHash(BLOCK_HEADER_HASH, header);
+        bridgeMock.setConfirmations(
+            int256(uint256(quote.transferConfirmations))
+        );
+
+        bytes memory btcTx = generateBtcTx(quote, quoteHash);
+
+        vm.prank(pegOutLp);
+        pegOutContract.refundPegOut(
+            quoteHash,
+            btcTx,
+            BLOCK_HEADER_HASH,
+            PARTIAL_MERKLE_TREE,
+            merkleHashes
+        );
+
+        assertTrue(pegOutContract.isQuoteCompleted(quoteHash));
+    }
+
     function test_RefundPegOut_RevertsIfCantExtractFirstConfirmationHeader()
         public
     {
@@ -704,26 +835,22 @@ contract LpRefundTest is PegOutTestBase {
 
     // ============ validatePegout function tests ============
 
-    function test_ValidatePegout_RevertsIfLPResigned() public {
-        // First, deposit a quote
+    function test_ValidatePegout_AllowsResignedLpWhenBtcTxValid() public {
         Quotes.PegOutQuote memory quote = createAndDepositQuote();
         bytes32 quoteHash = pegOutContract.hashPegOutQuote(quote);
 
-        // LP resigns
         vm.prank(pegOutLp);
         collateralManagement.resign();
 
-        // Try to validate - should fail
         bytes memory btcTx = generateBtcTx(quote, quoteHash);
 
         vm.prank(pegOutLp);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                Flyover.ProviderNotRegistered.selector,
-                pegOutLp
-            )
+        Quotes.PegOutQuote memory returnedQuote = pegOutContract.validatePegout(
+            quoteHash,
+            btcTx
         );
-        pegOutContract.validatePegout(quoteHash, btcTx);
+        assertEq(returnedQuote.lpRskAddress, pegOutLp);
+        assertEq(returnedQuote.value, quote.value);
     }
 
     function test_ValidatePegout_RevertsIfQuoteWasNotPaid() public {


### PR DESCRIPTION
## What
Allow not registered providers to refund pegouts if they have enough collateral for the penalization

## Why
Currently we're blocking honest payments if the LP lacks collateral even if they're not going to be penalized

## Task
https://rsklabs.atlassian.net/browse/FLY-2300