### PR TITLE
fix(collateral): clear resignation flag when collateral is zero after slash (F-57455)

### DIFF
--- a/src/CollateralManagement.sol
+++ b/src/CollateralManagement.sol
@@ -313,7 +313,10 @@ contract CollateralManagementContract is
         }
 
         uint256 amount = _pegOutCollateral[providerAddress] + _pegInCollateral[providerAddress];
-        if (amount < 1) revert NothingToWithdraw(providerAddress);
+        if (amount < 1) {
+            _resignationBlockNum[providerAddress] = 0;
+            return;
+        }
         _pegOutCollateral[providerAddress] = 0;
         _pegInCollateral[providerAddress] = 0;
         _resignationBlockNum[providerAddress] = 0;

--- a/test/collateral/Resign.t.sol
+++ b/test/collateral/Resign.t.sol
@@ -261,14 +261,26 @@ contract ResignTest is CollateralTestBase {
 
         vm.roll(block.number + TEST_RESIGN_DELAY_BLOCKS);
 
-        assertEq(collateralManagement.getPegInCollateral(pegInLp), 0, "slash zeroed peg-in collateral");
-        assertGt(collateralManagement.getResignationBlock(pegInLp), 0, "still resigned before withdraw");
+        assertEq(
+            collateralManagement.getPegInCollateral(pegInLp),
+            0,
+            "slash zeroed peg-in collateral"
+        );
+        assertGt(
+            collateralManagement.getResignationBlock(pegInLp),
+            0,
+            "still resigned before withdraw"
+        );
 
         uint256 balanceBefore = pegInLp.balance;
         vm.prank(pegInLp);
         collateralManagement.withdrawCollateral();
 
-        assertEq(pegInLp.balance, balanceBefore, "peg-in: no transfer when slash already zeroed collateral");
+        assertEq(
+            pegInLp.balance,
+            balanceBefore,
+            "peg-in: no transfer when slash already zeroed collateral"
+        );
         assertEq(collateralManagement.getPegInCollateral(pegInLp), 0);
         assertEq(collateralManagement.getResignationBlock(pegInLp), 0);
 
@@ -289,14 +301,26 @@ contract ResignTest is CollateralTestBase {
 
         vm.roll(block.number + TEST_RESIGN_DELAY_BLOCKS);
 
-        assertEq(collateralManagement.getPegOutCollateral(pegOutLp), 0, "slash zeroed peg-out collateral");
-        assertGt(collateralManagement.getResignationBlock(pegOutLp), 0, "still resigned before withdraw");
+        assertEq(
+            collateralManagement.getPegOutCollateral(pegOutLp),
+            0,
+            "slash zeroed peg-out collateral"
+        );
+        assertGt(
+            collateralManagement.getResignationBlock(pegOutLp),
+            0,
+            "still resigned before withdraw"
+        );
 
         balanceBefore = pegOutLp.balance;
         vm.prank(pegOutLp);
         collateralManagement.withdrawCollateral();
 
-        assertEq(pegOutLp.balance, balanceBefore, "peg-out: no transfer when slash already zeroed collateral");
+        assertEq(
+            pegOutLp.balance,
+            balanceBefore,
+            "peg-out: no transfer when slash already zeroed collateral"
+        );
         assertEq(collateralManagement.getPegOutCollateral(pegOutLp), 0);
         assertEq(collateralManagement.getResignationBlock(pegOutLp), 0);
 
@@ -323,14 +347,22 @@ contract ResignTest is CollateralTestBase {
         vm.roll(block.number + TEST_RESIGN_DELAY_BLOCKS);
 
         assertEq(collateralManagement.getPegInCollateral(fullLp), 0);
-        assertEq(collateralManagement.getPegOutCollateral(fullLp), 0, "slash zeroed both buckets");
+        assertEq(
+            collateralManagement.getPegOutCollateral(fullLp),
+            0,
+            "slash zeroed both buckets"
+        );
         assertGt(collateralManagement.getResignationBlock(fullLp), 0);
 
         balanceBefore = fullLp.balance;
         vm.prank(fullLp);
         collateralManagement.withdrawCollateral();
 
-        assertEq(fullLp.balance, balanceBefore, "both buckets: no transfer when slash already zeroed collateral");
+        assertEq(
+            fullLp.balance,
+            balanceBefore,
+            "both buckets: no transfer when slash already zeroed collateral"
+        );
         assertEq(collateralManagement.getResignationBlock(fullLp), 0);
     }
 

--- a/test/collateral/Resign.t.sol
+++ b/test/collateral/Resign.t.sol
@@ -241,8 +241,10 @@ contract ResignTest is CollateralTestBase {
         }
     }
 
-    function test_WithdrawCollateral_RevertsIfNoCollateralToWithdraw() public {
-        // Slash all collateral from pegInLp
+    function test_WithdrawCollateral_ClearsResignationWhenCollateralZeroAfterSlash()
+        public
+    {
+        // Peg-in collateral fully slashed after resign
         vm.prank(pegInLp);
         collateralManagement.resign();
 
@@ -257,19 +259,20 @@ contract ResignTest is CollateralTestBase {
             bytes32(0)
         );
 
-        // Wait for resign delay
         vm.roll(block.number + TEST_RESIGN_DELAY_BLOCKS);
 
+        assertEq(collateralManagement.getPegInCollateral(pegInLp), 0, "slash zeroed peg-in collateral");
+        assertGt(collateralManagement.getResignationBlock(pegInLp), 0, "still resigned before withdraw");
+
+        uint256 balanceBefore = pegInLp.balance;
         vm.prank(pegInLp);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                ICollateralManagement.NothingToWithdraw.selector,
-                pegInLp
-            )
-        );
         collateralManagement.withdrawCollateral();
 
-        // Slash all collateral from pegOutLp
+        assertEq(pegInLp.balance, balanceBefore, "peg-in: no transfer when slash already zeroed collateral");
+        assertEq(collateralManagement.getPegInCollateral(pegInLp), 0);
+        assertEq(collateralManagement.getResignationBlock(pegInLp), 0);
+
+        // Peg-out collateral fully slashed after resign
         vm.prank(pegOutLp);
         collateralManagement.resign();
 
@@ -284,19 +287,20 @@ contract ResignTest is CollateralTestBase {
             bytes32(0)
         );
 
-        // Wait for resign delay
         vm.roll(block.number + TEST_RESIGN_DELAY_BLOCKS);
 
+        assertEq(collateralManagement.getPegOutCollateral(pegOutLp), 0, "slash zeroed peg-out collateral");
+        assertGt(collateralManagement.getResignationBlock(pegOutLp), 0, "still resigned before withdraw");
+
+        balanceBefore = pegOutLp.balance;
         vm.prank(pegOutLp);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                ICollateralManagement.NothingToWithdraw.selector,
-                pegOutLp
-            )
-        );
         collateralManagement.withdrawCollateral();
 
