### PR TITLE
feat: validate btc prefix in hashPegInQuote

### DIFF
--- a/src/PegInContract.sol
+++ b/src/PegInContract.sol
@@ -542,10 +542,16 @@ contract PegInContract is
         ) {
             revert Flyover.NoContract(quote.contractAddress);
         }
-        if (quote.btcRefundAddress.length != _REFUND_ADDRESS_LENGTH) {
+        if (
+            quote.btcRefundAddress.length != _REFUND_ADDRESS_LENGTH ||
+            !_isValidBtcPrefix(quote.btcRefundAddress[0])
+        ) {
             revert InvalidRefundAddress(quote.btcRefundAddress);
         }
-        if (quote.liquidityProviderBtcAddress.length != _REFUND_ADDRESS_LENGTH) {
+        if (
+            quote.liquidityProviderBtcAddress.length != _REFUND_ADDRESS_LENGTH ||
+            !_isValidBtcPrefix(quote.liquidityProviderBtcAddress[0])
+        ) {
             revert InvalidRefundAddress(quote.liquidityProviderBtcAddress);
         }
         uint256 total = quote.value + quote.callFee + quote.gasFee;
@@ -555,6 +561,15 @@ contract PegInContract is
         if (type(uint32).max < uint64(quote.agreementTimestamp) + uint64(quote.timeForDeposit)) {
             revert Flyover.Overflow(type(uint32).max);
         }
+    }
+
+    /// @notice This function is used to check if the prefix of a btc address is valid
+    /// @param prefix The prefix of the address
+    /// @return isValid Whether the prefix is valid or not
+    function _isValidBtcPrefix(bytes1 prefix) private view returns (bool) {
+        return block.chainid == 30 ?
+            prefix == 0x00 || prefix == 0x05 : // p2pkh and p2sh mainnet
+            prefix == 0x6f || prefix == 0xc4; // p2pkh and p2sh testnet
     }
 
     /// @notice This function is used to determine if the liquidity provider should be penalized

--- a/src/PegInContract.sol
+++ b/src/PegInContract.sol
@@ -567,7 +567,7 @@ contract PegInContract is
     /// @param prefix The prefix of the address
     /// @return isValid Whether the prefix is valid or not
     function _isValidBtcPrefix(bytes1 prefix) private view returns (bool) {
-        return block.chainid == 30 ?
+        return _mainnet ?
             prefix == 0x00 || prefix == 0x05 : // p2pkh and p2sh mainnet
             prefix == 0x6f || prefix == 0xc4; // p2pkh and p2sh testnet
     }

--- a/test/collateral/Slashing.t.sol
+++ b/test/collateral/Slashing.t.sol
@@ -54,7 +54,8 @@ contract SlashingTest is CollateralTestBase {
         returns (Quotes.PegInQuote memory quote)
     {
         bytes memory emptyBytes = new bytes(0);
-        bytes memory testBtcAddress = new bytes(20);
+        bytes memory testBtcAddress = new bytes(21);
+        testBtcAddress[0] = 0x6f;
 
         quote.callFee = CALL_FEE;
         quote.penaltyFee = PENALTY_FEE;
@@ -74,7 +75,8 @@ contract SlashingTest is CollateralTestBase {
         view
         returns (Quotes.PegOutQuote memory quote)
     {
-        bytes memory testBtcAddress = new bytes(20);
+        bytes memory testBtcAddress = new bytes(21);
+        testBtcAddress[0] = 0x6f;
 
         quote.callFee = CALL_FEE;
         quote.penaltyFee = PENALTY_FEE;

--- a/test/collateral/Slashing.t.sol
+++ b/test/collateral/Slashing.t.sol
@@ -8,6 +8,7 @@ import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol"
 import {Flyover} from "../../src/libraries/Flyover.sol";
 import {Quotes} from "../../src/libraries/Quotes.sol";
 import {WalletMock} from "../../src/test-contracts/WalletMock.sol";
+import {P2PKH_ZERO_ADDRESS_TESTNET} from "../constants/btc.sol";
 
 contract SlashingTest is CollateralTestBase {
     address public punisher;
@@ -54,8 +55,7 @@ contract SlashingTest is CollateralTestBase {
         returns (Quotes.PegInQuote memory quote)
     {
         bytes memory emptyBytes = new bytes(0);
-        bytes memory testBtcAddress = new bytes(21);
-        testBtcAddress[0] = 0x6f;
+        bytes memory testBtcAddress = P2PKH_ZERO_ADDRESS_TESTNET;
 
         quote.callFee = CALL_FEE;
         quote.penaltyFee = PENALTY_FEE;

--- a/test/constants/btc.sol
+++ b/test/constants/btc.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+bytes constant P2PKH_ZERO_ADDRESS_TESTNET = hex"6f0000000000000000000000000000000000000000";

--- a/test/datasets/p2pkh.json
+++ b/test/datasets/p2pkh.json
@@ -1,0 +1,46 @@
+{
+  "testnet": [
+    {
+      "script": "0x76a914a278e6bc0735f7090f152d0d2a2af07e44d1480a88ac",
+      "address": "mvL2bVzGUeC9oqVyQWJ4PxQspFzKgjzAqe"
+    },
+    {
+      "script": "0x76a9143ef6b98133022d29b85961e44f16ca4af5a7ce1d88ac",
+      "address": "mmFskg7XSReFbTTq5C6PtJ2r2pEugqeyVW"
+    },
+    {
+      "script": "0x76a9143bd3f92e6a9f8509dab4b9d0b71d65f7bbfd20a188ac",
+      "address": "mkyJ6YFQyoTwpAtbHcNxpKnVEFUpRjgr76"
+    },
+    {
+      "script": "0x76a914eebde2e5b79139fe6e2fc209a90a2348abb4b19588ac",
+      "address": "n3HJbF1Ps5c9ZE3UvLyjGFDvyAfjzDEBkS"
+    },
+    {
+      "script": "0x76a914df42890907b79ae9a27d5a91cc20ebec0f1da38688ac",
+      "address": "n1sSgnWcHU8AeHTVFez9RQ8HxMdAVHJXui"
+    }
+  ],
+  "mainnet": [
+    {
+      "script": "0x76a91427c5e657972f8b4b2364de3f441cc6120490bfa488ac",
+      "address": "14dJRoKyj2i83uRbTUeKqhFMwvFZcpiXyn"
+    },
+    {
+      "script": "0x76a91423086a767de0143523e818d4273ddfe6d9e4bbcc88ac",
+      "address": "14CEjTd5ci3228J45GdnGeUKLSSeCWUQxK"
+    },
+    {
+      "script": "0x76a914e8cdb871958da45f245270076b72dc31f92804a488ac",
+      "address": "1NDxDDSHVHvSv48vd27NNHkXHYZjDdVLss"
+    },
+    {
+      "script": "0x76a91463ae2c72c675f4e0228fd8a7aa98eaa8376e50b288ac",
+      "address": "1A64YneE3sLtRc1HNGYUB766H2Wii5WFeB"
+    },
+    {
+      "script": "0x76a914fc879ddff8c7f83504f60331c4e0711d31d81d2388ac",
+      "address": "1Q2Fk9yNzQsAApxNovDeqdwiFga3em8W5J"
+    }
+  ]
+}

--- a/test/datasets/p2sh.json
+++ b/test/datasets/p2sh.json
@@ -1,0 +1,46 @@
+{
+  "testnet": [
+    {
+      "script": "0xa9146e4b5ae85d86e4db0e6e5db09f8c276328cdbf3f87",
+      "address": "2N3JQb9erL1SnAr3NTMrZiPQQ8dcjJp4idV"
+    },
+    {
+      "script": "0xa914a9974100aeee974a20cda9a2f545704a0ab54fdc87",
+      "address": "2N8hwP1WmJrFF5QWABn38y63uYLhnJYJYTF"
+    },
+    {
+      "script": "0xa914965e5ebe866f5d4a19b6c22db29c5906b590c59987",
+      "address": "2N6xJQ1PyGDr9Wk5te2zgTmyDQ93JAapsm7"
+    },
+    {
+      "script": "0xa9144e9f39ca4688ff102128ea4ccda34105324305b087",
+      "address": "2MzQwSSnBHWHqSAqtTVQ6v47XtaisrJa1Vc"
+    },
+    {
+      "script": "0xa9147e9f4da968bf799a43afc284045392032b46f8ea87",
+      "address": "2N4njy3ejXixQptACBXZKCoMdjbcqR6PNts"
+    }
+  ],
+  "mainnet": [
+    {
+      "script": "0xa9148370542411672a54b95ad6bd39f303b6c4ca629387",
+      "address": "3Dg11QYVGmwTohjt85GwkAJwK5AZqZQ1RT"
+    },
+    {
+      "script": "0xa9145a486554a77cdd17bdf7536829e02297f2510b3c87",
+      "address": "39vPTxYVwTSYpUJeExxkGoh393BXxtAX1q"
+    },
+    {
+      "script": "0xa91459a9a846a1518616cccd00af9607275f64413a5187",
+      "address": "39s7JcbG6pF9HzQpJ9N9WxNU5JGyqKoteG"
+    },
+    {
+      "script": "0xa9145249bdf2c131d43995cff42e8feee293f79297a887",
+      "address": "39C7fxSzEACPjM78Z7xdPxhf7mKxJwvfMJ"
+    },
+    {
+      "script": "0xa91442402a28dd61f2718a4b27ae72a4791d5bbdade787",
+      "address": "37jKPSmbEGwgfacCr2nayn1wTaqMAbA94Z"
+    }
+  ]
+}

--- a/test/datasets/p2tr.json
+++ b/test/datasets/p2tr.json
@@ -17,10 +17,6 @@
       "address": "tb1pnqdr56lugmtrcxtae8k9cfe7hve8986ud0daktljsh93wf8q7u4qhc2q3c"
     },
     {
-      "script": "0x5120ed2a8dca2d10ca8a07c036adc081053598b62b0dc2c9e3b904e93065831e55e8",
-      "address": "tb1pa54gmj3dzr9g5p7qx6kupqg9xkvtv2cdcty78wgyaycxtqc72h5qlqgz2c"
-    },
-    {
       "script": "0x51203fec64cc30a39ba1c07c8308b09c5ff8f6613e997ad7984277209df7db90c2bb",
       "address": "tb1p8lkxfnps5wd6rsrusvytp8zllrmxz05e0ttessnhyzwl0kusc2as4s72wz"
     }

--- a/test/datasets/p2tr.json
+++ b/test/datasets/p2tr.json
@@ -1,0 +1,50 @@
+{
+  "testnet": [
+    {
+      "script": "0x5120077b0a1b7ea3664a1e15a28b52e0bdb500da46174dbf3a95f2e56645753057db",
+      "address": "tb1pqaas5xm75dny58s452949c9ak5qd53shfkln490ju4ny2afs2ldsput844"
+    },
+    {
+      "script": "0x5120552ef34227abc1eee4d1b7cad85da7014a0174d6b9c740f9e2a547525b7350d7",
+      "address": "tb1p25h0xs3840q7aex3kl9dshd8q99qzaxkh8r5p70z54r4ykmn2rtsgcsj34"
+    },
+    {
+      "script": "0x5120f5d8e3ee60f8d61f253d3b85bb83cc6b7284a5b9e42b0fbc92d25d4a8a4dec74",
+      "address": "tb1p7hvw8mnqlrtp7ffa8wzmhq7vddegffdeus4sl0yj6fw54zjda36qhc5q8y"
+    },
+    {
+      "script": "0x5120981a3a6bfc46d63c197dc9ec5c273ebb32729f5c6bdbdb2ff285cb1724e0f72a",
+      "address": "tb1pnqdr56lugmtrcxtae8k9cfe7hve8986ud0daktljsh93wf8q7u4qhc2q3c"
+    },
+    {
+      "script": "0x5120ed2a8dca2d10ca8a07c036adc081053598b62b0dc2c9e3b904e93065831e55e8",
+      "address": "tb1pa54gmj3dzr9g5p7qx6kupqg9xkvtv2cdcty78wgyaycxtqc72h5qlqgz2c"
+    },
+    {
+      "script": "0x51203fec64cc30a39ba1c07c8308b09c5ff8f6613e997ad7984277209df7db90c2bb",
+      "address": "tb1p8lkxfnps5wd6rsrusvytp8zllrmxz05e0ttessnhyzwl0kusc2as4s72wz"
+    }
+  ],
+  "mainnet": [
+    {
+      "script": "0x5120a37c3903c8d0db6512e2b40b0dffa05e5a3ab73603ce8c9c4b7771e5412328f9",
+      "address": "bc1p5d7rjq7g6rdk2yhzks9smlaqtedr4dekq08ge8ztwac72sfr9rusxg3297"
+    },
+    {
+      "script": "0x512021d1565737ffe25283e1e988625911f0602bf5a5221ed0dccc95dbbb93c979d9",
+      "address": "bc1py8g4v4ehll399qlpaxyxykg37pszhad9yg0dphxvjhdmhy7f08vsn43s6p"
+    },
+    {
+      "script": "0x5120c3cb8ea59f47284b6cc42087547280718bd5085a48a3ffcb246b70517a7ea4ca",
+      "address": "bc1pc09cafvlgu5ykmxyyzr4gu5qwx9a2zz6fz3lljeyddc9z7n75n9qfz7ckr"
+    },
+    {
+      "script": "0x5120f56d12f9fa4e75378194b45e2a982069d1849fa120a658507c9585597e6ae452",
+      "address": "bc1p74k39706fe6n0qv5k30z4xpqd8gcf8apyzn9s5rujkz4jln2u3fqwwta94"
+    },
+    {
+      "script": "0x5120cad13b06ff3ab6d7d1a7aa1d9cbfbfb70410dd3221c98340b154d0c698e23f1f",
+      "address": "bc1petgnkphl82md05d84gwee0alkuzpphfjy8ycxs932ngvdx8z8u0s3dwj5t"
+    }
+  ]
+}

--- a/test/datasets/p2wpkh.json
+++ b/test/datasets/p2wpkh.json
@@ -1,0 +1,46 @@
+{
+  "testnet": [
+    {
+      "script": "0x001452b1b883a3f865144d34bbe360b6fd4adac494e0",
+      "address": "tb1q22cm3qarlpj3gnf5h03kpdhaftdvf98q58dp75"
+    },
+    {
+      "script": "0x0014977d48ab28e429a95a53e68c8496772e805e07c8",
+      "address": "tb1qja7532egus56jkjnu6xgf9nh96q9up7gq5473m"
+    },
+    {
+      "script": "0x0014e2236fe7d11674ec416dc55dc9da46e8413ee72b",
+      "address": "tb1qug3kle73ze6wcstdc4wunkjxapqnaeetprqjql"
+    },
+    {
+      "script": "0x0014d6b25f2201b2a31cafd655631a8b6a4e76c4d161",
+      "address": "tb1q66e97gspk233et7k24334zm2femvf5tpsq8ggm"
+    },
+    {
+      "script": "0x001492ff4f363ec63adde62fbb232b916b2a3050d5a0",
+      "address": "tb1qjtl57d37ccadme30hv3jhytt9gc9p4dq9zrz49"
+    }
+  ],
+  "mainnet": [
+    {
+      "script": "0x0014173fd310e9db2c7e9550ce0f03f1e6c01d833aa9",
+      "address": "bc1qzulaxy8fmvk8a92sec8s8u0xcqwcxw4fx037d8"
+    },
+    {
+      "script": "0x00143c0655b0b34548d3c3502e7334c3dbbaab266aac",
+      "address": "bc1q8sr9tv9ng4yd8s6s9eenfs7mh24jv64vnwzl0p"
+    },
+    {
+      "script": "0x0014a052249b6b346d3f48ee03b3a8c74bda1f3a7f61",
+      "address": "bc1q5pfzfxmtx3kn7j8wqwe6336tmg0n5lmpqss9kx"
+    },
+    {
+      "script": "0x00144028fd22bae29b3e77cfb45a40f343f1b91b2419",
+      "address": "bc1qgq506g46u2dnua70k3dypu6r7xu3kfqeee3c38"
+    },
+    {
+      "script": "0x0014b287402cb54ff84cde571ea79b75fd404dc9a147",
+      "address": "bc1qk2r5qt94fluyehjhr6neka0agpxung28pndjly"
+    }
+  ]
+}

--- a/test/datasets/p2wsh.json
+++ b/test/datasets/p2wsh.json
@@ -1,0 +1,46 @@
+{
+  "testnet": [
+    {
+      "script": "0x0020137b507ecd0c91b7196510d45086f71012ab71e50f9b28c404e20133bec8a6f8",
+      "address": "tb1qzda4qlkdpjgmwxt9zr29pphhzqf2ku09p7dj33qyugqn80kg5muq8x0wyv"
+    },
+    {
+      "script": "0x00204050b04b4713a0d178db600c6377b3f3709473da909f8488930206b63606f901",
+      "address": "tb1qgpgtqj68zwsdz7xmvqxxxaan7dcfgu76jz0cfzynqgrtvdsxlyqsf7dfz8"
+    },
+    {
+      "script": "0x0020b06bf361e5cc6b8c518e89e32aa868ee3830f9c30cdd2db3a26690a8e14468a2",
+      "address": "tb1qkp4lxc09e34cc5vw383j42rgacurp7wrpnwjmvazv6g23c2ydz3qx5tfhl"
+    },
+    {
+      "script": "0x002015f874c90ea77a0431e054b24ab678885181d71681e876eb3d497df9188ecf9e",
+      "address": "tb1qzhu8fjgw5aaqgv0q2jey4dnc3pgcr4cks858d6eaf97ljxywe70qwwsdku"
+    },
+    {
+      "script": "0x0020137b507ecd0c91b7196510d45086f71012ab71e50f9b28c404e20133bec8a6f8",
+      "address": "tb1qzda4qlkdpjgmwxt9zr29pphhzqf2ku09p7dj33qyugqn80kg5muq8x0wyv"
+    }
+  ],
+  "mainnet": [
+    {
+      "script": "0x0020bcf9b62d11c14d2503d2dace69daa1a5b76a292903ba63e0699d6e058c9a0432",
+      "address": "bc1qhnumvtg3c9xj2q7jmt8xnk4p5kmk52ffqwax8crfn4hqtry6qseq8vahua"
+    },
+    {
+      "script": "0x0020657d39bcbedeafc903ad76ac85d2f0b16efd5bcb401f4cec3f8ce71dc2dd3e12",
+      "address": "bc1qv47nn097m6hujqadw6kgt5hsk9h06k7tgq05empl3nn3mska8cfqpkjl36"
+    },
+    {
+      "script": "0x002091c20bbacc7db5752f7172c1cf1633959896eb4d675f517da16e324ac3b6a5e2",
+      "address": "bc1qj8pqhwkv0k6h2tm3wtqu793njkvfd66dva04zldpdcey4sak5h3qx3n8nz"
+    },
+    {
+      "script": "0x0020ced4beeb9629c691fbc55d5c9582a092c7132e5d2b1252122342f02e871e3ca3",
+      "address": "bc1qem2ta6uk98rfr779t4wftq4qjtr3xtja9vf9yy3rgtczapc78j3sxa6570"
+    },
+    {
+      "script": "0x0020e8b67904706c8d37801ef106277b6a8d5e483edce13e87d19cfd574ffd5fbb78",
+      "address": "bc1qazm8jprsdjxn0qq77yrzw7m2340ys0kuuylg05vul4t5ll2lhduquuhngw"
+    }
+  ]
+}

--- a/test/datasets/p2wsh.json
+++ b/test/datasets/p2wsh.json
@@ -17,8 +17,8 @@
       "address": "tb1qzhu8fjgw5aaqgv0q2jey4dnc3pgcr4cks858d6eaf97ljxywe70qwwsdku"
     },
     {
-      "script": "0x0020137b507ecd0c91b7196510d45086f71012ab71e50f9b28c404e20133bec8a6f8",
-      "address": "tb1qzda4qlkdpjgmwxt9zr29pphhzqf2ku09p7dj33qyugqn80kg5muq8x0wyv"
+      "script": "0x0020fe517401d2ec6692b6fe872e8fcbc05d18b4e74c32b3b86a1a02ef6a2bf17598",
+      "address": "tb1qleghgqwja3nf9dh7suhglj7qt5vtfe6vx2ems6s6qthk52l3wkvqaj73xh"
     }
   ],
   "mainnet": [

--- a/test/fuzz/collateral/CollateralFuzzTestBase.sol
+++ b/test/fuzz/collateral/CollateralFuzzTestBase.sol
@@ -8,6 +8,7 @@ import {PauseRegistry} from "../../../src/PauseRegistry.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {Flyover} from "../../../src/libraries/Flyover.sol";
 import {Quotes} from "../../../src/libraries/Quotes.sol";
+import {P2PKH_ZERO_ADDRESS_TESTNET} from "../../constants/btc.sol";
 import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
 
 /// @title Base contract for CollateralManagement fuzz tests
@@ -138,8 +139,7 @@ abstract contract CollateralFuzzTestBase is Test {
         uint256 penaltyFee
     ) internal pure returns (Quotes.PegInQuote memory quote) {
         bytes memory emptyBytes = new bytes(0);
-        bytes memory testBtcAddress = new bytes(21);
-        testBtcAddress[0] = 0x6f;
+        bytes memory testBtcAddress = P2PKH_ZERO_ADDRESS_TESTNET;
 
         quote.callFee = DEFAULT_CALL_FEE;
         quote.penaltyFee = penaltyFee;
@@ -156,8 +156,7 @@ abstract contract CollateralFuzzTestBase is Test {
         address liquidityProvider,
         uint256 penaltyFee
     ) internal pure returns (Quotes.PegOutQuote memory quote) {
-        bytes memory testBtcAddress = new bytes(21);
-        testBtcAddress[0] = 0x6f;
+        bytes memory testBtcAddress = P2PKH_ZERO_ADDRESS_TESTNET;
 
         quote.callFee = DEFAULT_CALL_FEE;
         quote.penaltyFee = penaltyFee;

--- a/test/fuzz/collateral/CollateralFuzzTestBase.sol
+++ b/test/fuzz/collateral/CollateralFuzzTestBase.sol
@@ -138,7 +138,8 @@ abstract contract CollateralFuzzTestBase is Test {
         uint256 penaltyFee
     ) internal pure returns (Quotes.PegInQuote memory quote) {
         bytes memory emptyBytes = new bytes(0);
-        bytes memory testBtcAddress = new bytes(20);
+        bytes memory testBtcAddress = new bytes(21);
+        testBtcAddress[0] = 0x6f;
 
         quote.callFee = DEFAULT_CALL_FEE;
         quote.penaltyFee = penaltyFee;
@@ -155,7 +156,8 @@ abstract contract CollateralFuzzTestBase is Test {
         address liquidityProvider,
         uint256 penaltyFee
     ) internal pure returns (Quotes.PegOutQuote memory quote) {
-        bytes memory testBtcAddress = new bytes(20);
+        bytes memory testBtcAddress = new bytes(21);
+        testBtcAddress[0] = 0x6f;
 
         quote.callFee = DEFAULT_CALL_FEE;
         quote.penaltyFee = penaltyFee;

--- a/test/fuzz/pegin/PegInFuzzTestBase.sol
+++ b/test/fuzz/pegin/PegInFuzzTestBase.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
+import {P2PKH_ZERO_ADDRESS_TESTNET} from "../../constants/btc.sol";
 import {PegInTestBase} from "../../pegin/PegInTestBase.sol";
 import {Quotes} from "../../../src/libraries/Quotes.sol";
 import {IPegIn} from "../../../src/interfaces/IPegIn.sol";
@@ -96,8 +97,7 @@ abstract contract PegInFuzzTestBase is PegInTestBase {
         address lp,
         bytes memory data
     ) internal view returns (Quotes.PegInQuote memory) {
-        bytes memory testBtcAddress = new bytes(21);
-        testBtcAddress[0] = 0x6f; // Testnet version byte
+        bytes memory testBtcAddress = P2PKH_ZERO_ADDRESS_TESTNET; // Testnet version byte
 
         return
             Quotes.PegInQuote({

--- a/test/fuzz/pegin/PegInHashPegInQuote.fuzz.t.sol
+++ b/test/fuzz/pegin/PegInHashPegInQuote.fuzz.t.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.25;
 
 import {PegInFuzzTestBase} from "./PegInFuzzTestBase.sol";
+import {PegInContract} from "../../../src/PegInContract.sol";
 import {BtcAddressDataset} from "../../helpers/BtcAddressDataset.sol";
 import {Quotes} from "../../../src/libraries/Quotes.sol";
 import {IPegIn} from "../../../src/interfaces/IPegIn.sol";
@@ -9,13 +10,16 @@ import {IPegIn} from "../../../src/interfaces/IPegIn.sol";
 /// @title PegIn hashPegInQuote BTC address fuzz tests
 /// @notice Verifies hashPegInQuote rejects non-P2PKH/P2SH BTC addresses using test/datasets fixtures
 contract PegInHashPegInQuoteFuzzTest is PegInFuzzTestBase, BtcAddressDataset {
+    PegInContract internal pegInContractMainnet;
+
     bytes[] internal invalidTestnetAddresses;
     bytes[] internal validTestnetAddresses;
     bytes[] internal validMainnetAddresses;
     bytes[] internal invalidMainnetAddresses;
 
     function setUp() public {
-        deployPegInContract();
+        pegInContract = deployPegInContract(false);
+        pegInContractMainnet = deployPegInContract(true);
         fuzzUser = makeAddr("user");
 
         invalidTestnetAddresses = loadInvalidTestnetQuoteAddresses();
@@ -70,13 +74,12 @@ contract PegInHashPegInQuoteFuzzTest is PegInFuzzTestBase, BtcAddressDataset {
         pegInContract.hashPegInQuote(quote);
     }
 
-    /// @notice Fuzz: P2WSH/P2TR addresses revert on mainnet (chainId 30); P2WPKH shares P2PKH prefix
+    /// @notice Fuzz: P2WSH/P2TR addresses revert on mainnet deployment; P2WPKH shares the P2PKH prefix
     function testFuzz_HashPegInQuote_RevertsOnInvalidBtcAddress_Mainnet(
         uint8 addressIndex,
         uint8 validAddressIndex,
         bool targetRefundAddress
     ) public {
-        vm.chainId(30);
         addressIndex = uint8(
             bound(addressIndex, 0, invalidMainnetAddresses.length - 1)
         );
@@ -87,8 +90,7 @@ contract PegInHashPegInQuoteFuzzTest is PegInFuzzTestBase, BtcAddressDataset {
         bytes memory invalidAddress = invalidMainnetAddresses[addressIndex];
         bytes memory validAddress = validMainnetAddresses[validAddressIndex];
 
-        Quotes.PegInQuote memory quote = createFuzzTestQuote(TEST_MIN_PEGIN);
-        quote.chainId = 30;
+        Quotes.PegInQuote memory quote = _createMainnetFuzzQuote();
         quote.btcRefundAddress = validAddress;
         quote.liquidityProviderBtcAddress = validAddress;
 
@@ -104,7 +106,7 @@ contract PegInHashPegInQuoteFuzzTest is PegInFuzzTestBase, BtcAddressDataset {
                 invalidAddress
             )
         );
-        pegInContract.hashPegInQuote(quote);
+        pegInContractMainnet.hashPegInQuote(quote);
     }
 
     /// @notice Fuzz: valid P2PKH/P2SH dataset addresses hash successfully on testnet
@@ -122,5 +124,14 @@ contract PegInHashPegInQuoteFuzzTest is PegInFuzzTestBase, BtcAddressDataset {
 
         bytes32 hash = pegInContract.hashPegInQuote(quote);
         assertTrue(hash != bytes32(0), "Valid address should produce a hash");
+    }
+
+    function _createMainnetFuzzQuote()
+        internal
+        view
+        returns (Quotes.PegInQuote memory quote)
+    {
+        quote = createFuzzTestQuote(TEST_MIN_PEGIN);
+        quote.lbcAddress = address(pegInContractMainnet);
     }
 }

--- a/test/fuzz/pegin/PegInHashPegInQuote.fuzz.t.sol
+++ b/test/fuzz/pegin/PegInHashPegInQuote.fuzz.t.sol
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {PegInFuzzTestBase} from "./PegInFuzzTestBase.sol";
+import {BtcAddressDataset} from "../../helpers/BtcAddressDataset.sol";
+import {Quotes} from "../../../src/libraries/Quotes.sol";
+import {IPegIn} from "../../../src/interfaces/IPegIn.sol";
+
+/// @title PegIn hashPegInQuote BTC address fuzz tests
+/// @notice Verifies hashPegInQuote rejects non-P2PKH/P2SH BTC addresses using test/datasets fixtures
+contract PegInHashPegInQuoteFuzzTest is PegInFuzzTestBase, BtcAddressDataset {
+    bytes[] internal invalidTestnetAddresses;
+    bytes[] internal validTestnetAddresses;
+    bytes[] internal validMainnetAddresses;
+    bytes[] internal invalidMainnetAddresses;
+
+    function setUp() public {
+        deployPegInContract();
+        fuzzUser = makeAddr("user");
+
+        invalidTestnetAddresses = loadInvalidTestnetQuoteAddresses();
+        validTestnetAddresses = loadValidTestnetQuoteAddresses();
+        validMainnetAddresses = loadValidMainnetQuoteAddresses();
+        invalidMainnetAddresses = loadInvalidMainnetQuoteAddresses();
+    }
+
+    /// @notice Fuzz: non-P2PKH/P2SH address on btcRefundAddress reverts on testnet
+    function testFuzz_HashPegInQuote_RevertsOnInvalidBtcRefundAddress_Testnet(
+        uint8 addressIndex
+    ) public {
+        addressIndex = uint8(
+            bound(addressIndex, 0, invalidTestnetAddresses.length - 1)
+        );
+
+        bytes memory invalidAddress = invalidTestnetAddresses[addressIndex];
+        assertInvalidTestnetScriptType(invalidAddress, addressIndex);
+
+        Quotes.PegInQuote memory quote = createFuzzTestQuote(TEST_MIN_PEGIN);
+        quote.btcRefundAddress = invalidAddress;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegIn.InvalidRefundAddress.selector,
+                invalidAddress
+            )
+        );
+        pegInContract.hashPegInQuote(quote);
+    }
+
+    /// @notice Fuzz: non-P2PKH/P2SH address on liquidityProviderBtcAddress reverts on testnet
+    function testFuzz_HashPegInQuote_RevertsOnInvalidLpBtcAddress_Testnet(
+        uint8 addressIndex
+    ) public {
+        addressIndex = uint8(
+            bound(addressIndex, 0, invalidTestnetAddresses.length - 1)
+        );
+
+        bytes memory invalidAddress = invalidTestnetAddresses[addressIndex];
+        assertInvalidTestnetScriptType(invalidAddress, addressIndex);
+
+        Quotes.PegInQuote memory quote = createFuzzTestQuote(TEST_MIN_PEGIN);
+        quote.liquidityProviderBtcAddress = invalidAddress;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegIn.InvalidRefundAddress.selector,
+                invalidAddress
+            )
+        );
+        pegInContract.hashPegInQuote(quote);
+    }
+
+    /// @notice Fuzz: P2WSH/P2TR addresses revert on mainnet (chainId 30); P2WPKH shares P2PKH prefix
+    function testFuzz_HashPegInQuote_RevertsOnInvalidBtcAddress_Mainnet(
+        uint8 addressIndex,
+        uint8 validAddressIndex,
+        bool targetRefundAddress
+    ) public {
+        vm.chainId(30);
+        addressIndex = uint8(
+            bound(addressIndex, 0, invalidMainnetAddresses.length - 1)
+        );
+        validAddressIndex = uint8(
+            bound(validAddressIndex, 0, validMainnetAddresses.length - 1)
+        );
+
+        bytes memory invalidAddress = invalidMainnetAddresses[addressIndex];
+        bytes memory validAddress = validMainnetAddresses[validAddressIndex];
+
+        Quotes.PegInQuote memory quote = createFuzzTestQuote(TEST_MIN_PEGIN);
+        quote.chainId = 30;
+        quote.btcRefundAddress = validAddress;
+        quote.liquidityProviderBtcAddress = validAddress;
+
+        if (targetRefundAddress) {
+            quote.btcRefundAddress = invalidAddress;
+        } else {
+            quote.liquidityProviderBtcAddress = invalidAddress;
+        }
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegIn.InvalidRefundAddress.selector,
+                invalidAddress
+            )
+        );
+        pegInContract.hashPegInQuote(quote);
+    }
+
+    /// @notice Fuzz: valid P2PKH/P2SH dataset addresses hash successfully on testnet
+    function testFuzz_HashPegInQuote_AcceptsValidP2pkhAndP2shAddresses_Testnet(
+        uint8 addressIndex
+    ) public view {
+        addressIndex = uint8(
+            bound(addressIndex, 0, validTestnetAddresses.length - 1)
+        );
+
+        Quotes.PegInQuote memory quote = createFuzzTestQuote(TEST_MIN_PEGIN);
+        bytes memory validAddress = validTestnetAddresses[addressIndex];
+        quote.btcRefundAddress = validAddress;
+        quote.liquidityProviderBtcAddress = validAddress;
+
+        bytes32 hash = pegInContract.hashPegInQuote(quote);
+        assertTrue(hash != bytes32(0), "Valid address should produce a hash");
+    }
+}

--- a/test/helpers/BtcAddressDataset.sol
+++ b/test/helpers/BtcAddressDataset.sol
@@ -80,7 +80,7 @@ abstract contract BtcAddressDataset is Test, BtcAddressParser {
             loadAddresses(BtcAddressType.P2PKH, BtcAddressType.P2SH, "testnet");
     }
 
-    /// @notice P2PKH/P2SH types accepted on mainnet (chainId 30)
+    /// @notice P2PKH/P2SH types accepted when PegIn is deployed with mainnet=true
     function loadValidMainnetQuoteAddresses()
         internal
         returns (bytes[] memory)

--- a/test/helpers/BtcAddressDataset.sol
+++ b/test/helpers/BtcAddressDataset.sol
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {Test} from "forge-std/Test.sol";
+import {BtcAddressParser} from "../../script/helpers/BtcAddressParser.sol";
+
+/// @title Helper for loading BTC addresses from test/datasets/*.json
+/// @dev Each dataset file has "testnet" and "mainnet" arrays of {script, address} entries.
+abstract contract BtcAddressDataset is Test, BtcAddressParser {
+    enum BtcAddressType {
+        P2PKH,
+        P2SH,
+        P2WPKH,
+        P2WSH,
+        P2TR
+    }
+
+    string internal constant DATASETS_DIR = "test/datasets/";
+    uint256 internal constant DATASET_ENTRY_COUNT = 5;
+
+    /// @notice Loads parsed addresses for a single script type and network
+    function loadAddresses(
+        BtcAddressType addrType,
+        string memory networkKey
+    ) internal returns (bytes[] memory addresses) {
+        return
+            parseDatasetAddresses(
+                loadDatasetAddressStrings(_datasetPath(addrType), networkKey)
+            );
+    }
+
+    /// @notice Loads and concatenates addresses for two script types
+    function loadAddresses(
+        BtcAddressType addrTypeA,
+        BtcAddressType addrTypeB,
+        string memory networkKey
+    ) internal returns (bytes[] memory addresses) {
+        return
+            concatAddressBytes(
+                loadAddresses(addrTypeA, networkKey),
+                loadAddresses(addrTypeB, networkKey)
+            );
+    }
+
+    /// @notice Loads and concatenates addresses for three script types
+    function loadAddresses(
+        BtcAddressType addrTypeA,
+        BtcAddressType addrTypeB,
+        BtcAddressType addrTypeC,
+        string memory networkKey
+    ) internal returns (bytes[] memory addresses) {
+        return
+            concatAddressBytes(
+                loadAddresses(addrTypeA, networkKey),
+                loadAddresses(addrTypeB, networkKey),
+                loadAddresses(addrTypeC, networkKey)
+            );
+    }
+
+    /// @notice Non-P2PKH/P2SH types that must revert on testnet quote hashing
+    function loadInvalidTestnetQuoteAddresses()
+        internal
+        returns (bytes[] memory)
+    {
+        return
+            loadAddresses(
+                BtcAddressType.P2WPKH,
+                BtcAddressType.P2WSH,
+                BtcAddressType.P2TR,
+                "testnet"
+            );
+    }
+
+    /// @notice P2PKH/P2SH types accepted on testnet
+    function loadValidTestnetQuoteAddresses()
+        internal
+        returns (bytes[] memory)
+    {
+        return
+            loadAddresses(BtcAddressType.P2PKH, BtcAddressType.P2SH, "testnet");
+    }
+
+    /// @notice P2PKH/P2SH types accepted on mainnet (chainId 30)
+    function loadValidMainnetQuoteAddresses()
+        internal
+        returns (bytes[] memory)
+    {
+        return
+            loadAddresses(BtcAddressType.P2PKH, BtcAddressType.P2SH, "mainnet");
+    }
+
+    /// @notice P2WSH/P2TR types that revert on mainnet; P2WPKH shares the P2PKH prefix so is not included
+    function loadInvalidMainnetQuoteAddresses()
+        internal
+        returns (bytes[] memory)
+    {
+        return
+            loadAddresses(
+                //BtcAddressType.P2WPKH,
+                BtcAddressType.P2WSH,
+                BtcAddressType.P2TR,
+                "mainnet"
+            );
+    }
+
+    /// @dev Flat index layout for loadInvalidTestnetQuoteAddresses: [0..4] p2wpkh, [5..9] p2wsh, [10..14] p2tr
+    function assertInvalidTestnetScriptType(
+        bytes memory addressBytes,
+        uint8 addressIndex
+    ) internal pure {
+        if (addressIndex < DATASET_ENTRY_COUNT) {
+            assertEq(addressBytes.length, 21, "expected P2WPKH length");
+            assertEq(addressBytes[0], bytes1(0x00), "expected P2WPKH prefix");
+        } else if (addressIndex < 2 * DATASET_ENTRY_COUNT) {
+            assertEq(addressBytes.length, 33, "expected P2WSH length");
+            assertEq(addressBytes[0], bytes1(0x00), "expected P2WSH prefix");
+        } else {
+            assertEq(addressBytes.length, 33, "expected P2TR length");
+            assertEq(addressBytes[0], bytes1(0x01), "expected P2TR prefix");
+        }
+    }
+
+    function _datasetPath(
+        BtcAddressType addrType
+    ) internal pure returns (string memory path) {
+        if (addrType == BtcAddressType.P2PKH) {
+            return string.concat(DATASETS_DIR, "p2pkh.json");
+        }
+        if (addrType == BtcAddressType.P2SH) {
+            return string.concat(DATASETS_DIR, "p2sh.json");
+        }
+        if (addrType == BtcAddressType.P2WPKH) {
+            return string.concat(DATASETS_DIR, "p2wpkh.json");
+        }
+        if (addrType == BtcAddressType.P2WSH) {
+            return string.concat(DATASETS_DIR, "p2wsh.json");
+        }
+        return string.concat(DATASETS_DIR, "p2tr.json");
+    }
+
+    function loadDatasetAddressStrings(
+        string memory path,
+        string memory networkKey
+    ) internal view returns (string[] memory addresses) {
+        string memory json = vm.readFile(path);
+        addresses = new string[](DATASET_ENTRY_COUNT);
+        for (uint256 i = 0; i < DATASET_ENTRY_COUNT; i++) {
+            string memory key = string(
+                abi.encodePacked(
+                    ".",
+                    networkKey,
+                    "[",
+                    vm.toString(i),
+                    "].address"
+                )
+            );
+            addresses[i] = vm.parseJsonString(json, key);
+        }
+    }
+
+    function parseDatasetAddresses(
+        string[] memory addressStrings
+    ) internal returns (bytes[] memory addresses) {
+        addresses = new bytes[](addressStrings.length);
+        for (uint256 i = 0; i < addressStrings.length; i++) {
+            addresses[i] = parseBtcAddress(addressStrings[i]);
+        }
+    }
+
+    function concatAddressBytes(
+        bytes[] memory a,
+        bytes[] memory b,
+        bytes[] memory c
+    ) internal pure returns (bytes[] memory combined) {
+        combined = new bytes[](a.length + b.length + c.length);
+        uint256 offset;
+        for (uint256 i = 0; i < a.length; i++) {
+            combined[offset++] = a[i];
+        }
+        for (uint256 i = 0; i < b.length; i++) {
+            combined[offset++] = b[i];
+        }
+        for (uint256 i = 0; i < c.length; i++) {
+            combined[offset++] = c[i];
+        }
+    }
+
+    function concatAddressBytes(
+        bytes[] memory a,
+        bytes[] memory b
+    ) internal pure returns (bytes[] memory combined) {
+        combined = new bytes[](a.length + b.length);
+        for (uint256 i = 0; i < a.length; i++) {
+            combined[i] = a[i];
+        }
+        for (uint256 i = 0; i < b.length; i++) {
+            combined[a.length + i] = b[i];
+        }
+    }
+}

--- a/test/pegin/CallForUser.t.sol
+++ b/test/pegin/CallForUser.t.sol
@@ -673,6 +673,7 @@ contract CallForUserTest is PegInTestBase {
         bytes memory data
     ) internal view returns (Quotes.PegInQuote memory) {
         bytes memory testBtcAddress = new bytes(21);
+        testBtcAddress[0] = 0x6f;
 
         return
             Quotes.PegInQuote({

--- a/test/pegin/CallForUser.t.sol
+++ b/test/pegin/CallForUser.t.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.25;
 
 import {PegInTestBase} from "./PegInTestBase.sol";
+import {P2PKH_ZERO_ADDRESS_TESTNET} from "../constants/btc.sol";
 import {IPegIn} from "../../src/interfaces/IPegIn.sol";
 import {Quotes} from "../../src/libraries/Quotes.sol";
 import {Flyover} from "../../src/libraries/Flyover.sol";
@@ -672,8 +673,7 @@ contract CallForUserTest is PegInTestBase {
         address lp,
         bytes memory data
     ) internal view returns (Quotes.PegInQuote memory) {
-        bytes memory testBtcAddress = new bytes(21);
-        testBtcAddress[0] = 0x6f;
+        bytes memory testBtcAddress = P2PKH_ZERO_ADDRESS_TESTNET;
 
         return
             Quotes.PegInQuote({

--- a/test/pegin/DerivationAddress.t.sol
+++ b/test/pegin/DerivationAddress.t.sol
@@ -69,7 +69,7 @@ contract DerivationAddressTest is Test {
     function test_HashPegInQuote_RevertsIfQuoteBelongsToOtherContract() public {
         PegInContract pegIn = deployPegInContract(true);
 
-        Quotes.PegInQuote memory quote = createTestQuote1(address(pegIn));
+        Quotes.PegInQuote memory quote = createTestQuote1(address(pegIn), true);
         quote.lbcAddress = address(0x123); // Wrong contract address
 
         vm.expectRevert(
@@ -83,10 +83,9 @@ contract DerivationAddressTest is Test {
     }
 
     function test_HashPegInQuote_IsDeterministic() public {
-        vm.chainId(30);
         PegInContract pegIn = deployPegInContract(true);
 
-        Quotes.PegInQuote memory quote = createTestQuote1(address(pegIn));
+        Quotes.PegInQuote memory quote = createTestQuote1(address(pegIn), true);
 
         bytes32 hash1 = pegIn.hashPegInQuote(quote);
         bytes32 hash2 = pegIn.hashPegInQuote(quote);
@@ -103,8 +102,8 @@ contract DerivationAddressTest is Test {
     function test_ValidatePegInDepositAddress_ValidatesMainnetAddresses()
         public
     {
+        // chainId 30 matches the fixtures used to derive MAINNET_DEPOSIT_ADDRESS_*
         vm.chainId(30);
-        // Deploy mainnet contract
         PegInContract pegInMainnet = deployPegInContract(true);
 
         // Verify it deployed to the expected address
@@ -116,7 +115,8 @@ contract DerivationAddressTest is Test {
 
         // Test Case 1: nonce 3635227228603468300
         Quotes.PegInQuote memory quote1 = createTestQuote1(
-            address(pegInMainnet)
+            address(pegInMainnet),
+            true
         );
         bool result1 = pegInMainnet.validatePegInDepositAddress(
             quote1,
@@ -126,7 +126,8 @@ contract DerivationAddressTest is Test {
 
         // Test Case 2: nonce 6080686644105603000
         Quotes.PegInQuote memory quote2 = createTestQuote2(
-            address(pegInMainnet)
+            address(pegInMainnet),
+            true
         );
         bool result2 = pegInMainnet.validatePegInDepositAddress(
             quote2,
@@ -136,7 +137,8 @@ contract DerivationAddressTest is Test {
 
         // Test Case 3: nonce 7756734892733337000
         Quotes.PegInQuote memory quote3 = createTestQuote3(
-            address(pegInMainnet)
+            address(pegInMainnet),
+            true
         );
         bool result3 = pegInMainnet.validatePegInDepositAddress(
             quote3,
@@ -160,7 +162,8 @@ contract DerivationAddressTest is Test {
 
         // Test Case 1: nonce 3635227228603468300
         Quotes.PegInQuote memory quote1 = createTestQuote1(
-            address(pegInTestnet)
+            address(pegInTestnet),
+            false
         );
         bool result1 = pegInTestnet.validatePegInDepositAddress(
             quote1,
@@ -170,7 +173,8 @@ contract DerivationAddressTest is Test {
 
         // Test Case 2: nonce 6080686644105603000
         Quotes.PegInQuote memory quote2 = createTestQuote2(
-            address(pegInTestnet)
+            address(pegInTestnet),
+            false
         );
         bool result2 = pegInTestnet.validatePegInDepositAddress(
             quote2,
@@ -180,7 +184,8 @@ contract DerivationAddressTest is Test {
 
         // Test Case 3: nonce 7756734892733337000
         Quotes.PegInQuote memory quote3 = createTestQuote3(
-            address(pegInTestnet)
+            address(pegInTestnet),
+            false
         );
         bool result3 = pegInTestnet.validatePegInDepositAddress(
             quote3,
@@ -286,7 +291,8 @@ contract DerivationAddressTest is Test {
 
     /// @notice Creates test quote 1 (nonce: 3635227228603468300)
     function createTestQuote1(
-        address lbcAddress
+        address lbcAddress,
+        bool mainnet
     ) internal view returns (Quotes.PegInQuote memory) {
         return
             Quotes.PegInQuote({
@@ -309,10 +315,10 @@ contract DerivationAddressTest is Test {
                 callTime: 7200,
                 depositConfirmations: 3,
                 callOnRegister: false,
-                btcRefundAddress: block.chainid == 30
+                btcRefundAddress: mainnet
                     ? BTC_REFUND_ADDRESS_MAINNET
                     : BTC_REFUND_ADDRESS_TESTNET,
-                liquidityProviderBtcAddress: block.chainid == 30
+                liquidityProviderBtcAddress: mainnet
                     ? LP_BTC_ADDRESS_MAINNET
                     : LP_BTC_ADDRESS_TESTNET,
                 data: new bytes(0)
@@ -321,7 +327,8 @@ contract DerivationAddressTest is Test {
 
     /// @notice Creates test quote 2 (nonce: 6080686644105603000)
     function createTestQuote2(
-        address lbcAddress
+        address lbcAddress,
+        bool mainnet
     ) internal view returns (Quotes.PegInQuote memory) {
         return
             Quotes.PegInQuote({
@@ -344,10 +351,10 @@ contract DerivationAddressTest is Test {
                 callTime: 10800,
                 depositConfirmations: 2,
                 callOnRegister: false,
-                btcRefundAddress: block.chainid == 30
+                btcRefundAddress: mainnet
                     ? BTC_REFUND_ADDRESS_MAINNET
                     : BTC_REFUND_ADDRESS_TESTNET,
-                liquidityProviderBtcAddress: block.chainid == 30
+                liquidityProviderBtcAddress: mainnet
                     ? LP_BTC_ADDRESS_MAINNET
                     : LP_BTC_ADDRESS_TESTNET,
                 data: new bytes(0)
@@ -356,7 +363,8 @@ contract DerivationAddressTest is Test {
 
     /// @notice Creates test quote 3 (nonce: 7756734892733337000)
     function createTestQuote3(
-        address lbcAddress
+        address lbcAddress,
+        bool mainnet
     ) internal view returns (Quotes.PegInQuote memory) {
         return
             Quotes.PegInQuote({
@@ -379,10 +387,10 @@ contract DerivationAddressTest is Test {
                 callTime: 10800,
                 depositConfirmations: 2,
                 callOnRegister: false,
-                btcRefundAddress: block.chainid == 30
+                btcRefundAddress: mainnet
                     ? BTC_REFUND_ADDRESS_MAINNET
                     : BTC_REFUND_ADDRESS_TESTNET,
-                liquidityProviderBtcAddress: block.chainid == 30
+                liquidityProviderBtcAddress: mainnet
                     ? LP_BTC_ADDRESS_MAINNET
                     : LP_BTC_ADDRESS_TESTNET,
                 data: new bytes(0)

--- a/test/pegin/DerivationAddress.t.sol
+++ b/test/pegin/DerivationAddress.t.sol
@@ -32,24 +32,28 @@ contract DerivationAddressTest is Test {
     // Shared BTC addresses for test quotes
     bytes20 constant FED_BTC_ADDRESS =
         bytes20(hex"a157fd1a536371656f3c19c2005199308a49bc9c");
-    bytes constant LP_BTC_ADDRESS =
+    bytes constant LP_BTC_ADDRESS_MAINNET =
         hex"00840098213fec4001cdc4a77cc3340f5bb83d9ed5";
-    bytes constant BTC_REFUND_ADDRESS =
+    bytes constant LP_BTC_ADDRESS_TESTNET =
+        hex"6f840098213fec4001cdc4a77cc3340f5bb83d9ed5";
+    bytes constant BTC_REFUND_ADDRESS_MAINNET =
         hex"000000000000000000000000000000000000000000";
+    bytes constant BTC_REFUND_ADDRESS_TESTNET =
+        hex"6f0000000000000000000000000000000000000000";
 
     // Deposit addresses (mainnet and testnet for each test case)
     bytes constant MAINNET_DEPOSIT_ADDRESS_1 =
-        hex"05a028a93b57d3ae056504de4ccedbe45349f728708f508621";
+        hex"0551e9a3af3e3ee3e82623092779c6bf2f6842bdfb265747e8";
     bytes constant TESTNET_DEPOSIT_ADDRESS_1 =
-        hex"c4a028a93b57d3ae056504de4ccedbe45349f72870077cc2a3";
+        hex"c4291a9564b48c8e6871ceaaae2673b7d47afbab75a97b1e54";
     bytes constant MAINNET_DEPOSIT_ADDRESS_2 =
-        hex"05f3d8cc0272674bf44b53d1a2c4012a35b8161dfec4f77bd2";
+        hex"0533a3241448538400b4126bda482a70ec99f9dba60130cdd1";
     bytes constant TESTNET_DEPOSIT_ADDRESS_2 =
-        hex"c4f3d8cc0272674bf44b53d1a2c4012a35b8161dfea43d7a4c";
+        hex"c4e224d91e0a8e31b9d814476ad4a23938ac16d23df79452b6";
     bytes constant MAINNET_DEPOSIT_ADDRESS_3 =
-        hex"0560478d263979f125a4b0fa58a0fc2238eca545ab2f3c1de5";
+        hex"05ed352bccc4344b145b6739593c65a1eaa673bcfc79808a91";
     bytes constant TESTNET_DEPOSIT_ADDRESS_3 =
-        hex"c460478d263979f125a4b0fa58a0fc2238eca545abe95f5e84";
+        hex"c450f741e356eb218b8b8fca751ad51c3bdd523f8bb058a8d5";
 
     address owner = address(1);
     PauseRegistry internal _pauseRegistry;
@@ -79,6 +83,7 @@ contract DerivationAddressTest is Test {
     }
 
     function test_HashPegInQuote_IsDeterministic() public {
+        vm.chainId(30);
         PegInContract pegIn = deployPegInContract(true);
 
         Quotes.PegInQuote memory quote = createTestQuote1(address(pegIn));
@@ -98,6 +103,7 @@ contract DerivationAddressTest is Test {
     function test_ValidatePegInDepositAddress_ValidatesMainnetAddresses()
         public
     {
+        vm.chainId(30);
         // Deploy mainnet contract
         PegInContract pegInMainnet = deployPegInContract(true);
 
@@ -303,8 +309,12 @@ contract DerivationAddressTest is Test {
                 callTime: 7200,
                 depositConfirmations: 3,
                 callOnRegister: false,
-                btcRefundAddress: BTC_REFUND_ADDRESS,
-                liquidityProviderBtcAddress: LP_BTC_ADDRESS,
+                btcRefundAddress: block.chainid == 30
+                    ? BTC_REFUND_ADDRESS_MAINNET
+                    : BTC_REFUND_ADDRESS_TESTNET,
+                liquidityProviderBtcAddress: block.chainid == 30
+                    ? LP_BTC_ADDRESS_MAINNET
+                    : LP_BTC_ADDRESS_TESTNET,
                 data: new bytes(0)
             });
     }
@@ -334,8 +344,12 @@ contract DerivationAddressTest is Test {
                 callTime: 10800,
                 depositConfirmations: 2,
                 callOnRegister: false,
-                btcRefundAddress: BTC_REFUND_ADDRESS,
-                liquidityProviderBtcAddress: LP_BTC_ADDRESS,
+                btcRefundAddress: block.chainid == 30
+                    ? BTC_REFUND_ADDRESS_MAINNET
+                    : BTC_REFUND_ADDRESS_TESTNET,
+                liquidityProviderBtcAddress: block.chainid == 30
+                    ? LP_BTC_ADDRESS_MAINNET
+                    : LP_BTC_ADDRESS_TESTNET,
                 data: new bytes(0)
             });
     }
@@ -365,8 +379,12 @@ contract DerivationAddressTest is Test {
                 callTime: 10800,
                 depositConfirmations: 2,
                 callOnRegister: false,
-                btcRefundAddress: BTC_REFUND_ADDRESS,
-                liquidityProviderBtcAddress: LP_BTC_ADDRESS,
+                btcRefundAddress: block.chainid == 30
+                    ? BTC_REFUND_ADDRESS_MAINNET
+                    : BTC_REFUND_ADDRESS_TESTNET,
+                liquidityProviderBtcAddress: block.chainid == 30
+                    ? LP_BTC_ADDRESS_MAINNET
+                    : LP_BTC_ADDRESS_TESTNET,
                 data: new bytes(0)
             });
     }

--- a/test/pegin/Hashing.t.sol
+++ b/test/pegin/Hashing.t.sol
@@ -342,6 +342,7 @@ contract HashingTest is PegInTestBase {
         returns (Quotes.PegInQuote memory)
     {
         bytes memory testBtcAddress = new bytes(21);
+        testBtcAddress[0] = 0x6f;
 
         return
             Quotes.PegInQuote({
@@ -375,6 +376,7 @@ contract HashingTest is PegInTestBase {
     {
         // This matches QUOTE_MOCK from the TypeScript test
         bytes memory testBtcAddress = new bytes(21);
+        testBtcAddress[0] = 0x6f;
 
         return
             Quotes.PegInQuote({
@@ -411,6 +413,7 @@ contract HashingTest is PegInTestBase {
         returns (Quotes.PegInQuote memory)
     {
         bytes memory testBtcAddress = new bytes(21);
+        testBtcAddress[0] = 0x6f;
 
         return
             Quotes.PegInQuote({
@@ -447,6 +450,7 @@ contract HashingTest is PegInTestBase {
         returns (Quotes.PegInQuote memory)
     {
         bytes memory testBtcAddress = new bytes(21);
+        testBtcAddress[0] = 0x6f;
 
         return
             Quotes.PegInQuote({

--- a/test/pegin/Hashing.t.sol
+++ b/test/pegin/Hashing.t.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.25;
 
 import {PegInTestBase} from "./PegInTestBase.sol";
+import {P2PKH_ZERO_ADDRESS_TESTNET} from "../constants/btc.sol";
 import {Quotes} from "../../src/libraries/Quotes.sol";
 import {Flyover} from "../../src/libraries/Flyover.sol";
 import {IPegIn} from "../../src/interfaces/IPegIn.sol";
@@ -341,8 +342,7 @@ contract HashingTest is PegInTestBase {
         internal
         returns (Quotes.PegInQuote memory)
     {
-        bytes memory testBtcAddress = new bytes(21);
-        testBtcAddress[0] = 0x6f;
+        bytes memory testBtcAddress = P2PKH_ZERO_ADDRESS_TESTNET;
 
         return
             Quotes.PegInQuote({
@@ -375,8 +375,7 @@ contract HashingTest is PegInTestBase {
         returns (Quotes.PegInQuote memory)
     {
         // This matches QUOTE_MOCK from the TypeScript test
-        bytes memory testBtcAddress = new bytes(21);
-        testBtcAddress[0] = 0x6f;
+        bytes memory testBtcAddress = P2PKH_ZERO_ADDRESS_TESTNET;
 
         return
             Quotes.PegInQuote({
@@ -412,8 +411,7 @@ contract HashingTest is PegInTestBase {
         view
         returns (Quotes.PegInQuote memory)
     {
-        bytes memory testBtcAddress = new bytes(21);
-        testBtcAddress[0] = 0x6f;
+        bytes memory testBtcAddress = P2PKH_ZERO_ADDRESS_TESTNET;
 
         return
             Quotes.PegInQuote({
@@ -449,8 +447,7 @@ contract HashingTest is PegInTestBase {
         view
         returns (Quotes.PegInQuote memory)
     {
-        bytes memory testBtcAddress = new bytes(21);
-        testBtcAddress[0] = 0x6f;
+        bytes memory testBtcAddress = P2PKH_ZERO_ADDRESS_TESTNET;
 
         return
             Quotes.PegInQuote({

--- a/test/pegin/PegInTestBase.sol
+++ b/test/pegin/PegInTestBase.sol
@@ -42,22 +42,18 @@ abstract contract PegInTestBase is Test {
 
     address constant ZERO_ADDRESS = address(0);
 
-    /// @notice Deploy PegInContract with all dependencies
+    /// @notice Deploy PegInContract with all dependencies (testnet BTC prefixes)
     function deployPegInContract() internal {
-        // Create owner
-        owner = makeAddr("owner");
-        vm.deal(owner, 100 ether);
+        pegInContract = deployPegInContract(false);
+    }
 
-        // Deploy CollateralManagement
-        deployCollateralManagement();
+    /// @notice Deploy PegInContract with all dependencies
+    /// @param mainnet When true, validates P2PKH/P2SH mainnet prefixes (0x00, 0x05)
+    function deployPegInContract(
+        bool mainnet
+    ) internal returns (PegInContract pegIn) {
+        _deployPegInDependencies();
 
-        // Deploy Discovery
-        deployDiscovery();
-
-        // Deploy BridgeMock
-        bridgeMock = new BridgeMock();
-
-        // Deploy PegInContract
         PegInContract implementation = new PegInContract();
 
         bytes memory initData = abi.encodeCall(
@@ -68,7 +64,7 @@ abstract contract PegInTestBase is Test {
                 TEST_DUST_THRESHOLD,
                 TEST_MIN_PEGIN,
                 address(collateralManagement),
-                false, // mainnet
+                mainnet,
                 pauseRegistry
             )
         );
@@ -77,13 +73,23 @@ abstract contract PegInTestBase is Test {
             address(implementation),
             initData
         );
-        pegInContract = PegInContract(payable(address(proxy)));
+        pegIn = PegInContract(payable(address(proxy)));
 
-        // Grant COLLATERAL_SLASHER role to PegInContract
         bytes32 slasherRole = collateralManagement.COLLATERAL_SLASHER();
-
         vm.prank(owner);
-        collateralManagement.grantRole(slasherRole, address(pegInContract));
+        collateralManagement.grantRole(slasherRole, address(pegIn));
+    }
+
+    function _deployPegInDependencies() internal {
+        if (address(collateralManagement) != address(0)) {
+            return;
+        }
+
+        owner = makeAddr("owner");
+        vm.deal(owner, 100 ether);
+        deployCollateralManagement();
+        deployDiscovery();
+        bridgeMock = new BridgeMock();
     }
 
     function deployCollateralManagement() internal {

--- a/test/pegin/RegisterPegIn.t.sol
+++ b/test/pegin/RegisterPegIn.t.sol
@@ -1187,6 +1187,7 @@ contract RegisterPegInTest is PegInTestBase {
         bytes20 fedBtcAddr = bytes20(
             hex"a157fd1a536371656f3c19c2005199308a49bc9c"
         );
+        vm.chainId(30);
         // "17kksixYkbHeLy9okV16kr4eAxVhFkRhP" (P2PKH mainnet) -> full decoded bytes
         bytes
             memory lpBtcAddr = hex"00840098213fec4001cdc4a77cc3340f5bb83d9ed5";
@@ -1460,6 +1461,7 @@ contract RegisterPegInTest is PegInTestBase {
         uint256 value
     ) internal view returns (Quotes.PegInQuote memory) {
         bytes memory testBtcAddress = new bytes(21);
+        testBtcAddress[0] = 0x6f;
 
         return
             Quotes.PegInQuote({

--- a/test/pegin/RegisterPegIn.t.sol
+++ b/test/pegin/RegisterPegIn.t.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.25;
 
 import {PegInTestBase} from "./PegInTestBase.sol";
+import {P2PKH_ZERO_ADDRESS_TESTNET} from "../constants/btc.sol";
 import {IPegIn} from "../../src/interfaces/IPegIn.sol";
 import {Quotes} from "../../src/libraries/Quotes.sol";
 import {Flyover} from "../../src/libraries/Flyover.sol";
@@ -1461,8 +1462,7 @@ contract RegisterPegInTest is PegInTestBase {
     function createTestQuote(
         uint256 value
     ) internal view returns (Quotes.PegInQuote memory) {
-        bytes memory testBtcAddress = new bytes(21);
-        testBtcAddress[0] = 0x6f;
+        bytes memory testBtcAddress = P2PKH_ZERO_ADDRESS_TESTNET;
 
         return
             Quotes.PegInQuote({

--- a/test/pegin/RegisterPegIn.t.sol
+++ b/test/pegin/RegisterPegIn.t.sol
@@ -1180,7 +1180,8 @@ contract RegisterPegInTest is PegInTestBase {
     function test_RegisterPegIn_RefundPegInWithWrongAmountWithoutPenalizingLP()
         public
     {
-        // Uses real mainnet transaction data to ensure compatibility with actual edge cases
+        // Uses real mainnet transaction data; redeploy with mainnet BTC prefix validation
+        pegInContract = deployPegInContract(true);
 
         // Decode BTC addresses from base58check format
         // "3LxPz39femVBL278mTiBvgzBNMVFqXssoH" (P2SH mainnet) -> slice(1) removes version byte


### PR DESCRIPTION
## What
- Validate prefix of the btc addresses in hashPegInQuote function
- Update the test to take into account the validation
- Add a fuzz test to validate different combinations of btc address types

## Why
so we don't rely only in the address length

## Task
https://rsklabs.atlassian.net/browse/FLY-2328