### PR TITLE
feat: remove penalization on late refund call for pegout

### DIFF
--- a/src/PegOutContract.sol
+++ b/src/PegOutContract.sol
@@ -369,7 +369,6 @@ contract PegOutContract is
     /// @notice This function is used to check if a liquidity provider should be penalized
     /// according to the following rules:
     /// - If the transfer was not made on time, the liquidity provider should be penalized
-    /// - If the liquidity provider is refunding after expiration, the liquidity provider should be penalized
     /// @param quote the peg out quote
     /// @param quoteHash the hash of the quote
     /// @param blockHash the hash of the block that contains the first confirmation of the peg out transaction

--- a/src/PegOutContract.sol
+++ b/src/PegOutContract.sol
@@ -392,11 +392,6 @@ contract PegOutContract is
             return true;
         }
 
-        // penalize if LP is refunding after expiration
-        if (block.timestamp > quote.expireDate || block.number > quote.expireBlock) {
-            return true;
-        }
-
         return false;
     }
 

--- a/test/pegout/LpRefund.t.sol
+++ b/test/pegout/LpRefund.t.sol
@@ -409,50 +409,6 @@ contract LpRefundTest is PegOutTestBase {
         );
     }
 
-    function test_RefundPegOut_PenalizesLPForBeingExpiredByTime() public {
-        Quotes.PegOutQuote memory quote = createAndDepositQuote();
-        bytes32 quoteHash = pegOutContract.hashPegOutQuote(quote);
-
-        // Warp to after expireDate
-        vm.warp(quote.expireDate + 1);
-
-        // Setup block header with late timestamp
-        bytes memory header = createBtcBlockHeader(
-            uint32(quote.expireDate + 1)
-        );
-        bridgeMock.setHeaderByHash(BLOCK_HEADER_HASH, header);
-        bridgeMock.setConfirmations(
-            int256(uint256(quote.transferConfirmations))
-        );
-
-        bytes memory btcTx = generateBtcTx(quote, quoteHash);
-
-        // Calculate expected penalty and reward
-        uint256 penalty = quote.penaltyFee;
-        uint256 reward = (penalty * TEST_REWARD_PERCENTAGE) / 10000;
-
-        // Refund should succeed but emit penalization
-        vm.prank(pegOutLp);
-        vm.expectEmit(true, false, false, true);
-        emit IPegOut.PegOutRefunded(quoteHash);
-        vm.expectEmit(true, true, true, true);
-        emit ICollateralManagement.Penalized(
-            pegOutLp,
-            pegOutLp,
-            quoteHash,
-            Flyover.ProviderType.PegOut,
-            penalty,
-            reward
-        );
-        pegOutContract.refundPegOut(
-            quoteHash,
-            btcTx,
-            BLOCK_HEADER_HASH,
-            PARTIAL_MERKLE_TREE,
-            merkleHashes
-        );
-    }
-
     function test_RefundPegOut_PenalizesLPForSendingBtcAfterExpectedFirstConfirmation()
         public
     {
@@ -478,6 +434,8 @@ contract LpRefundTest is PegOutTestBase {
         uint256 penalty = quote.penaltyFee;
         uint256 reward = (penalty * TEST_REWARD_PERCENTAGE) / 10000;
 
+        // assert to confirm time is late enough
+        assertTrue(quote.expireDate < lateTime);
         // Refund should succeed but emit penalization
         vm.prank(pegOutLp);
         vm.expectEmit(true, false, false, true);

--- a/test/pegout/LpRefund.t.sol
+++ b/test/pegout/LpRefund.t.sol
@@ -453,50 +453,6 @@ contract LpRefundTest is PegOutTestBase {
         );
     }
 
-    function test_RefundPegOut_PenalizesLPForBeingExpiredByBlocks() public {
-        Quotes.PegOutQuote memory quote = createAndDepositQuote();
-        bytes32 quoteHash = pegOutContract.hashPegOutQuote(quote);
-
-        // Mine past expireBlock
-        vm.roll(quote.expireBlock + 1);
-
-        // Setup block header
-        bytes memory header = createBtcBlockHeader(
-            uint32(block.timestamp + 100)
-        );
-        bridgeMock.setHeaderByHash(BLOCK_HEADER_HASH, header);
-        bridgeMock.setConfirmations(
-            int256(uint256(quote.transferConfirmations))
-        );
-
-        bytes memory btcTx = generateBtcTx(quote, quoteHash);
-
-        // Calculate expected penalty and reward
-        uint256 penalty = quote.penaltyFee;
-        uint256 reward = (penalty * TEST_REWARD_PERCENTAGE) / 10000;
-
-        // Refund should succeed but emit penalization
-        vm.prank(pegOutLp);
-        vm.expectEmit(true, false, false, true);
-        emit IPegOut.PegOutRefunded(quoteHash);
-        vm.expectEmit(true, true, true, true);
-        emit ICollateralManagement.Penalized(
-            pegOutLp,
-            pegOutLp,
-            quoteHash,
-            Flyover.ProviderType.PegOut,
-            penalty,
-            reward
-        );
-        pegOutContract.refundPegOut(
-            quoteHash,
-            btcTx,
-            BLOCK_HEADER_HASH,
-            PARTIAL_MERKLE_TREE,
-            merkleHashes
-        );
-    }
-
     function test_RefundPegOut_PenalizesLPForSendingBtcAfterExpectedFirstConfirmation()
         public
     {


### PR DESCRIPTION
## What
Remove penalization on late `refundPegout` call

## Why
There is enough incentive for the LP to call `refundPegout` and as long as the BTC is delivered on time the LP accomplished its part of the deal 

## Task
https://rsklabs.atlassian.net/browse/FLY-2327