-        // Slash all collateral from fullLp (both pegIn and pegOut)
+        assertEq(pegOutLp.balance, balanceBefore, "peg-out: no transfer when slash already zeroed collateral");
+        assertEq(collateralManagement.getPegOutCollateral(pegOutLp), 0);
+        assertEq(collateralManagement.getResignationBlock(pegOutLp), 0);
+
+        // Both buckets slashed for fullLp
         vm.prank(fullLp);
         collateralManagement.resign();
 
@@ -316,17 +320,18 @@ contract ResignTest is CollateralTestBase {
             bytes32(0)
         );
 
-        // Wait for resign delay
         vm.roll(block.number + TEST_RESIGN_DELAY_BLOCKS);
 
+        assertEq(collateralManagement.getPegInCollateral(fullLp), 0);
+        assertEq(collateralManagement.getPegOutCollateral(fullLp), 0, "slash zeroed both buckets");
+        assertGt(collateralManagement.getResignationBlock(fullLp), 0);
+
+        balanceBefore = fullLp.balance;
         vm.prank(fullLp);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                ICollateralManagement.NothingToWithdraw.selector,
-                fullLp
-            )
-        );
         collateralManagement.withdrawCollateral();
+
+        assertEq(fullLp.balance, balanceBefore, "both buckets: no transfer when slash already zeroed collateral");
+        assertEq(collateralManagement.getResignationBlock(fullLp), 0);
     }
 
     function test_WithdrawCollateral_RevertsWithInvalidAddressWhenRecipientIsZeroAddress()

