### PR TITLE
feat: declare release_request_rejected event in IBridge interface

### DIFF
--- a/src/interfaces/IBridge.sol
+++ b/src/interfaces/IBridge.sol
@@ -3,6 +3,12 @@ pragma solidity 0.8.25;
 
 interface IBridge {
 
+    event release_request_rejected(
+        address indexed sender,
+        uint256 amount,
+        int256 reason
+    );
+
     receive() external payable;
 
     function registerBtcTransaction(bytes calldata atx, int256 height, bytes calldata pmt) external;


### PR DESCRIPTION
event release_request_rejected(address,uint256,int256) was added to IBridge.sol interface to make consistency 