--- a/test/integration/FlyoverDiscovery.t.sol
+++ b/test/integration/FlyoverDiscovery.t.sol
@@ -567,6 +567,7 @@ contract FlyoverDiscoveryIntegrationTest is Test {
         setupProviders();
 
         address lp = pegOutLp;
+        uint originalProviderId = discovery.getProvider(lp).id;
 
         vm.prank(lp);
         collateralManagement.resign();
@@ -595,13 +596,15 @@ contract FlyoverDiscoveryIntegrationTest is Test {
         assertEq(collateralManagement.getPegOutCollateral(lp), 0);
 
         vm.prank(lp, lp);
-        discovery.register{value: MIN_COLLATERAL}(
+        uint reregisteredId = discovery.register{value: MIN_COLLATERAL}(
             "PegOut Provider Again",
             "lp2.com",
             true,
             Flyover.ProviderType.PegOut
         );
 
+        assertEq(reregisteredId, originalProviderId);
+        assertEq(discovery.getProvider(lp).id, originalProviderId);
         assertTrue(
             collateralManagement.isRegistered(Flyover.ProviderType.PegOut, lp)
         );

--- a/test/integration/FlyoverDiscovery.t.sol
+++ b/test/integration/FlyoverDiscovery.t.sol
@@ -532,6 +532,85 @@ contract FlyoverDiscoveryIntegrationTest is Test {
         assertFalse(discovery.isOperational(Flyover.ProviderType.PegIn, lp));
     }
 
+    function getEmptyPegOutQuote()
+        internal
+        view
+        returns (Quotes.PegOutQuote memory)
+    {
+        bytes memory testAddress = new bytes(20);
+
+        return
+            Quotes.PegOutQuote({
+                chainId: block.chainid,
+                callFee: 0,
+                penaltyFee: 0,
+                value: 0,
+                gasFee: 0,
+                lbcAddress: ZERO_ADDRESS,
+                lpRskAddress: ZERO_ADDRESS,
+                rskRefundAddress: ZERO_ADDRESS,
+                nonce: 0,
+                agreementTimestamp: 0,
+                depositDateLimit: 0,
+                transferTime: 0,
+                expireDate: 0,
+                expireBlock: 0,
+                depositConfirmations: 0,
+                transferConfirmations: 0,
+                depositAddress: testAddress,
+                btcRefundAddress: testAddress,
+                lpBtcAddress: testAddress
+            });
+    }
+
+    function test_CanRegisterAgainAfterResignSlashAndZeroWithdraw() public {
+        setupProviders();
+
+        address lp = pegOutLp;
+
+        vm.prank(lp);
+        collateralManagement.resign();
+
+        Quotes.PegOutQuote memory pegOutQuote = getEmptyPegOutQuote();
+        pegOutQuote.penaltyFee = 300 ether;
+        pegOutQuote.lpRskAddress = lp;
+
+        vm.prank(owner);
+        collateralManagement.grantRole(
+            collateralManagement.COLLATERAL_SLASHER(),
+            owner
+        );
+        collateralManagement.slashPegOutCollateral(
+            owner,
+            pegOutQuote,
+            bytes32(uint256(1))
+        );
+
+        vm.roll(block.number + RESIGN_DELAY_BLOCKS);
+
+        vm.prank(lp);
+        collateralManagement.withdrawCollateral();
+
+        assertEq(collateralManagement.getResignationBlock(lp), 0);
+        assertEq(collateralManagement.getPegOutCollateral(lp), 0);
+
+        vm.prank(lp, lp);
+        discovery.register{value: MIN_COLLATERAL}(
+            "PegOut Provider Again",
+            "lp2.com",
+            true,
+            Flyover.ProviderType.PegOut
+        );
+
+        assertTrue(
+            collateralManagement.isRegistered(
+                Flyover.ProviderType.PegOut,
+                lp
+            )
+        );
+        assertTrue(discovery.isOperational(Flyover.ProviderType.PegOut, lp));
+    }
+
     function test_ShouldSupportReRegistrationWithDifferentProviderTypeAfterFullResignationAndWithdrawal()
         public
     {

--- a/test/integration/FlyoverDiscovery.t.sol
+++ b/test/integration/FlyoverDiscovery.t.sol
@@ -603,10 +603,7 @@ contract FlyoverDiscoveryIntegrationTest is Test {
         );
 
         assertTrue(
-            collateralManagement.isRegistered(
-                Flyover.ProviderType.PegOut,
-                lp
-            )
+            collateralManagement.isRegistered(Flyover.ProviderType.PegOut, lp)
         );
         assertTrue(discovery.isOperational(Flyover.ProviderType.PegOut, lp));
     }


### PR DESCRIPTION
## What

Fixes audit finding **F-57455** in `CollateralManagement._withdrawCollateralTo`: when a resigned LP’s combined peg-in + peg-out collateral is already zero after slashing, `withdrawCollateral()` after the resignation delay now clears `_resignationBlockNum` without revert or ETH transfer, allowing the address to call `FlyoverDiscovery.register` again.

Changes:
- `src/CollateralManagement.sol` — zero-collateral branch clears resignation flag and returns early
- `test/collateral/Resign.t.sol` — behavioral regression (replaces `NothingToWithdraw` expectation on zero-slash path)
- `test/integration/FlyoverDiscovery.t.sol` — resign → slash → zero withdraw → re-register integration

## Why

After `resign()` and a full public slash to zero collateral, the pre-fix implementation reverted `NothingToWithdraw` on `withdrawCollateral()` because `amount < 1`, so `_resignationBlockNum` never cleared and `register()` kept reverting `AlreadyRegistered`. That permanently locked the LP address out of the protocol.

## Type of Change

- [x] Bug fix (security / audit response)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation only

## Affected part

- `CollateralManagement` — private `_withdrawCollateralTo` (post-delay zero-collateral path only)
- Collateral / resignation tests and Flyover discovery integration tests
- No change to slash math, `resign()`, quote lifecycle, or public ABI

## Related Issues

- Audit finding **F-57455** (Medium) — `liquidity-bridge-contract-2.0.0 | V12` Autopilot run
- Flyover workflow artifacts: `f-57455-*` (intake through verification) on branch `fix/f-57455-zeroed-resignations`

## How to test

```bash
forge test --match-path test/collateral/Resign.t.sol
forge test --match-path test/integration/FlyoverDiscovery.t.sol
forge test --match-path test/deployment/UpgradeLBC.t.sol
forge test --match-path test/Pause.t.sol
forge test --match-path test/fuzz/collateral/CollateralResignWithdraw.fuzz.t.sol
forge test --match-path test/invariant/CollateralInvariant.t.sol
```

Key new tests:
- `test_WithdrawCollateral_ClearsResignationWhenCollateralZeroAfterSlash`
- `test_CanRegisterAgainAfterResignSlashAndZeroWithdraw`

Pre-deploy: run `optional/contract-deploy-fork-test` storage layout check vs `version-2.5.0-fixes` before implementation upgrade (WU4).

## Reviewer Guidelines

Please confirm:

1. **Zero branch only after delay** — `NotResigned` / `ResignationDelayNotMet` unchanged; non-zero withdraw path still transfers once and clears flag.
2. **No double-clear with funds** — `amount < 1` is the only entry to the early-return; mappings already zero from slash; no `call{value}` on zero branch.
3. **Pause posture** — `withdrawCollateral` remains callable while paused (existing behavior); acceptable for clearing LP lock state without moving quote escrow funds (see security impact note in workflow bundle).
4. **Upgrade safety** — no new storage variables; `UpgradeLBC.t.sol` passes; fork-test before mainnet deploy.
5. **No public ABI drift** — no new events/errors on external interfaces.

## Additional Notes

- Merge target: `version-2.5.0-fixes`
- Implementation upgrade (proxy) and `addresses.json` update are **out of scope** for this PR (WU4 / ops)
- Optional pre-deploy ops: mainnet inventory of stuck resigned+zero-collateral LPs (WU0 deferred)
- LPS/SDK: no code changes; release-note-only if needed after deploy