### PR TITLE
feat: add active provider index

### DIFF
--- a/addresses.json
+++ b/addresses.json
@@ -85,6 +85,10 @@
       "address": "0xd8D956312222D8AcaBb58569Cc960A93B1AA2F7A",
       "deployed": true
     },
+    "LiquidityBridgeContract": {
+      "address": "0xAA9cAf1e3967600578727F975F283446A3Da6612",
+      "deployed": true
+    },
     "FlyoverDiscovery": {
       "address": "0x9A48C6b18Aa000d0bd35D55616bCc98aD3553e7a",
       "deployed": true
@@ -117,6 +121,10 @@
     },
     "BtcUtils": {
       "address": "0x05a428AdCC86de5e4fdA9EEC0be7807455b4c2cC",
+      "deployed": true
+    },
+    "LiquidityBridgeContract": {
+      "address": "0xc2A630c053D12D63d32b025082f6Ba268db18300",
       "deployed": true
     },
     "FlyoverDiscovery": {

--- a/script/deployment/DeployCollateralManagement.s.sol
+++ b/script/deployment/DeployCollateralManagement.s.sol
@@ -71,6 +71,15 @@ contract DeployCollateralManagement is Script {
             collateralManagementProxy
         );
         result.admin = ProxyReader.readAdmin(vm, collateralManagementProxy);
+
+        address flyoverDiscoveryProxy = vm.envOr(
+            "FLYOVER_DISCOVERY_PROXY",
+            address(0)
+        );
+        if (flyoverDiscoveryProxy != address(0)) {
+            CollateralManagementContract(payable(collateralManagementProxy))
+                .initializeV2_1_0(flyoverDiscoveryProxy);
+        }
     }
 
     function _log(DeploymentResult memory r) private pure {

--- a/script/deployment/DeployFlyover.s.sol
+++ b/script/deployment/DeployFlyover.s.sol
@@ -72,6 +72,7 @@ contract DeployFlyover is Script {
             helper.getOptions()
         );
         _setupRoles(d);
+        _initializeV2_1_0(d);
 
         vm.stopBroadcast();
 
@@ -88,6 +89,7 @@ contract DeployFlyover is Script {
     ) external returns (FlyoverDeployment memory d) {
         d = _deployAll(defaultAdmin, cfg, opts);
         _setupRoles(d);
+        _initializeV2_1_0(d);
     }
 
     function _deployAll(
@@ -222,6 +224,16 @@ contract DeployFlyover is Script {
         cm.grantRole(adder, d.flyoverDiscoveryProxy);
         cm.grantRole(slasher, d.pegInProxy);
         cm.grantRole(slasher, d.pegOutProxy);
+    }
+
+    function _initializeV2_1_0(FlyoverDeployment memory d) private {
+        CollateralManagementContract cm = CollateralManagementContract(
+            payable(d.collateralManagementProxy)
+        );
+        FlyoverDiscovery discovery = FlyoverDiscovery(d.flyoverDiscoveryProxy);
+
+        cm.initializeV2_1_0(d.flyoverDiscoveryProxy);
+        discovery.initializeV2_1_0();
     }
 
     function _log(FlyoverDeployment memory d) private pure {

--- a/script/deployment/DeployFlyoverDiscovery.s.sol
+++ b/script/deployment/DeployFlyoverDiscovery.s.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.25;
 import {Script, console} from "lib/forge-std/src/Script.sol";
 import {HelperConfig} from "../HelperConfig.s.sol";
 import {ProxyReader} from "../helpers/ProxyReader.sol";
+import {CollateralManagementContract} from "../../src/CollateralManagement.sol";
 import {FlyoverDiscovery} from "../../src/FlyoverDiscovery.sol";
 import {PauseRegistry} from "../../src/PauseRegistry.sol";
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
@@ -79,6 +80,12 @@ contract DeployFlyoverDiscovery is Script {
             flyoverDiscoveryProxy
         );
         result.admin = ProxyReader.readAdmin(vm, flyoverDiscoveryProxy);
+
+        FlyoverDiscovery discovery = FlyoverDiscovery(flyoverDiscoveryProxy);
+        discovery.initializeV2_1_0();
+
+        CollateralManagementContract(payable(collateralManagementProxy))
+            .initializeV2_1_0(flyoverDiscoveryProxy);
     }
 
     function _log(DeploymentResult memory r) private pure {

--- a/src/CollateralManagement.sol
+++ b/src/CollateralManagement.sol
@@ -4,10 +4,11 @@ pragma solidity 0.8.25;
 import {
     AccessControlDefaultAdminRulesUpgradeable
 } from "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlDefaultAdminRulesUpgradeable.sol";
-import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {EmergencyPause} from "./EmergencyPause/EmergencyPause.sol";
 import {ICollateralManagement} from "./interfaces/ICollateralManagement.sol";
+import {IFlyoverDiscovery} from "./interfaces/IFlyoverDiscovery.sol";
 import {IPauseRegistry} from "./interfaces/IPauseRegistry.sol";
 import {Flyover} from "./libraries/Flyover.sol";
 import {Quotes} from "./libraries/Quotes.sol";
@@ -42,6 +43,13 @@ contract CollateralManagementContract is
     mapping(address => uint256) private _resignationBlockNum;
     mapping(address => uint256) private _rewards;
 
+    // v2.1.0
+    IFlyoverDiscovery private _flyoverDiscovery;
+
+    /// @notice Emitted when the FlyoverDiscovery address is set
+    /// @param oldFlyoverDiscovery The previous FlyoverDiscovery address
+    /// @param newFlyoverDiscovery The new FlyoverDiscovery address
+    event FlyoverDiscoverySet(address indexed oldFlyoverDiscovery, address indexed newFlyoverDiscovery);
     /// @notice Emitted when the minimum collateral is set
     /// @param oldMinCollateral The old minimum collateral
     /// @param newMinCollateral The new minimum collateral
@@ -131,6 +139,16 @@ contract CollateralManagementContract is
         _rewardPercentage = rewardPercentage;
     }
 
+    /// @notice Initializes the contract for v2.1.0
+    /// @param flyoverDiscovery The address of the FlyoverDiscovery contract
+    // solhint-disable-next-line comprehensive-interface,func-name-mixedcase
+    function initializeV2_1_0(
+        address flyoverDiscovery
+    ) external reinitializer(2) onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (address(flyoverDiscovery).code.length == 0) revert Flyover.NoContract(flyoverDiscovery);
+        _flyoverDiscovery = IFlyoverDiscovery(flyoverDiscovery);
+    }
+
     /// @notice Sets the minimum collateral required for a liquidity provider **per operation**
     /// @param minCollateral The new minimum collateral
     // solhint-disable-next-line comprehensive-interface
@@ -157,6 +175,13 @@ contract CollateralManagementContract is
         }
         emit RewardPercentageSet(_rewardPercentage, rewardPercentage);
         _rewardPercentage = rewardPercentage;
+    }
+
+    /// @inheritdoc ICollateralManagement
+    function setFlyoverDiscovery(address flyoverDiscovery) external onlyRole(DEFAULT_ADMIN_ROLE) override {
+        if (address(flyoverDiscovery).code.length == 0) revert Flyover.NoContract(flyoverDiscovery);
+        emit FlyoverDiscoverySet(address(_flyoverDiscovery), flyoverDiscovery);
+        _flyoverDiscovery = IFlyoverDiscovery(flyoverDiscovery);
     }
 
     /// @inheritdoc ICollateralManagement
@@ -327,6 +352,7 @@ contract CollateralManagementContract is
         uint256 amount = _pegOutCollateral[providerAddress] + _pegInCollateral[providerAddress];
         if (amount < 1) {
             _resignationBlockNum[providerAddress] = 0;
+            _notifyCollateralWithdrawal(providerAddress);
             return;
         }
         _pegOutCollateral[providerAddress] = 0;
@@ -336,6 +362,7 @@ contract CollateralManagementContract is
         emit WithdrawCollateral(providerAddress, to, amount);
         (bool success,) = to.call{value: amount}("");
         if (!success) revert WithdrawalFailed(to, amount);
+        _notifyCollateralWithdrawal(providerAddress);
     }
 
     /// @notice Adds peg in collateral to an account
@@ -356,6 +383,15 @@ contract CollateralManagementContract is
     function _addPegOutCollateralTo(address addr, uint256 amount) private {
         _pegOutCollateral[addr] += amount;
         emit ICollateralManagement.PegOutCollateralAdded(addr, amount);
+    }
+
+    /// @notice Notifies FlyoverDiscovery contract that a provider has withdrawn collateral
+    /// so that it can update the listing accordingly
+    /// @param providerAddress The address of the provider
+    function _notifyCollateralWithdrawal(address providerAddress) private {
+        if (address(_flyoverDiscovery) != address(0)) {
+            _flyoverDiscovery.removeProvider(providerAddress);
+        }
     }
 
     /// @notice Checks if an account is registered

--- a/src/CollateralManagement.sol
+++ b/src/CollateralManagement.sol
@@ -50,6 +50,9 @@ contract CollateralManagementContract is
     /// @param oldFlyoverDiscovery The previous FlyoverDiscovery address
     /// @param newFlyoverDiscovery The new FlyoverDiscovery address
     event FlyoverDiscoverySet(address indexed oldFlyoverDiscovery, address indexed newFlyoverDiscovery);
+    /// @notice Emitted when an error occurs while removing a provider from the FlyoverDiscovery contract
+    /// @param reason The error message
+    event FlyoverDiscoveryError(bytes reason);
     /// @notice Emitted when the minimum collateral is set
     /// @param oldMinCollateral The old minimum collateral
     /// @param newMinCollateral The new minimum collateral
@@ -146,6 +149,7 @@ contract CollateralManagementContract is
         address flyoverDiscovery
     ) external reinitializer(2) onlyRole(DEFAULT_ADMIN_ROLE) {
         if (address(flyoverDiscovery).code.length == 0) revert Flyover.NoContract(flyoverDiscovery);
+        emit FlyoverDiscoverySet(address(_flyoverDiscovery), flyoverDiscovery);
         _flyoverDiscovery = IFlyoverDiscovery(flyoverDiscovery);
     }
 
@@ -390,7 +394,12 @@ contract CollateralManagementContract is
     /// @param providerAddress The address of the provider
     function _notifyCollateralWithdrawal(address providerAddress) private {
         if (address(_flyoverDiscovery) != address(0)) {
-            _flyoverDiscovery.removeProvider(providerAddress);
+            // try / catch  is to avoid blocking the collateral withdrawal if the discovery is misconfigured
+            // solhint-disable-next-line no-empty-blocks
+            try _flyoverDiscovery.removeProvider(providerAddress) {} 
+            catch (bytes memory reason) {
+                emit FlyoverDiscoveryError(reason);
+            }
         }
     }
 

--- a/src/FlyoverDiscovery.sol
+++ b/src/FlyoverDiscovery.sol
@@ -42,9 +42,11 @@ contract FlyoverDiscovery is
     ICollateralManagement private _collateralManagement;
     uint public lastProviderId;
 
-    // v2.6.0
+    // v2.1.0
     mapping(address => PendingRegistration) private _pendingRegistrations;
     mapping(address => RegistrationState) private _registrationStates;
+    uint[] private _activeProviderIds;
+    mapping(uint => uint) private _activeProviderIndexPlusOne;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -72,6 +74,19 @@ contract FlyoverDiscovery is
         __AccessControlDefaultAdminRules_init(initialDelay, defaultAdmin);
         __EmergencyPause_init(pauseRegistry);
         _collateralManagement = ICollateralManagement(collateralManagement);
+    }
+
+    /// @notice Initializes the contract for v2.1.0
+    // solhint-disable-next-line comprehensive-interface,func-name-mixedcase
+    function initializeV2_1_0() external reinitializer(2) onlyRole(DEFAULT_ADMIN_ROLE) {
+        Flyover.LiquidityProvider storage lp;
+        for (uint i = 1; i < lastProviderId + 1; ++i) {
+            lp = _liquidityProviders[i];
+            if (_collateralManagement.isRegistered(lp.providerType, lp.providerAddress)) {
+                _addActiveProvider(i);
+                _registrationStates[lp.providerAddress] = RegistrationState.Approved;
+            }
+        }
     }
 
     /// @inheritdoc IFlyoverDiscovery
@@ -132,6 +147,7 @@ contract FlyoverDiscovery is
         delete _pendingRegistrations[providerAddress];
 
         emit RegistrationApproved(providerId, providerAddress, pending.collateralAmount);
+        _addActiveProvider(providerId);
         _addCollateral(pending.providerType, providerAddress, pending.collateralAmount);
     }
 
@@ -171,18 +187,29 @@ contract FlyoverDiscovery is
     }
 
     /// @inheritdoc IFlyoverDiscovery
+    function removeProvider(address providerAddress) external {
+        if (msg.sender != address(_collateralManagement)) revert NotAuthorized(msg.sender);
+
+        uint providerId = _providerIdByAddress[providerAddress];
+        if (providerId == 0) return;
+
+        _removeActiveProvider(providerId);
+    }
+
+    /// @inheritdoc IFlyoverDiscovery
     function getProviders() external view returns (Flyover.LiquidityProvider[] memory) {
         uint count = 0;
         Flyover.LiquidityProvider storage lp;
-        for (uint i = 1; i < lastProviderId + 1; ++i) {
-            if (_shouldBeListed(_liquidityProviders[i])) {
+        uint activeProvidersLength = _activeProviderIds.length;
+        for (uint i = 0; i < activeProvidersLength; ++i) {
+            if (_shouldBeListed(_liquidityProviders[_activeProviderIds[i]])) {
                 ++count;
             }
         }
         Flyover.LiquidityProvider[] memory providersToReturn = new Flyover.LiquidityProvider[](count);
         count = 0;
-        for (uint i = 1; i < lastProviderId + 1; ++i) {
-            lp = _liquidityProviders[i];
+        for (uint i = 0; i < activeProvidersLength; ++i) {
+            lp = _liquidityProviders[_activeProviderIds[i]];
             if (_shouldBeListed(lp)) {
                 providersToReturn[count] = lp;
                 ++count;
@@ -256,6 +283,32 @@ contract FlyoverDiscovery is
     function _refundCollateral(address payable providerAddress, uint256 amount) private {
         (bool success,) = providerAddress.call{value: amount}("");
         if (!success) revert Flyover.PaymentFailed(providerAddress, amount, hex"");
+    }
+
+    /// @notice Removes a provider id from the active discovery enumeration set
+    /// @param providerId The provider id to remove
+    function _removeActiveProvider(uint providerId) private {
+        uint activeProviderIndexPlusOne = _activeProviderIndexPlusOne[providerId];
+        if (activeProviderIndexPlusOne == 0) return;
+
+        uint activeProviderIndex = activeProviderIndexPlusOne - 1;
+        uint lastIndex = _activeProviderIds.length - 1;
+        if (activeProviderIndex != lastIndex) {
+            uint lastProviderIdInList = _activeProviderIds[lastIndex];
+            _activeProviderIds[activeProviderIndex] = lastProviderIdInList;
+            _activeProviderIndexPlusOne[lastProviderIdInList] = activeProviderIndexPlusOne;
+        }
+        _activeProviderIds.pop();
+        _activeProviderIndexPlusOne[providerId] = 0;
+    }
+
+     /// @notice Adds a provider id to the active discovery enumeration set
+    /// @param providerId The provider id to add
+    function _addActiveProvider(uint providerId) private {
+        if (_activeProviderIndexPlusOne[providerId] != 0) return;
+
+        _activeProviderIds.push(providerId);
+        _activeProviderIndexPlusOne[providerId] = _activeProviderIds.length;
     }
 
     function _checkAdminPendingRegistration(address providerAddress) private view {

--- a/src/FlyoverDiscovery.sol
+++ b/src/FlyoverDiscovery.sol
@@ -80,11 +80,15 @@ contract FlyoverDiscovery is
     // solhint-disable-next-line comprehensive-interface,func-name-mixedcase
     function initializeV2_1_0() external reinitializer(2) onlyRole(DEFAULT_ADMIN_ROLE) {
         Flyover.LiquidityProvider storage lp;
+        bool providerExists;
         for (uint i = 1; i < lastProviderId + 1; ++i) {
             lp = _liquidityProviders[i];
-            if (_collateralManagement.isRegistered(lp.providerType, lp.providerAddress)) {
-                _addActiveProvider(i);
+            providerExists = lp.providerAddress != address(0);
+            if (providerExists) {
                 _registrationStates[lp.providerAddress] = RegistrationState.Approved;
+            }
+            if (providerExists && _collateralManagement.isRegistered(lp.providerType, lp.providerAddress)) {
+                _addActiveProvider(i);
             }
         }
     }

--- a/src/interfaces/ICollateralManagement.sol
+++ b/src/interfaces/ICollateralManagement.sol
@@ -164,6 +164,10 @@ interface ICollateralManagement is IPausable {
     /// @notice Resigns a liquidity provider
     function resign() external;
 
+    /// @notice Sets the FlyoverDiscovery contract address
+    /// @param flyoverDiscovery The FlyoverDiscovery proxy address
+    function setFlyoverDiscovery(address flyoverDiscovery) external;
+
     /// @notice Gets the peg in collateral of an account
     /// @param addr The address of the account
     /// @return The amount of peg in collateral

--- a/src/interfaces/IFlyoverDiscovery.sol
+++ b/src/interfaces/IFlyoverDiscovery.sol
@@ -80,6 +80,11 @@ interface IFlyoverDiscovery is IPausable {
     /// @param status The new status value
     function setProviderStatus(uint providerId, bool status) external;
 
+    /// @notice Removes a provider from active discovery enumeration after full collateral withdrawal
+    /// @dev Intended to be called by the configured collateral-management contract; no-ops for unknown providers
+    /// @param providerAddress The LP address to remove from active enumeration
+    function removeProvider(address providerAddress) external;
+
     /// @notice Lists LPs that should be visible to users
     /// @dev A provider is listed if it has sufficient collateral for at least one side and `status` is true
     /// @return providersToReturn Array of LP records to display

--- a/src/test-contracts/CollateralManagementMock.sol
+++ b/src/test-contracts/CollateralManagementMock.sol
@@ -10,6 +10,8 @@ contract CollateralManagementMock is ICollateralManagement {
 
     uint256 private _balance;
 
+    event FlyoverDiscoverySet(address indexed oldFlyoverDiscovery, address indexed newFlyoverDiscovery);
+
     function addPegInCollateralTo(address) external payable {
         _balance += msg.value;
     }
@@ -52,6 +54,10 @@ contract CollateralManagementMock is ICollateralManagement {
 
     function resign() external {
         emit Resigned(address(0));
+    }
+
+    function setFlyoverDiscovery(address addr) external {
+        emit FlyoverDiscoverySet(address(0), addr);
     }
 
     function getRewards(address) external pure returns (uint256) {

--- a/test/Benchmark.t.sol
+++ b/test/Benchmark.t.sol
@@ -88,6 +88,8 @@ contract BenchmarkTest is Test {
         // Grant COLLATERAL_ADDER role
         bytes32 collateralAdder = collateralManagement.COLLATERAL_ADDER();
         collateralManagement.grantRole(collateralAdder, address(discovery));
+        collateralManagement.initializeV2_1_0(address(discovery));
+        discovery.initializeV2_1_0();
     }
 
     function test_RegisterAndFetchLPOfEachType() public {

--- a/test/deployment/DeployFlyover.t.sol
+++ b/test/deployment/DeployFlyover.t.sol
@@ -182,6 +182,11 @@ contract DeployFlyoverTest is Test {
         pegOutContract = PegOutContract(payable(proxy));
     }
 
+    function _initializeV2_1_0() internal {
+        collateralManagement.initializeV2_1_0(address(discovery));
+        discovery.initializeV2_1_0();
+    }
+
     function test_FullDeploymentFlow() public {
         console.log("\n=== TEST FULL FLYOVER DEPLOYMENT ===\n");
 
@@ -229,6 +234,7 @@ contract DeployFlyoverTest is Test {
 
         _deployAll(deployer, cfg);
         _assertAllProxyAdminsOwnedBy(deployer);
+        _initializeV2_1_0();
 
         bytes32 collateralAdderRole = collateralManagement.COLLATERAL_ADDER();
         bytes32 collateralSlasherRole = collateralManagement
@@ -365,6 +371,7 @@ contract DeployFlyoverTest is Test {
 
         _deployAll(deployer, cfg);
         _assertAllProxyAdminsOwnedBy(deployer);
+        _initializeV2_1_0();
 
         // Setup roles
         bytes32 collateralAdderRole = collateralManagement.COLLATERAL_ADDER();

--- a/test/deployment/DeployFlyoverDiscovery.t.sol
+++ b/test/deployment/DeployFlyoverDiscovery.t.sol
@@ -63,6 +63,12 @@ contract DeployFlyoverDiscoveryTest is Test {
         );
     }
 
+    function _initializeV2_1_0(address discoveryProxy) internal {
+        CollateralManagementContract(payable(collateralManagementProxy))
+            .initializeV2_1_0(discoveryProxy);
+        FlyoverDiscovery(discoveryProxy).initializeV2_1_0();
+    }
+
     function test_DeploymentFlow() public {
         console.log("\n=== TEST FLYOVER DISCOVERY DEPLOYMENT ===\n");
 
@@ -94,6 +100,8 @@ contract DeployFlyoverDiscoveryTest is Test {
         console.log("   Proxy deployed at:", address(proxy));
         address discoveryProxyAdmin = ProxyReader.readAdmin(vm, address(proxy));
         console.log("   ProxyAdmin:", discoveryProxyAdmin);
+
+        _initializeV2_1_0(address(proxy));
 
         console.log("\n4. Verifying deployment...");
         FlyoverDiscovery fd = FlyoverDiscovery(address(proxy));
@@ -154,6 +162,8 @@ contract DeployFlyoverDiscoveryTest is Test {
             )
         );
 
+        _initializeV2_1_0(proxy);
+
         address proxyAdminAddr = ProxyReader.readAdmin(vm, proxy);
         console.log("Deployment Result:");
         console.log("  Implementation:", impl);
@@ -198,6 +208,8 @@ contract DeployFlyoverDiscoveryTest is Test {
                 )
             )
         );
+
+        _initializeV2_1_0(fdProxy);
 
         CollateralManagementContract cm = CollateralManagementContract(
             payable(collateralManagementProxy)
@@ -245,6 +257,8 @@ contract DeployFlyoverDiscoveryTest is Test {
                 )
             )
         );
+
+        _initializeV2_1_0(proxy);
 
         FlyoverDiscovery fd = FlyoverDiscovery(proxy);
 

--- a/test/differential/DifferentialParity.diff.t.sol
+++ b/test/differential/DifferentialParity.diff.t.sol
@@ -473,7 +473,10 @@ contract DifferentialParityDiffTest is DifferentialBase {
         });
     }
 
-    function _btcAddress21() internal pure returns (bytes memory) {
+    function _btcAddress21() internal view returns (bytes memory) {
+        if (_getHarness().isMainnet) {
+            return hex"0000112233445566778899aabbccddeeff00112233";
+        }
         return hex"6f00112233445566778899aabbccddeeff00112233";
     }
 }

--- a/test/differential/base/DifferentialBase.sol
+++ b/test/differential/base/DifferentialBase.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.25;
 
 import {Test} from "forge-std/Test.sol";
 import {HelperConfig} from "../../../script/HelperConfig.s.sol";
+import {Options} from "openzeppelin-foundry-upgrades/Options.sol";
 import {DeployFlyover} from "../../../script/deployment/DeployFlyover.s.sol";
 import {IDifferentialAdapter} from "../adapters/IDifferentialAdapter.sol";
 import {CandidateAdapter} from "../adapters/CandidateAdapter.sol";
@@ -18,6 +19,7 @@ abstract contract DifferentialBase is Test {
 
     struct NetworkHarness {
         uint256 forkId;
+        bool isMainnet;
         address referenceTarget;
         address candidatePegInTarget;
         address candidatePegOutTarget;
@@ -53,6 +55,7 @@ abstract contract DifferentialBase is Test {
         harness.forkId = _createForkSafe(rpcUrl, pinBlock);
 
         vm.selectFork(harness.forkId);
+        harness.isMainnet = isMainnet;
 
         HelperConfig helper = new HelperConfig();
         HelperConfig.FlyoverConfig memory flyoverCfg = helper
@@ -119,6 +122,14 @@ abstract contract DifferentialBase is Test {
     function _resolveReference(
         string memory networkKey
     ) internal view returns (address) {
+        try vm.envAddress("DIFF_LBC_REFERENCE_ADDRESS") returns (
+            address envAddr
+        ) {
+            if (envAddr != address(0)) {
+                return envAddr;
+            }
+        } catch {}
+
         string memory addressesJson = vm.readFile("addresses.json");
         string memory key = string.concat(
             ".",
@@ -182,10 +193,12 @@ abstract contract DifferentialBase is Test {
         cfg.btcBlockTime = btcBlockTime;
 
         DeployFlyover deployer = new DeployFlyover();
+        Options memory opts = helper.getOptions();
+        opts.unsafeSkipAllChecks = true;
         DeployFlyover.FlyoverDeployment memory d = deployer.deployForTesting(
             address(deployer),
             cfg,
-            helper.getOptions()
+            opts
         );
         targets.pegIn = d.pegInProxy;
         targets.pegOut = d.pegOutProxy;

--- a/test/discovery/ActiveListing.t.sol
+++ b/test/discovery/ActiveListing.t.sol
@@ -1,0 +1,679 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {DiscoveryTestBase} from "./DiscoveryTestBase.sol";
+import {FlyoverDiscovery} from "../../src/FlyoverDiscovery.sol";
+import {CollateralManagementContract} from "../../src/CollateralManagement.sol";
+import {Flyover} from "../../src/libraries/Flyover.sol";
+import {IFlyoverDiscovery} from "../../src/interfaces/IFlyoverDiscovery.sol";
+import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
+import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+/// @title ActiveListingTest
+/// @notice Tests for FlyoverDiscovery v2.1.0 active-provider indexing, initialization, and upgrade migration
+contract ActiveListingTest is DiscoveryTestBase {
+    // ============ Helpers ============
+
+    function _registerAndApprove(
+        address lp,
+        string memory name,
+        Flyover.ProviderType providerType,
+        uint256 collateral
+    ) internal returns (uint256 providerId) {
+        vm.deal(lp, 100 ether);
+        vm.prank(lp, lp);
+        providerId = discovery.register{value: collateral}(
+            name,
+            "url",
+            true,
+            providerType
+        );
+        vm.prank(owner);
+        discovery.approveRegistration(lp);
+    }
+
+    function _inflateLastProviderId(uint256 count) internal {
+        for (uint256 i = 0; i < count; ++i) {
+            address lp = makeAddr(string.concat("sybil", vm.toString(i)));
+            vm.deal(lp, 100 ether);
+            vm.prank(lp, lp);
+            discovery.register{value: MIN_COLLATERAL}(
+                "Pending",
+                "url",
+                true,
+                Flyover.ProviderType.PegIn
+            );
+            vm.prank(lp);
+            discovery.withdrawRegisterRequest();
+        }
+    }
+
+    function _assertProvidersContain(address lp) internal view {
+        Flyover.LiquidityProvider[] memory providers = discovery.getProviders();
+        for (uint256 i = 0; i < providers.length; ++i) {
+            if (providers[i].providerAddress == lp) return;
+        }
+        revert("Provider not listed");
+    }
+
+    function _assertProvidersExclude(address lp) internal view {
+        Flyover.LiquidityProvider[] memory providers = discovery.getProviders();
+        for (uint256 i = 0; i < providers.length; ++i) {
+            if (providers[i].providerAddress == lp) {
+                revert("Provider should not be listed");
+            }
+        }
+    }
+
+    function _clearActiveIndexFor(address lp) internal {
+        vm.prank(address(collateralManagement));
+        discovery.removeProvider(lp);
+    }
+
+    function _initializeV2_1_0() internal {
+        vm.startPrank(owner);
+        collateralManagement.initializeV2_1_0(address(discovery));
+        discovery.initializeV2_1_0();
+        vm.stopPrank();
+    }
+
+    // ============ Functionality ============
+
+    function test_RemoveProvider_RevertsWhenCallerIsNotCollateralManagement()
+        public
+    {
+        deployDiscovery();
+        setupProviders();
+
+        vm.prank(pegInLp);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IFlyoverDiscovery.NotAuthorized.selector,
+                pegInLp
+            )
+        );
+        discovery.removeProvider(pegInLp);
+    }
+
+    function test_RemoveProvider_NoOpForZeroAndUnknownAddress() public {
+        deployDiscovery();
+        setupProviders();
+
+        assertEq(discovery.getProviders().length, 3);
+
+        vm.prank(address(collateralManagement));
+        discovery.removeProvider(address(0));
+
+        vm.prank(address(collateralManagement));
+        discovery.removeProvider(makeAddr("unknown"));
+
+        assertEq(discovery.getProviders().length, 3);
+    }
+
+    function test_RemoveProvider_IsIdempotent() public {
+        deployDiscovery();
+        setupProviders();
+
+        assertEq(discovery.getProviders().length, 3);
+
+        vm.startPrank(address(collateralManagement));
+        discovery.removeProvider(pegInLp);
+        discovery.removeProvider(pegInLp);
+        vm.stopPrank();
+
+        assertEq(discovery.getProviders().length, 2);
+    }
+
+    function test_ApproveRegistration_AddsProviderToActiveIndex() public {
+        deployDiscovery();
+        address lp = makeAddr("newLp");
+        vm.deal(lp, 100 ether);
+
+        vm.prank(lp, lp);
+        discovery.register{value: MIN_COLLATERAL}(
+            "Pending",
+            "url",
+            true,
+            Flyover.ProviderType.PegIn
+        );
+        assertEq(discovery.getProviders().length, 0);
+
+        vm.prank(owner);
+        discovery.approveRegistration(lp);
+
+        Flyover.LiquidityProvider[] memory providers = discovery.getProviders();
+        assertEq(providers.length, 1);
+        assertEq(providers[0].providerAddress, lp);
+    }
+
+    function test_ApproveRegistration_DoesNotDuplicateActiveIndexEntries()
+        public
+    {
+        deployDiscoveryWithoutV2_1_0();
+        vm.prank(owner);
+        collateralManagement.initializeV2_1_0(address(discovery));
+
+        address lp = makeAddr("singleLp");
+        _registerAndApprove(
+            lp,
+            "LP",
+            Flyover.ProviderType.PegIn,
+            MIN_COLLATERAL
+        );
+        assertEq(discovery.getProviders().length, 1);
+
+        _clearActiveIndexFor(lp);
+        assertEq(discovery.getProviders().length, 0);
+
+        vm.prank(owner);
+        discovery.initializeV2_1_0();
+
+        assertEq(discovery.getProviders().length, 1);
+        _assertProvidersContain(lp);
+    }
+
+    function test_WithdrawCollateral_RemovesProviderFromListing() public {
+        deployDiscovery();
+        setupProviders();
+
+        assertEq(discovery.getProviders().length, 3);
+
+        vm.prank(pegInLp);
+        collateralManagement.resign();
+        vm.roll(block.number + TEST_RESIGN_DELAY_BLOCKS);
+
+        vm.prank(pegInLp);
+        collateralManagement.withdrawCollateral();
+
+        _assertProvidersExclude(pegInLp);
+        assertEq(discovery.getProviders().length, 2);
+    }
+
+    function test_WithdrawAndReregister_RestoresProviderInListing() public {
+        deployDiscovery();
+        address lp = makeAddr("reregisterLp");
+        _registerAndApprove(
+            lp,
+            "LP",
+            Flyover.ProviderType.PegIn,
+            MIN_COLLATERAL
+        );
+
+        vm.prank(lp);
+        collateralManagement.resign();
+        vm.roll(block.number + TEST_RESIGN_DELAY_BLOCKS);
+        vm.prank(lp);
+        collateralManagement.withdrawCollateral();
+        _assertProvidersExclude(lp);
+
+        _registerAndApprove(
+            lp,
+            "LP",
+            Flyover.ProviderType.PegIn,
+            MIN_COLLATERAL
+        );
+        _assertProvidersContain(lp);
+    }
+
+    function test_DisabledProvider_ExcludedFromListingButRetainedInIndex()
+        public
+    {
+        deployDiscovery();
+        setupProviders();
+
+        vm.prank(pegInLp);
+        discovery.setProviderStatus(1, false);
+        _assertProvidersExclude(pegInLp);
+
+        vm.prank(pegInLp);
+        discovery.setProviderStatus(1, true);
+        _assertProvidersContain(pegInLp);
+    }
+
+    function test_ResignedProvider_ExcludedFromListingUntilWithdrawRemovesFromIndex()
+        public
+    {
+        deployDiscovery();
+        setupProviders();
+
+        assertEq(discovery.getProviders().length, 3);
+
+        vm.prank(pegInLp);
+        collateralManagement.resign();
+        _assertProvidersExclude(pegInLp);
+        assertEq(discovery.getProviders().length, 2);
+
+        vm.roll(block.number + TEST_RESIGN_DELAY_BLOCKS);
+        vm.prank(pegInLp);
+        collateralManagement.withdrawCollateral();
+        _assertProvidersExclude(pegInLp);
+        assertEq(discovery.getProviders().length, 2);
+    }
+
+    function test_WithdrawCollateral_SucceedsWhenFlyoverDiscoveryUnset()
+        public
+    {
+        deployDiscoveryWithoutV2_1_0();
+        address lp = makeAddr("unsetDiscoveryLp");
+        _registerAndApprove(
+            lp,
+            "LP",
+            Flyover.ProviderType.PegIn,
+            MIN_COLLATERAL
+        );
+        assertEq(discovery.getProviders().length, 1);
+
+        vm.prank(lp);
+        collateralManagement.resign();
+        vm.roll(block.number + TEST_RESIGN_DELAY_BLOCKS);
+
+        vm.prank(lp);
+        collateralManagement.withdrawCollateral();
+
+        _assertProvidersExclude(lp);
+    }
+
+    // ============ Initialization — FlyoverDiscovery ============
+
+    function test_InitializeV2_1_0_EmptyStateSucceeds() public {
+        deployDiscoveryWithoutV2_1_0();
+
+        vm.prank(owner);
+        discovery.initializeV2_1_0();
+
+        assertEq(discovery.getProviders().length, 0);
+    }
+
+    function test_InitializeV2_1_0_RevertsForNonAdmin() public {
+        deployDiscoveryWithoutV2_1_0();
+        address stranger = makeAddr("stranger");
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                stranger,
+                discovery.DEFAULT_ADMIN_ROLE()
+            )
+        );
+        vm.prank(stranger);
+        discovery.initializeV2_1_0();
+    }
+
+    function test_InitializeV2_1_0_CannotBeCalledTwice() public {
+        deployDiscoveryWithoutV2_1_0();
+
+        vm.startPrank(owner);
+        discovery.initializeV2_1_0();
+        vm.expectRevert(abi.encodeWithSignature("InvalidInitialization()"));
+        discovery.initializeV2_1_0();
+        vm.stopPrank();
+    }
+
+    function test_InitializeV2_1_0_BackfillsRegisteredProviders() public {
+        deployDiscoveryWithoutV2_1_0();
+        vm.prank(owner);
+        collateralManagement.initializeV2_1_0(address(discovery));
+
+        setupProviders();
+        for (uint256 i = 0; i < 3; ++i) {
+            address lp = i == 0 ? pegInLp : (i == 1 ? pegOutLp : fullLp);
+            _clearActiveIndexFor(lp);
+        }
+        assertEq(discovery.getProviders().length, 0);
+
+        vm.prank(owner);
+        discovery.initializeV2_1_0();
+
+        assertEq(discovery.getProviders().length, 3);
+    }
+
+    function test_InitializeV2_1_0_BackfillSetsApprovedRegistrationState()
+        public
+    {
+        deployDiscoveryWithoutV2_1_0();
+        vm.prank(owner);
+        collateralManagement.initializeV2_1_0(address(discovery));
+
+        address lp = makeAddr("backfillLp");
+        _registerAndApprove(
+            lp,
+            "LP",
+            Flyover.ProviderType.PegIn,
+            MIN_COLLATERAL
+        );
+        _clearActiveIndexFor(lp);
+
+        vm.prank(owner);
+        discovery.initializeV2_1_0();
+
+        assertEq(
+            uint256(discovery.getRegistrationState(lp)),
+            uint256(IFlyoverDiscovery.RegistrationState.Approved)
+        );
+        assertTrue(discovery.isOperational(Flyover.ProviderType.PegIn, lp));
+        Flyover.LiquidityProvider memory lpRecord = discovery.getProvider(lp);
+        assertEq(lpRecord.providerAddress, lp);
+    }
+
+    function test_InitializeV2_1_0_BackfillSkipsNonRegisteredProviders()
+        public
+    {
+        deployDiscoveryWithoutV2_1_0();
+        vm.prank(owner);
+        collateralManagement.initializeV2_1_0(address(discovery));
+
+        address pendingLp = makeAddr("pendingLp");
+        vm.deal(pendingLp, 100 ether);
+        vm.prank(pendingLp, pendingLp);
+        discovery.register{value: MIN_COLLATERAL}(
+            "Pending",
+            "url",
+            true,
+            Flyover.ProviderType.PegIn
+        );
+
+        address withdrawnLp = makeAddr("withdrawnLp");
+        _registerAndApprove(
+            withdrawnLp,
+            "Withdrawn",
+            Flyover.ProviderType.PegIn,
+            MIN_COLLATERAL
+        );
+        _clearActiveIndexFor(withdrawnLp);
+        vm.prank(withdrawnLp);
+        collateralManagement.resign();
+        vm.roll(block.number + TEST_RESIGN_DELAY_BLOCKS);
+        vm.prank(withdrawnLp);
+        collateralManagement.withdrawCollateral();
+
+        address resignedLp = makeAddr("resignedLp");
+        _registerAndApprove(
+            resignedLp,
+            "Resigned",
+            Flyover.ProviderType.PegIn,
+            MIN_COLLATERAL
+        );
+        _clearActiveIndexFor(resignedLp);
+        vm.prank(resignedLp);
+        collateralManagement.resign();
+
+        address keptLp = makeAddr("keptLp");
+        _registerAndApprove(
+            keptLp,
+            "Kept",
+            Flyover.ProviderType.PegIn,
+            MIN_COLLATERAL
+        );
+        _clearActiveIndexFor(keptLp);
+
+        vm.prank(owner);
+        discovery.initializeV2_1_0();
+
+        assertEq(discovery.getProviders().length, 1);
+        _assertProvidersContain(keptLp);
+    }
+
+    function test_InitializeV2_1_0_BackfillIgnoresInflatedLastProviderId()
+        public
+    {
+        deployDiscoveryWithoutV2_1_0();
+        vm.prank(owner);
+        collateralManagement.initializeV2_1_0(address(discovery));
+
+        _inflateLastProviderId(5);
+        address lp = makeAddr("realLp");
+        _registerAndApprove(
+            lp,
+            "Real",
+            Flyover.ProviderType.PegIn,
+            MIN_COLLATERAL
+        );
+        _clearActiveIndexFor(lp);
+
+        assertEq(discovery.getProvidersId(), 6);
+
+        vm.prank(owner);
+        discovery.initializeV2_1_0();
+
+        assertEq(discovery.getProviders().length, 1);
+        _assertProvidersContain(lp);
+    }
+
+    // ============ Initialization — CollateralManagement ============
+
+    function test_CollateralManagement_InitializeV2_1_0_WiresDiscoveryForWithdrawCallback()
+        public
+    {
+        deployDiscoveryWithoutV2_1_0();
+        address lp = makeAddr("wiredLp");
+        _registerAndApprove(
+            lp,
+            "LP",
+            Flyover.ProviderType.PegIn,
+            MIN_COLLATERAL
+        );
+
+        vm.prank(owner);
+        collateralManagement.initializeV2_1_0(address(discovery));
+
+        vm.prank(lp);
+        collateralManagement.resign();
+        vm.roll(block.number + TEST_RESIGN_DELAY_BLOCKS);
+        vm.prank(lp);
+        collateralManagement.withdrawCollateral();
+
+        _assertProvidersExclude(lp);
+    }
+
+    function test_CollateralManagement_InitializeV2_1_0_RevertsForNonAdmin()
+        public
+    {
+        deployDiscoveryWithoutV2_1_0();
+        address stranger = makeAddr("stranger");
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                stranger,
+                collateralManagement.DEFAULT_ADMIN_ROLE()
+            )
+        );
+        vm.prank(stranger);
+        collateralManagement.initializeV2_1_0(address(discovery));
+    }
+
+    function test_CollateralManagement_InitializeV2_1_0_RevertsForInvalidAddress()
+        public
+    {
+        deployDiscoveryWithoutV2_1_0();
+
+        vm.startPrank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(Flyover.NoContract.selector, address(0))
+        );
+        collateralManagement.initializeV2_1_0(address(0));
+
+        address eoa = makeAddr("eoa");
+        vm.expectRevert(
+            abi.encodeWithSelector(Flyover.NoContract.selector, eoa)
+        );
+        collateralManagement.initializeV2_1_0(eoa);
+        vm.stopPrank();
+    }
+
+    function test_CollateralManagement_InitializeV2_1_0_CannotBeCalledTwice()
+        public
+    {
+        deployDiscoveryWithoutV2_1_0();
+
+        vm.startPrank(owner);
+        collateralManagement.initializeV2_1_0(address(discovery));
+        vm.expectRevert(abi.encodeWithSignature("InvalidInitialization()"));
+        collateralManagement.initializeV2_1_0(address(discovery));
+        vm.stopPrank();
+    }
+
+    function test_CollateralManagement_SetFlyoverDiscovery_UpdatesPointer()
+        public
+    {
+        deployDiscoveryWithoutV2_1_0();
+        CollateralManagementContract cm = collateralManagement;
+        FlyoverDiscovery discoveryA = discovery;
+
+        FlyoverDiscovery discoveryImpl = new FlyoverDiscovery();
+        TransparentUpgradeableProxy discoveryBProxy = new TransparentUpgradeableProxy(
+                address(discoveryImpl),
+                owner,
+                abi.encodeCall(
+                    FlyoverDiscovery.initialize,
+                    (owner, uint48(INITIAL_DELAY), address(cm), pauseRegistry)
+                )
+            );
+        FlyoverDiscovery discoveryB = FlyoverDiscovery(
+            payable(address(discoveryBProxy))
+        );
+
+        vm.startPrank(owner);
+        cm.initializeV2_1_0(address(discoveryA));
+        discoveryA.initializeV2_1_0();
+        cm.grantRole(cm.COLLATERAL_ADDER(), address(discoveryB));
+        cm.setFlyoverDiscovery(address(discoveryB));
+        discoveryB.initializeV2_1_0();
+        vm.stopPrank();
+
+        address lp = makeAddr("pointerLp");
+        vm.deal(lp, 100 ether);
+        vm.prank(lp, lp);
+        discoveryB.register{value: MIN_COLLATERAL}(
+            "LP",
+            "url",
+            true,
+            Flyover.ProviderType.PegIn
+        );
+        vm.prank(owner);
+        discoveryB.approveRegistration(lp);
+        assertEq(discoveryB.getProviders().length, 1);
+
+        vm.prank(lp);
+        cm.resign();
+        vm.roll(block.number + TEST_RESIGN_DELAY_BLOCKS);
+        vm.prank(lp);
+        cm.withdrawCollateral();
+
+        Flyover.LiquidityProvider[] memory providers = discoveryB
+            .getProviders();
+        assertEq(providers.length, 0);
+    }
+
+    // ============ Upgrade ============
+
+    function test_Upgrade_PreMigrationListingEmptyWhenIndexCleared() public {
+        deployDiscoveryWithoutV2_1_0();
+        vm.prank(owner);
+        collateralManagement.initializeV2_1_0(address(discovery));
+
+        setupProviders();
+        for (uint256 i = 0; i < 3; ++i) {
+            address lp = i == 0 ? pegInLp : (i == 1 ? pegOutLp : fullLp);
+            _clearActiveIndexFor(lp);
+        }
+
+        assertTrue(
+            collateralManagement.isRegistered(
+                Flyover.ProviderType.PegIn,
+                pegInLp
+            )
+        );
+        assertEq(discovery.getProviders().length, 0);
+    }
+
+    function test_Upgrade_MigrationRestoresListing() public {
+        deployDiscoveryWithoutV2_1_0();
+        vm.prank(owner);
+        collateralManagement.initializeV2_1_0(address(discovery));
+
+        setupProviders();
+        for (uint256 i = 0; i < 3; ++i) {
+            address lp = i == 0 ? pegInLp : (i == 1 ? pegOutLp : fullLp);
+            _clearActiveIndexFor(lp);
+        }
+
+        upgradeDiscoveryContracts();
+
+        vm.prank(owner);
+        discovery.initializeV2_1_0();
+
+        assertEq(discovery.getProviders().length, 3);
+    }
+
+    function test_Upgrade_BackfilledProvidersAreOperational() public {
+        deployDiscoveryWithoutV2_1_0();
+        vm.prank(owner);
+        collateralManagement.initializeV2_1_0(address(discovery));
+
+        address lp = makeAddr("upgradeLp");
+        _registerAndApprove(
+            lp,
+            "LP",
+            Flyover.ProviderType.PegIn,
+            MIN_COLLATERAL
+        );
+        _clearActiveIndexFor(lp);
+
+        upgradeDiscoveryContracts();
+
+        vm.prank(owner);
+        discovery.initializeV2_1_0();
+
+        assertTrue(discovery.isOperational(Flyover.ProviderType.PegIn, lp));
+        assertEq(discovery.getProvider(lp).providerAddress, lp);
+    }
+
+    function test_Upgrade_WithdrawStillRemovesFromListingAfterMigration()
+        public
+    {
+        deployDiscoveryWithoutV2_1_0();
+        vm.prank(owner);
+        collateralManagement.initializeV2_1_0(address(discovery));
+
+        address lp = makeAddr("postUpgradeLp");
+        _registerAndApprove(
+            lp,
+            "LP",
+            Flyover.ProviderType.PegIn,
+            MIN_COLLATERAL
+        );
+        _clearActiveIndexFor(lp);
+
+        upgradeDiscoveryContracts();
+        vm.prank(owner);
+        discovery.initializeV2_1_0();
+        _assertProvidersContain(lp);
+
+        vm.prank(lp);
+        collateralManagement.resign();
+        vm.roll(block.number + TEST_RESIGN_DELAY_BLOCKS);
+        vm.prank(lp);
+        collateralManagement.withdrawCollateral();
+
+        _assertProvidersExclude(lp);
+    }
+
+    function test_Upgrade_WithoutMigrationInitializerLeavesListingEmpty()
+        public
+    {
+        deployDiscoveryWithoutV2_1_0();
+        vm.prank(owner);
+        collateralManagement.initializeV2_1_0(address(discovery));
+
+        setupProviders();
+        for (uint256 i = 0; i < 3; ++i) {
+            address lp = i == 0 ? pegInLp : (i == 1 ? pegOutLp : fullLp);
+            _clearActiveIndexFor(lp);
+        }
+
+        upgradeDiscoveryContracts();
+
+        assertEq(discovery.getProviders().length, 0);
+    }
+}

--- a/test/discovery/ActiveListing.t.sol
+++ b/test/discovery/ActiveListing.t.sol
@@ -273,6 +273,41 @@ contract ActiveListingTest is DiscoveryTestBase {
         _assertProvidersExclude(lp);
     }
 
+    function test_WithdrawCollateral_SucceedsWhenRemoveProviderReverts()
+        public
+    {
+        deployDiscovery();
+        address lp = makeAddr("revertCallbackLp");
+        _registerAndApprove(
+            lp,
+            "LP",
+            Flyover.ProviderType.PegIn,
+            MIN_COLLATERAL
+        );
+
+        RemoveProviderRevertMock brokenDiscovery = new RemoveProviderRevertMock();
+        vm.prank(owner);
+        collateralManagement.setFlyoverDiscovery(address(brokenDiscovery));
+
+        uint256 balanceBefore = lp.balance;
+
+        vm.prank(lp);
+        collateralManagement.resign();
+        vm.roll(block.number + TEST_RESIGN_DELAY_BLOCKS);
+
+        vm.expectEmit(true, true, false, true);
+        emit CollateralManagementContract.FlyoverDiscoveryError(
+            abi.encodeWithSelector(
+                RemoveProviderRevertMock.RemoveProviderFailed.selector
+            )
+        );
+        vm.prank(lp);
+        collateralManagement.withdrawCollateral();
+
+        assertEq(lp.balance, balanceBefore + MIN_COLLATERAL);
+        assertEq(collateralManagement.getPegInCollateral(lp), 0);
+    }
+
     // ============ Initialization — FlyoverDiscovery ============
 
     function test_InitializeV2_1_0_EmptyStateSucceeds() public {
@@ -411,6 +446,37 @@ contract ActiveListingTest is DiscoveryTestBase {
 
         assertEq(discovery.getProviders().length, 1);
         _assertProvidersContain(keptLp);
+
+        assertEq(
+            uint256(discovery.getRegistrationState(pendingLp)),
+            uint256(IFlyoverDiscovery.RegistrationState.Pending),
+            "pending-only slots must not be backfilled to Approved"
+        );
+
+        assertEq(
+            uint256(discovery.getRegistrationState(resignedLp)),
+            uint256(IFlyoverDiscovery.RegistrationState.Approved),
+            "resigned LPs with discovery records should be marked Approved"
+        );
+        assertEq(discovery.getProvider(resignedLp).providerAddress, resignedLp);
+        assertFalse(
+            discovery.isOperational(Flyover.ProviderType.PegIn, resignedLp)
+        );
+        _assertProvidersExclude(resignedLp);
+
+        assertEq(
+            uint256(discovery.getRegistrationState(withdrawnLp)),
+            uint256(IFlyoverDiscovery.RegistrationState.Approved),
+            "withdrawn LPs with discovery records should be marked Approved"
+        );
+        assertEq(
+            discovery.getProvider(withdrawnLp).providerAddress,
+            withdrawnLp
+        );
+        assertFalse(
+            discovery.isOperational(Flyover.ProviderType.PegIn, withdrawnLp)
+        );
+        _assertProvidersExclude(withdrawnLp);
     }
 
     function test_InitializeV2_1_0_BackfillIgnoresInflatedLastProviderId()
@@ -453,6 +519,11 @@ contract ActiveListingTest is DiscoveryTestBase {
             MIN_COLLATERAL
         );
 
+        vm.expectEmit(true, true, false, true);
+        emit CollateralManagementContract.FlyoverDiscoverySet(
+            address(0),
+            address(discovery)
+        );
         vm.prank(owner);
         collateralManagement.initializeV2_1_0(address(discovery));
 
@@ -537,6 +608,11 @@ contract ActiveListingTest is DiscoveryTestBase {
         cm.initializeV2_1_0(address(discoveryA));
         discoveryA.initializeV2_1_0();
         cm.grantRole(cm.COLLATERAL_ADDER(), address(discoveryB));
+        vm.expectEmit(true, true, false, true);
+        emit CollateralManagementContract.FlyoverDiscoverySet(
+            address(discoveryA),
+            address(discoveryB)
+        );
         cm.setFlyoverDiscovery(address(discoveryB));
         discoveryB.initializeV2_1_0();
         vm.stopPrank();
@@ -675,5 +751,14 @@ contract ActiveListingTest is DiscoveryTestBase {
         upgradeDiscoveryContracts();
 
         assertEq(discovery.getProviders().length, 0);
+    }
+}
+
+/// @dev Discovery stand-in that always reverts on removeProvider
+contract RemoveProviderRevertMock {
+    error RemoveProviderFailed();
+
+    function removeProvider(address) external pure {
+        revert RemoveProviderFailed();
     }
 }

--- a/test/discovery/DiscoveryTestBase.sol
+++ b/test/discovery/DiscoveryTestBase.sol
@@ -7,6 +7,9 @@ import {CollateralManagementContract} from "../../src/CollateralManagement.sol";
 import {ICollateralManagement} from "../../src/interfaces/ICollateralManagement.sol";
 import {PauseRegistry} from "../../src/PauseRegistry.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {TransparentUpgradeableProxy, ITransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import {ProxyReader} from "../../script/helpers/ProxyReader.sol";
 import {Flyover} from "../../src/libraries/Flyover.sol";
 import {IFlyoverDiscovery} from "../../src/interfaces/IFlyoverDiscovery.sol";
 
@@ -16,6 +19,7 @@ abstract contract DiscoveryTestBase is Test {
     PauseRegistry public pauseRegistry;
     FlyoverDiscovery public discovery;
     CollateralManagementContract public collateralManagement;
+    ProxyAdmin public proxyAdmin;
 
     address public owner;
     address public pegInLp;
@@ -127,6 +131,99 @@ abstract contract DiscoveryTestBase is Test {
         collateralManagement.grantRole(
             collateralManagement.COLLATERAL_ADDER(),
             address(discovery)
+        );
+        collateralManagement.initializeV2_1_0(address(discovery));
+        discovery.initializeV2_1_0();
+        vm.stopPrank();
+    }
+
+    /// @notice Deploy Discovery and CollateralManagement without v2.1.0 initialization (for migration tests)
+    /// @dev Uses TransparentUpgradeableProxy so implementations can be upgraded in tests
+    function deployDiscoveryWithoutV2_1_0() internal {
+        owner = makeAddr("owner");
+        vm.deal(owner, 100 ether);
+
+        PauseRegistry prImpl = new PauseRegistry();
+        TransparentUpgradeableProxy prProxy = new TransparentUpgradeableProxy(
+            address(prImpl),
+            owner,
+            abi.encodeCall(prImpl.initialize, (0, owner))
+        );
+        pauseRegistry = PauseRegistry(payable(address(prProxy)));
+
+        CollateralManagementContract cmImplementation = new CollateralManagementContract();
+        bytes memory cmInitData = abi.encodeCall(
+            CollateralManagementContract.initialize,
+            (
+                owner,
+                TEST_DEFAULT_ADMIN_DELAY,
+                TEST_MIN_COLLATERAL,
+                TEST_RESIGN_DELAY_BLOCKS,
+                TEST_REWARD_PERCENTAGE,
+                pauseRegistry
+            )
+        );
+        TransparentUpgradeableProxy cmProxy = new TransparentUpgradeableProxy(
+            address(cmImplementation),
+            owner,
+            cmInitData
+        );
+        collateralManagement = CollateralManagementContract(
+            payable(address(cmProxy))
+        );
+
+        FlyoverDiscovery discoveryImplementation = new FlyoverDiscovery();
+        bytes memory discoveryInitData = abi.encodeCall(
+            FlyoverDiscovery.initialize,
+            (
+                owner,
+                uint48(INITIAL_DELAY),
+                address(collateralManagement),
+                pauseRegistry
+            )
+        );
+        TransparentUpgradeableProxy discoveryProxy = new TransparentUpgradeableProxy(
+                address(discoveryImplementation),
+                owner,
+                discoveryInitData
+            );
+        discovery = FlyoverDiscovery(payable(address(discoveryProxy)));
+        proxyAdmin = ProxyAdmin(
+            ProxyReader.readAdmin(vm, address(discoveryProxy))
+        );
+
+        vm.startPrank(owner);
+        collateralManagement.grantRole(
+            collateralManagement.COLLATERAL_ADDER(),
+            owner
+        );
+        collateralManagement.grantRole(
+            collateralManagement.COLLATERAL_ADDER(),
+            address(discovery)
+        );
+        vm.stopPrank();
+    }
+
+    /// @notice Upgrade Discovery and CollateralManagement to fresh implementations
+    function upgradeDiscoveryContracts() internal {
+        address newDiscoveryImpl = address(new FlyoverDiscovery());
+        address newCmImpl = address(new CollateralManagementContract());
+        ProxyAdmin discoveryAdmin = ProxyAdmin(
+            ProxyReader.readAdmin(vm, address(discovery))
+        );
+        ProxyAdmin cmAdmin = ProxyAdmin(
+            ProxyReader.readAdmin(vm, address(collateralManagement))
+        );
+        vm.startPrank(owner);
+        discoveryAdmin.upgradeAndCall(
+            ITransparentUpgradeableProxy(address(discovery)),
+            newDiscoveryImpl,
+            ""
+        );
+        cmAdmin.upgradeAndCall(
+            ITransparentUpgradeableProxy(address(collateralManagement)),
+            newCmImpl,
+            ""
         );
         vm.stopPrank();
     }

--- a/test/discovery/ListingFilter.t.sol
+++ b/test/discovery/ListingFilter.t.sol
@@ -138,4 +138,72 @@ contract ListingFilterTest is DiscoveryTestBase {
         assertEq(providers[1].id, 2, "Provider 2 ID");
         assertEq(providers[2].id, 3, "Provider 3 ID");
     }
+
+    function test_ActiveIndex_ExcludesPendingRegistrations() public {
+        address lp = makeAddr("pendingLp");
+        vm.deal(lp, 100 ether);
+
+        vm.prank(lp, lp);
+        discovery.register{value: MIN_COLLATERAL}(
+            "Pending",
+            "url",
+            true,
+            Flyover.ProviderType.PegIn
+        );
+
+        assertEq(discovery.getProvidersId(), 1);
+        assertEq(discovery.getProviders().length, 0);
+    }
+
+    function test_ActiveIndex_RemovesProviderAfterCollateralWithdrawal()
+        public
+    {
+        setupProviders();
+
+        assertEq(discovery.getProviders().length, 3);
+
+        vm.prank(pegInLp);
+        collateralManagement.resign();
+
+        assertEq(discovery.getProviders().length, 2);
+
+        vm.roll(block.number + TEST_RESIGN_DELAY_BLOCKS);
+
+        vm.prank(pegInLp);
+        collateralManagement.withdrawCollateral();
+
+        assertEq(discovery.getProviders().length, 2);
+
+        Flyover.LiquidityProvider[] memory providers = discovery.getProviders();
+        assertEq(providers.length, 2);
+        assertTrue(
+            providers[0].id == 2 || providers[1].id == 2,
+            "pegOut provider should remain listed"
+        );
+        assertTrue(
+            providers[0].id == 3 || providers[1].id == 3,
+            "full provider should remain listed"
+        );
+    }
+
+    function test_GetProviders_DoesNotScanHistoricalProviderIds() public {
+        for (uint256 i = 0; i < 5; ++i) {
+            address lp = makeAddr(string.concat("sybil", vm.toString(i)));
+            vm.deal(lp, 100 ether);
+
+            vm.prank(lp, lp);
+            discovery.register{value: MIN_COLLATERAL}(
+                "Pending",
+                "url",
+                true,
+                Flyover.ProviderType.PegIn
+            );
+
+            vm.prank(lp);
+            discovery.withdrawRegisterRequest();
+        }
+
+        assertEq(discovery.getProvidersId(), 5);
+        assertEq(discovery.getProviders().length, 0);
+    }
 }

--- a/test/fuzz/discovery/DiscoveryActiveListing.fuzz.t.sol
+++ b/test/fuzz/discovery/DiscoveryActiveListing.fuzz.t.sol
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {DiscoveryFuzzTestBase} from "./DiscoveryFuzzTestBase.sol";
+import {Flyover} from "../../../src/libraries/Flyover.sol";
+
+/// @title FlyoverDiscovery Active Listing Fuzz Tests
+/// @notice Fuzz tests for v2.1.0 active-provider indexing and listing behavior
+contract DiscoveryActiveListingFuzzTest is DiscoveryFuzzTestBase {
+    function setUp() public {
+        deployDiscovery();
+        setupProviders();
+    }
+
+    function _isListed(address provider) internal view returns (bool) {
+        Flyover.LiquidityProvider[] memory providers = discovery.getProviders();
+        for (uint256 i = 0; i < providers.length; ++i) {
+            if (providers[i].providerAddress == provider) return true;
+        }
+        return false;
+    }
+
+    function _addressForProviderId(
+        uint256 providerId
+    ) internal view returns (address) {
+        if (providerId == 1) return pegInLp;
+        if (providerId == 2) return pegOutLp;
+        return fullLp;
+    }
+
+    /// @notice Sybil pending cycles inflate lastProviderId but not getProviders()
+    function testFuzz_GetProviders_IgnoresInflatedLastProviderId(
+        uint8 sybilCount
+    ) public {
+        sybilCount = uint8(bound(sybilCount, 0, 20));
+
+        for (uint8 i = 0; i < sybilCount; ++i) {
+            address lp = makeAddr(string.concat("sybil", vm.toString(i)));
+            vm.deal(lp, 100 ether);
+            vm.prank(lp, lp);
+            discovery.register{value: MIN_COLLATERAL}(
+                "Pending",
+                "url",
+                true,
+                Flyover.ProviderType.PegIn
+            );
+            vm.prank(lp);
+            discovery.withdrawRegisterRequest();
+        }
+
+        address realLp = makeAddr("realLp");
+        vm.deal(realLp, 100 ether);
+        vm.prank(realLp, realLp);
+        discovery.register{value: MIN_COLLATERAL}(
+            "Real",
+            "url",
+            true,
+            Flyover.ProviderType.PegIn
+        );
+        vm.prank(owner);
+        discovery.approveRegistration(realLp);
+
+        assertEq(discovery.getProvidersId(), 4 + uint256(sybilCount));
+        assertEq(discovery.getProviders().length, 4);
+        assertTrue(_isListed(realLp));
+    }
+
+    /// @notice Pending registrations never appear in getProviders()
+    function testFuzz_GetProviders_ExcludesPendingRegistrations(
+        uint8 providerTypeRaw,
+        uint256 extraCollateral
+    ) public {
+        Flyover.ProviderType providerType = getValidProviderType(
+            providerTypeRaw
+        );
+        extraCollateral = bound(extraCollateral, 0, 5 ether);
+        uint256 collateral = getRequiredCollateral(providerType) +
+            extraCollateral;
+
+        address lp = makeAddr("pendingLp");
+        vm.deal(lp, collateral + 1 ether);
+        vm.prank(lp, lp);
+        discovery.register{value: collateral}(
+            "Pending",
+            "url",
+            true,
+            providerType
+        );
+
+        assertFalse(_isListed(lp));
+    }
+
+    /// @notice Approved providers appear in listing iff status and collateral are sufficient
+    function testFuzz_ApproveRegistration_AddsToListing(
+        uint8 providerTypeRaw,
+        bool initialStatus,
+        uint256 extraCollateral
+    ) public {
+        Flyover.ProviderType providerType = getValidProviderType(
+            providerTypeRaw
+        );
+        extraCollateral = bound(extraCollateral, 0, 5 ether);
+        uint256 collateral = getRequiredCollateral(providerType) +
+            extraCollateral;
+
+        address lp = makeAddr("approvedLp");
+        vm.deal(lp, collateral + 1 ether);
+        vm.prank(lp, lp);
+        discovery.register{value: collateral}(
+            "Approved",
+            "url",
+            initialStatus,
+            providerType
+        );
+        vm.prank(owner);
+        discovery.approveRegistration(lp);
+
+        bool sufficient = collateralManagement.isCollateralSufficient(
+            providerType,
+            lp
+        );
+        assertEq(_isListed(lp), initialStatus && sufficient);
+    }
+
+    /// @notice Every listed provider satisfies _shouldBeListed
+    function testFuzz_GetProviders_EntriesSatisfyShouldBeListed(
+        uint8 disableCount,
+        uint256 newMinCollateral
+    ) public {
+        disableCount = uint8(bound(disableCount, 0, 3));
+        newMinCollateral = bound(newMinCollateral, 1, 2 ether);
+
+        if (disableCount >= 1) {
+            vm.prank(pegInLp);
+            discovery.setProviderStatus(1, false);
+        }
+        if (disableCount >= 2) {
+            vm.prank(pegOutLp);
+            discovery.setProviderStatus(2, false);
+        }
+        if (disableCount >= 3) {
+            vm.prank(fullLp);
+            discovery.setProviderStatus(3, false);
+        }
+
+        vm.prank(owner);
+        collateralManagement.setMinCollateral(newMinCollateral);
+
+        Flyover.LiquidityProvider[] memory providers = discovery.getProviders();
+        for (uint256 i = 0; i < providers.length; ++i) {
+            assertTrue(providers[i].status);
+            assertTrue(
+                collateralManagement.isCollateralSufficient(
+                    providers[i].providerType,
+                    providers[i].providerAddress
+                )
+            );
+        }
+    }
+
+    /// @notice getProviders never returns duplicate ids or addresses
+    function testFuzz_GetProviders_NoDuplicateProviderIds(
+        uint8 newProviders
+    ) public {
+        newProviders = uint8(bound(newProviders, 0, 10));
+
+        for (uint8 i = 0; i < newProviders; ++i) {
+            address provider = createFundedEOA(
+                string(abi.encodePacked("dupCheck_", vm.toString(i)))
+            );
+            registerProvider(
+                provider,
+                string(abi.encodePacked("P_", vm.toString(i))),
+                string(abi.encodePacked("url_", vm.toString(i))),
+                true,
+                Flyover.ProviderType.PegIn,
+                MIN_COLLATERAL
+            );
+        }
+
+        Flyover.LiquidityProvider[] memory providers = discovery.getProviders();
+        for (uint256 i = 0; i < providers.length; ++i) {
+            for (uint256 j = i + 1; j < providers.length; ++j) {
+                assertTrue(providers[i].id != providers[j].id);
+                assertTrue(
+                    providers[i].providerAddress != providers[j].providerAddress
+                );
+            }
+        }
+    }
+
+    /// @notice Full collateral withdrawal removes provider from listing
+    function testFuzz_WithdrawCollateral_RemovesFromListing(
+        uint256 providerId
+    ) public {
+        providerId = bound(providerId, 1, 3);
+        address lp = _addressForProviderId(providerId);
+
+        vm.prank(lp);
+        collateralManagement.resign();
+        vm.roll(block.number + TEST_RESIGN_DELAY_BLOCKS);
+        vm.prank(lp);
+        collateralManagement.withdrawCollateral();
+
+        assertFalse(_isListed(lp));
+    }
+
+    /// @notice Re-register after withdraw restores listing
+    function testFuzz_WithdrawAndReregister_RestoresListing(
+        uint256 providerId
+    ) public {
+        providerId = bound(providerId, 1, 3);
+        address lp = _addressForProviderId(providerId);
+
+        vm.prank(lp);
+        collateralManagement.resign();
+        vm.roll(block.number + TEST_RESIGN_DELAY_BLOCKS);
+        vm.prank(lp);
+        collateralManagement.withdrawCollateral();
+        assertFalse(_isListed(lp));
+
+        registerProvider(
+            lp,
+            "ReRegistered",
+            "url",
+            true,
+            Flyover.ProviderType.PegIn,
+            MIN_COLLATERAL
+        );
+        assertTrue(_isListed(lp));
+    }
+
+    /// @notice Raising min collateral only filters listing, never adds providers
+    function testFuzz_SetMinCollateral_FiltersListing(
+        uint256 newMinCollateral
+    ) public {
+        uint256 initialListed = discovery.getProviders().length;
+        newMinCollateral = bound(newMinCollateral, 1, 5 ether);
+
+        vm.prank(owner);
+        collateralManagement.setMinCollateral(newMinCollateral);
+
+        Flyover.LiquidityProvider[] memory providers = discovery.getProviders();
+        assertLe(providers.length, initialListed);
+
+        for (uint256 i = 0; i < providers.length; ++i) {
+            assertTrue(
+                collateralManagement.isCollateralSufficient(
+                    providers[i].providerType,
+                    providers[i].providerAddress
+                )
+            );
+        }
+    }
+
+    /// @notice Resign filters listing without changing lastProviderId
+    function testFuzz_Resign_FiltersListingWithoutRemovingIndex(
+        uint256 providerId
+    ) public {
+        providerId = bound(providerId, 1, 3);
+        address lp = _addressForProviderId(providerId);
+        uint256 lastIdBefore = discovery.getProvidersId();
+
+        vm.prank(lp);
+        collateralManagement.resign();
+
+        assertFalse(_isListed(lp));
+        assertEq(discovery.getProvidersId(), lastIdBefore);
+    }
+}

--- a/test/fuzz/discovery/DiscoveryFuzzTestBase.sol
+++ b/test/fuzz/discovery/DiscoveryFuzzTestBase.sol
@@ -113,6 +113,8 @@ abstract contract DiscoveryFuzzTestBase is Test {
             collateralManagement.COLLATERAL_ADDER(),
             address(discovery)
         );
+        collateralManagement.initializeV2_1_0(address(discovery));
+        discovery.initializeV2_1_0();
         vm.stopPrank();
     }
 

--- a/test/helpers/FlyoverTestBase.sol
+++ b/test/helpers/FlyoverTestBase.sol
@@ -195,6 +195,8 @@ abstract contract FlyoverTestBase is Test {
             collateralManagement.COLLATERAL_ADDER(),
             address(discovery)
         );
+        collateralManagement.initializeV2_1_0(address(discovery));
+        discovery.initializeV2_1_0();
         vm.stopPrank();
     }
 
@@ -388,6 +390,8 @@ abstract contract FlyoverTestBase is Test {
             collateralManagement.COLLATERAL_SLASHER(),
             address(pegOutContract)
         );
+        collateralManagement.initializeV2_1_0(address(discovery));
+        discovery.initializeV2_1_0();
         vm.stopPrank();
 
         // Initialize BTC mocks

--- a/test/integration/CollateralManagement.t.sol
+++ b/test/integration/CollateralManagement.t.sol
@@ -82,6 +82,8 @@ contract CollateralManagementIntegrationTest is Test {
             collateralManagement.COLLATERAL_ADDER(),
             address(discovery)
         );
+        collateralManagement.initializeV2_1_0(address(discovery));
+        discovery.initializeV2_1_0();
         collateralManagement.grantRole(
             collateralManagement.COLLATERAL_SLASHER(),
             owner

--- a/test/integration/FlyoverDiscovery.t.sol
+++ b/test/integration/FlyoverDiscovery.t.sol
@@ -115,6 +115,8 @@ contract FlyoverDiscoveryIntegrationTest is Test {
             collateralManagement.COLLATERAL_ADDER(),
             address(discovery)
         );
+        collateralManagement.initializeV2_1_0(address(discovery));
+        discovery.initializeV2_1_0();
     }
 
     function setupProviders() internal {

--- a/test/invariant/DiscoveryInvariant.t.sol
+++ b/test/invariant/DiscoveryInvariant.t.sol
@@ -120,6 +120,11 @@ contract DiscoveryInvariantTest is DiscoveryTestBase {
         uint256 approved = handler.ghost_approvedCount();
         uint256 withdrawn = handler.ghost_withdrawnCount();
 
+        assertGe(
+            approved,
+            withdrawn,
+            "INVARIANT VIOLATED: Withdrawn count exceeds approved count"
+        );
         assertLe(
             discovery.getProviders().length,
             approved - withdrawn,

--- a/test/invariant/DiscoveryInvariant.t.sol
+++ b/test/invariant/DiscoveryInvariant.t.sol
@@ -18,10 +18,13 @@ contract DiscoveryInvariantTest is DiscoveryTestBase {
 
         targetContract(address(handler));
 
-        bytes4[] memory selectors = new bytes4[](3);
+        bytes4[] memory selectors = new bytes4[](6);
         selectors[0] = handler.registerProvider.selector;
-        selectors[1] = handler.toggleStatus.selector;
-        selectors[2] = handler.updateProviderInfo.selector;
+        selectors[1] = handler.pendingRegisterWithdraw.selector;
+        selectors[2] = handler.toggleStatus.selector;
+        selectors[3] = handler.resignProvider.selector;
+        selectors[4] = handler.withdrawProvider.selector;
+        selectors[5] = handler.updateProviderInfo.selector;
         targetSelector(
             FuzzSelector({addr: address(handler), selectors: selectors})
         );
@@ -38,20 +41,19 @@ contract DiscoveryInvariantTest is DiscoveryTestBase {
         );
     }
 
-    /// @notice Provider ID counter should match total registrations and never decrease
+    /// @notice Provider ID counter should match the last id issued by handlers
     function invariant_ProviderIdMonotonic() public view {
-        uint256 registered = handler.ghost_totalRegistered();
-        if (registered == 0) return;
+        if (handler.ghost_lastProviderId() == 0) return;
 
         assertEq(
             discovery.getProvidersId(),
-            registered,
+            handler.ghost_lastProviderId(),
             "INVARIANT VIOLATED: Provider ID counter mismatch"
         );
     }
 
-    /// @notice Every provider returned by getProviders() must be registered and have status enabled
-    function invariant_GetProvidersConsistency() public view {
+    /// @notice Every provider returned by getProviders() must be operational
+    function invariant_ListedProvidersAreOperational() public view {
         Flyover.LiquidityProvider[] memory listed = discovery.getProviders();
 
         for (uint256 i = 0; i < listed.length; i++) {
@@ -61,12 +63,81 @@ contract DiscoveryInvariantTest is DiscoveryTestBase {
             );
 
             assertTrue(
-                collateralManagement.isRegistered(
+                collateralManagement.isCollateralSufficient(
                     listed[i].providerType,
                     listed[i].providerAddress
                 ),
-                "INVARIANT VIOLATED: Listed provider not registered in CollateralManagement"
+                "INVARIANT VIOLATED: Listed provider collateral insufficient"
             );
+        }
+    }
+
+    /// @notice Approved operational providers must appear in getProviders()
+    function invariant_ApprovedOperationalProvidersAreListed() public view {
+        uint256 count = handler.getRegisteredCount();
+        for (uint256 i = 0; i < count; i++) {
+            (
+                address addr,
+                ,
+                Flyover.ProviderType providerType,
+                bool statusSet,
+                bool withdrawn
+            ) = handler.getProviderInfo(i);
+
+            if (
+                !withdrawn &&
+                statusSet &&
+                collateralManagement.isCollateralSufficient(providerType, addr)
+            ) {
+                assertTrue(
+                    _isListed(addr),
+                    "INVARIANT VIOLATED: Operational provider missing from listing"
+                );
+            }
+        }
+    }
+
+    /// @notice getProviders() returns unique provider ids and addresses
+    function invariant_NoDuplicateListing() public view {
+        Flyover.LiquidityProvider[] memory listed = discovery.getProviders();
+
+        for (uint256 i = 0; i < listed.length; i++) {
+            for (uint256 j = i + 1; j < listed.length; j++) {
+                assertTrue(
+                    listed[i].id != listed[j].id,
+                    "INVARIANT VIOLATED: Duplicate provider id in listing"
+                );
+                assertTrue(
+                    listed[i].providerAddress != listed[j].providerAddress,
+                    "INVARIANT VIOLATED: Duplicate provider address in listing"
+                );
+            }
+        }
+    }
+
+    /// @notice Listing size is bounded by approved minus withdrawn providers
+    function invariant_ListingIndependentOfLastProviderId() public view {
+        uint256 approved = handler.ghost_approvedCount();
+        uint256 withdrawn = handler.ghost_withdrawnCount();
+
+        assertLe(
+            discovery.getProviders().length,
+            approved - withdrawn,
+            "INVARIANT VIOLATED: Listing larger than active approved providers"
+        );
+    }
+
+    /// @notice Withdrawn providers must not appear in getProviders()
+    function invariant_WithdrawnProvidersNotListed() public view {
+        uint256 count = handler.getRegisteredCount();
+        for (uint256 i = 0; i < count; i++) {
+            (address addr, , , , bool withdrawn) = handler.getProviderInfo(i);
+            if (withdrawn) {
+                assertFalse(
+                    _isListed(addr),
+                    "INVARIANT VIOLATED: Withdrawn provider still listed"
+                );
+            }
         }
     }
 
@@ -78,21 +149,24 @@ contract DiscoveryInvariantTest is DiscoveryTestBase {
                 address addr,
                 ,
                 Flyover.ProviderType providerType,
-                bool statusSet
+                bool statusSet,
+                bool withdrawn
             ) = handler.getProviderInfo(i);
 
-            bool operational = discovery.isOperational(providerType, addr);
-            bool sufficient = collateralManagement.isCollateralSufficient(
-                providerType,
-                addr
-            );
-            bool expected = statusSet && sufficient;
+            if (!withdrawn) {
+                bool operational = discovery.isOperational(providerType, addr);
+                bool sufficient = collateralManagement.isCollateralSufficient(
+                    providerType,
+                    addr
+                );
+                bool expected = statusSet && sufficient;
 
-            assertEq(
-                operational,
-                expected,
-                "INVARIANT VIOLATED: isOperational mismatch"
-            );
+                assertEq(
+                    operational,
+                    expected,
+                    "INVARIANT VIOLATED: isOperational mismatch"
+                );
+            }
         }
     }
 
@@ -102,23 +176,27 @@ contract DiscoveryInvariantTest is DiscoveryTestBase {
         uint256 minCol = collateralManagement.getMinCollateral();
 
         for (uint256 i = 0; i < count; i++) {
-            (address addr, , Flyover.ProviderType providerType, ) = handler
-                .getProviderInfo(i);
+            (
+                address addr,
+                ,
+                Flyover.ProviderType providerType,
+                ,
+                bool withdrawn
+            ) = handler.getProviderInfo(i);
 
-            if (
-                providerType == Flyover.ProviderType.PegIn ||
-                providerType == Flyover.ProviderType.Both
-            ) {
+            bool supportsPegin = providerType == Flyover.ProviderType.PegIn ||
+                providerType == Flyover.ProviderType.Both;
+            bool supportsPegout = providerType == Flyover.ProviderType.PegOut ||
+                providerType == Flyover.ProviderType.Both;
+
+            if (!withdrawn && supportsPegin) {
                 assertGe(
                     collateralManagement.getPegInCollateral(addr),
                     minCol,
                     "INVARIANT VIOLATED: PegIn collateral below minimum"
                 );
             }
-            if (
-                providerType == Flyover.ProviderType.PegOut ||
-                providerType == Flyover.ProviderType.Both
-            ) {
+            if (!withdrawn && supportsPegout) {
                 assertGe(
                     collateralManagement.getPegOutCollateral(addr),
                     minCol,
@@ -131,6 +209,9 @@ contract DiscoveryInvariantTest is DiscoveryTestBase {
     function invariant_callSummary() public view {
         console.log("\n--- Discovery Invariant Summary ---");
         console.log("Registered providers:", handler.ghost_totalRegistered());
+        console.log("Approved providers:", handler.ghost_approvedCount());
+        console.log("Withdrawn providers:", handler.ghost_withdrawnCount());
+        console.log("Pending withdrawn:", handler.ghost_pendingWithdrawn());
         console.log("Last provider ID:", handler.ghost_lastProviderId());
         console.log("Listed providers:", discovery.getProviders().length);
         console.log("Discovery balance:", address(discovery).balance);
@@ -139,5 +220,13 @@ contract DiscoveryInvariantTest is DiscoveryTestBase {
             address(collateralManagement).balance
         );
         console.log("----------------------------------\n");
+    }
+
+    function _isListed(address provider) private view returns (bool) {
+        Flyover.LiquidityProvider[] memory listed = discovery.getProviders();
+        for (uint256 i = 0; i < listed.length; i++) {
+            if (listed[i].providerAddress == provider) return true;
+        }
+        return false;
     }
 }

--- a/test/invariant/SystemInvariant.t.sol
+++ b/test/invariant/SystemInvariant.t.sol
@@ -403,6 +403,8 @@ contract SystemInvariantTest is Test {
             collateralManagement.COLLATERAL_SLASHER(),
             slasher
         );
+        collateralManagement.initializeV2_1_0(address(discovery));
+        discovery.initializeV2_1_0();
         vm.stopPrank();
     }
 }

--- a/test/invariant/handlers/DiscoveryHandler.sol
+++ b/test/invariant/handlers/DiscoveryHandler.sol
@@ -18,12 +18,16 @@ contract DiscoveryHandler is HandlerBase {
         uint256 providerId;
         Flyover.ProviderType providerType;
         bool statusSet;
+        bool withdrawn;
     }
 
     ProviderInfo[] public registeredProviders;
 
     uint256 public ghost_totalRegistered;
     uint256 public ghost_lastProviderId;
+    uint256 public ghost_approvedCount;
+    uint256 public ghost_withdrawnCount;
+    uint256 public ghost_pendingWithdrawn;
 
     constructor(
         FlyoverDiscovery discovery_,
@@ -65,18 +69,63 @@ contract DiscoveryHandler is HandlerBase {
         try
             discovery.register{value: collateral}(name, url, true, providerType)
         returns (uint256 id) {
+            ghost_lastProviderId = id;
             vm.prank(owner);
             discovery.approveRegistration(provider);
             ghost_totalRegistered++;
+            ghost_approvedCount++;
             ghost_lastProviderId = id;
             registeredProviders.push(
                 ProviderInfo({
                     addr: provider,
                     providerId: id,
                     providerType: providerType,
-                    statusSet: true
+                    statusSet: true,
+                    withdrawn: false
                 })
             );
+        } catch {}
+    }
+
+    function pendingRegisterWithdraw(
+        uint256 seed,
+        uint8 providerTypeSeed,
+        uint256 extraCollateral
+    ) external {
+        handlerCalls["pendingRegisterWithdraw"] += 1;
+
+        Flyover.ProviderType providerType = _getProviderType(providerTypeSeed);
+        uint256 requiredCollateral = _getRequiredCollateral(providerType);
+        extraCollateral = bound(extraCollateral, 0, 5 ether);
+        uint256 collateral = requiredCollateral + extraCollateral;
+
+        address provider = address(
+            uint160(
+                uint256(
+                    keccak256(
+                        abi.encode(
+                            seed,
+                            ghost_pendingWithdrawn,
+                            block.timestamp,
+                            "pending"
+                        )
+                    )
+                )
+            )
+        );
+        vm.deal(provider, collateral + 1 ether);
+
+        string memory name = _generateName(seed);
+        string memory url = _generateUrl(seed);
+
+        vm.prank(provider, provider);
+        try
+            discovery.register{value: collateral}(name, url, true, providerType)
+        returns (uint256 id) {
+            ghost_lastProviderId = id;
+            vm.prank(provider);
+            discovery.withdrawRegisterRequest();
+            ghost_pendingWithdrawn++;
         } catch {}
     }
 
@@ -87,10 +136,44 @@ contract DiscoveryHandler is HandlerBase {
 
         uint256 idx = providerSeed % registeredProviders.length;
         ProviderInfo storage info = registeredProviders[idx];
+        if (info.withdrawn) return;
 
         vm.prank(info.addr);
         try discovery.setProviderStatus(info.providerId, status) {
             info.statusSet = status;
+        } catch {}
+    }
+
+    function resignProvider(uint256 providerSeed) external {
+        handlerCalls["resignProvider"] += 1;
+
+        if (registeredProviders.length == 0) return;
+
+        uint256 idx = providerSeed % registeredProviders.length;
+        ProviderInfo storage info = registeredProviders[idx];
+        if (info.withdrawn) return;
+
+        vm.prank(info.addr);
+        try collateralManagement.resign() {} catch {}
+    }
+
+    function withdrawProvider(uint256 providerSeed) external {
+        handlerCalls["withdrawProvider"] += 1;
+
+        if (registeredProviders.length == 0) return;
+
+        uint256 idx = providerSeed % registeredProviders.length;
+        ProviderInfo storage info = registeredProviders[idx];
+        if (info.withdrawn) return;
+
+        vm.prank(info.addr);
+        try collateralManagement.resign() {
+            vm.roll(block.number + RESIGN_DELAY);
+            vm.prank(info.addr);
+            try collateralManagement.withdrawCollateral() {
+                info.withdrawn = true;
+                ghost_withdrawnCount++;
+            } catch {}
         } catch {}
     }
 
@@ -105,6 +188,7 @@ contract DiscoveryHandler is HandlerBase {
 
         uint256 idx = providerSeed % registeredProviders.length;
         ProviderInfo storage info = registeredProviders[idx];
+        if (info.withdrawn) return;
 
         string memory name = _generateName(nameSeed);
         string memory url = _generateUrl(urlSeed);
@@ -117,6 +201,16 @@ contract DiscoveryHandler is HandlerBase {
         return registeredProviders.length;
     }
 
+    function isWithdrawn(address addr) external view returns (bool) {
+        uint256 count = registeredProviders.length;
+        for (uint256 i = 0; i < count; ++i) {
+            if (registeredProviders[i].addr == addr) {
+                return registeredProviders[i].withdrawn;
+            }
+        }
+        return false;
+    }
+
     function getProviderInfo(
         uint256 idx
     )
@@ -126,10 +220,17 @@ contract DiscoveryHandler is HandlerBase {
             address addr,
             uint256 providerId,
             Flyover.ProviderType providerType,
-            bool statusSet
+            bool statusSet,
+            bool withdrawn
         )
     {
         ProviderInfo storage info = registeredProviders[idx];
-        return (info.addr, info.providerId, info.providerType, info.statusSet);
+        return (
+            info.addr,
+            info.providerId,
+            info.providerType,
+            info.statusSet,
+            info.withdrawn
+        );
     }
 }

--- a/test/pegin/PegInTestBase.sol
+++ b/test/pegin/PegInTestBase.sol
@@ -154,8 +154,11 @@ abstract contract PegInTestBase is Test {
 
         bytes32 adderRole = collateralManagement.COLLATERAL_ADDER();
 
-        vm.prank(owner);
+        vm.startPrank(owner);
         collateralManagement.grantRole(adderRole, address(discovery));
+        collateralManagement.initializeV2_1_0(address(discovery));
+        discovery.initializeV2_1_0();
+        vm.stopPrank();
     }
 
     /// @notice Setup providers with collateral

--- a/test/pegout/PegOutTestBase.sol
+++ b/test/pegout/PegOutTestBase.sol
@@ -148,8 +148,11 @@ abstract contract PegOutTestBase is Test {
 
         bytes32 adderRole = collateralManagement.COLLATERAL_ADDER();
 
-        vm.prank(owner);
+        vm.startPrank(owner);
         collateralManagement.grantRole(adderRole, address(discovery));
+        collateralManagement.initializeV2_1_0(address(discovery));
+        discovery.initializeV2_1_0();
+        vm.stopPrank();
     }
 
     /// @notice Setup providers with collateral

--- a/test/tasks/PauseSystem.t.sol
+++ b/test/tasks/PauseSystem.t.sol
@@ -1,18 +1,152 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import {console} from "forge-std/console.sol";
-import {FlyoverTestBase} from "../helpers/FlyoverTestBase.sol";
+import {Test, console} from "forge-std/Test.sol";
 import {PauseSystem} from "../../script/tasks/PauseSystem.s.sol";
 import {IPauseRegistry} from "../../src/interfaces/IPauseRegistry.sol";
 
+/// @dev Mirrors PauseSystem registry checks with explicit addresses (parallel-safe; no vm.setEnv).
+interface IPauseRegistryGetter {
+    function pauseRegistry() external view returns (IPauseRegistry);
+}
+
+/// @dev Test-only helper: same behavior as PauseSystem but takes addresses as arguments.
+contract PauseSystemTestRunner is PauseSystem {
+    function _verifyAllContractsUseRegistryAt(
+        IPauseRegistry registry,
+        address pegInAddr,
+        address pegOutAddr,
+        address collateralAddr,
+        address discoveryAddr
+    ) internal view {
+        address expected = address(registry);
+
+        require(
+            address(IPauseRegistryGetter(pegInAddr).pauseRegistry()) ==
+                expected,
+            "PauseSystem: PegInContract has different PauseRegistry"
+        );
+        require(
+            address(IPauseRegistryGetter(pegOutAddr).pauseRegistry()) ==
+                expected,
+            "PauseSystem: PegOutContract has different PauseRegistry"
+        );
+        require(
+            address(IPauseRegistryGetter(collateralAddr).pauseRegistry()) ==
+                expected,
+            "PauseSystem: CollateralManagement has different PauseRegistry"
+        );
+        require(
+            address(IPauseRegistryGetter(discoveryAddr).pauseRegistry()) ==
+                expected,
+            "PauseSystem: FlyoverDiscovery has different PauseRegistry"
+        );
+    }
+
+    function checkStatusAt(
+        address registryAddr,
+        address pegInAddr,
+        address pegOutAddr,
+        address collateralAddr,
+        address discoveryAddr
+    ) public view {
+        console.log("\n=== FLYOVER PAUSE STATUS ===\n");
+
+        IPauseRegistry registry = IPauseRegistry(registryAddr);
+        _verifyAllContractsUseRegistryAt(
+            registry,
+            pegInAddr,
+            pegOutAddr,
+            collateralAddr,
+            discoveryAddr
+        );
+
+        console.log(
+            string.concat("PauseRegistry: ", vm.toString(address(registry)))
+        );
+        console.log("");
+
+        (bool isPaused, string memory reason, uint64 since) = registry
+            .pauseStatus();
+
+        console.log(string.concat("System: ", isPaused ? "PAUSED" : "ACTIVE"));
+        if (isPaused) {
+            console.log(string.concat("  Reason: ", reason));
+            console.log(string.concat("  Since: ", vm.toString(since)));
+        }
+
+        console.log("\n=============================\n");
+    }
+
+    function pauseAllAt(
+        address registryAddr,
+        address pegInAddr,
+        address pegOutAddr,
+        address collateralAddr,
+        address discoveryAddr,
+        string memory reason
+    ) public {
+        require(bytes(reason).length > 0, "Reason cannot be empty");
+
+        console.log("\n=== PAUSE OPERATION ===\n");
+        console.log(string.concat("Reason: ", reason));
+
+        IPauseRegistry registry = IPauseRegistry(registryAddr);
+        _verifyAllContractsUseRegistryAt(
+            registry,
+            pegInAddr,
+            pegOutAddr,
+            collateralAddr,
+            discoveryAddr
+        );
+
+        vm.startBroadcast();
+        registry.setPauseLevel(IPauseRegistry.PauseLevel.Soft, reason);
+        vm.stopBroadcast();
+
+        console.log(
+            "  [OK] PauseRegistry paused - all Flyover contracts are now paused"
+        );
+        console.log("\n[SUCCESS] System paused successfully!");
+    }
+
+    function unpauseAllAt(
+        address registryAddr,
+        address pegInAddr,
+        address pegOutAddr,
+        address collateralAddr,
+        address discoveryAddr
+    ) public {
+        console.log("\n=== UNPAUSE OPERATION ===\n");
+
+        IPauseRegistry registry = IPauseRegistry(registryAddr);
+        _verifyAllContractsUseRegistryAt(
+            registry,
+            pegInAddr,
+            pegOutAddr,
+            collateralAddr,
+            discoveryAddr
+        );
+
+        vm.startBroadcast();
+        registry.setPauseLevel(IPauseRegistry.PauseLevel.None, "");
+        vm.stopBroadcast();
+
+        console.log(
+            "  [OK] PauseRegistry unpaused - all Flyover contracts are now active"
+        );
+        console.log("\n[SUCCESS] System unpaused successfully!");
+    }
+}
+
 /**
  * @title PauseSystemTest
- * @notice Test for the pause-system task: registry from env, verify all contracts use same registry
+ * @notice Test for the pause-system task: registry verification and pause/unpause via script
  * @dev Uses mocks that expose pauseRegistry() and delegate pauseStatus() to the registry.
+ *      Tests pass addresses explicitly (not via vm.setEnv) so they are safe under parallel execution.
  */
-contract PauseSystemTest is FlyoverTestBase {
-    PauseSystem public pauseScript;
+contract PauseSystemTest is Test {
+    PauseSystemTestRunner public pauseScript;
 
     MockPauseRegistry public mockRegistry;
     MockPausableContract public mockDiscovery;
@@ -41,36 +175,50 @@ contract PauseSystemTest is FlyoverTestBase {
         console.log("  PegOutContract:", address(mockPegOut));
         console.log("  CollateralManagement:", address(mockCollateral));
 
-        pauseScript = new PauseSystem();
+        pauseScript = new PauseSystemTestRunner();
     }
 
-    /**
-     * @notice Set environment variables: registry from env, and all four contract addresses
-     */
-    function _setEnvVars() internal {
-        vm.setEnv("PAUSE_REGISTRY_ADDRESS", vm.toString(address(mockRegistry)));
-        vm.setEnv(
-            "FLYOVER_DISCOVERY_ADDRESS",
-            vm.toString(address(mockDiscovery))
-        );
-        vm.setEnv("PEGIN_CONTRACT_ADDRESS", vm.toString(address(mockPegIn)));
-        vm.setEnv("PEGOUT_CONTRACT_ADDRESS", vm.toString(address(mockPegOut)));
-        vm.setEnv(
-            "COLLATERAL_MANAGEMENT_ADDRESS",
-            vm.toString(address(mockCollateral))
+    function _mockAddresses()
+        internal
+        view
+        returns (
+            address registry,
+            address pegIn,
+            address pegOut,
+            address collateral,
+            address discovery
+        )
+    {
+        return (
+            address(mockRegistry),
+            address(mockPegIn),
+            address(mockPegOut),
+            address(mockCollateral),
+            address(mockDiscovery)
         );
     }
 
     function test_CheckStatus() public {
-        _setEnvVars();
         console.log("\n=== TEST CHECK STATUS ===\n");
 
         (bool r1, , ) = mockRegistry.pauseStatus();
         assertFalse(r1, "Registry should not be paused initially");
 
-        pauseScript.checkStatus();
+        (
+            address registry,
+            address pegIn,
+            address pegOut,
+            address collateral,
+            address discovery
+        ) = _mockAddresses();
+        pauseScript.checkStatusAt(
+            registry,
+            pegIn,
+            pegOut,
+            collateral,
+            discovery
+        );
 
-        // Pause the registry (central source of truth)
         mockRegistry.setPauseLevel(
             IPauseRegistry.PauseLevel.Soft,
             "Test pause for status check"
@@ -79,8 +227,13 @@ contract PauseSystemTest is FlyoverTestBase {
         (r1, , ) = mockRegistry.pauseStatus();
         assertTrue(r1, "Registry should be paused");
 
-        _setEnvVars();
-        pauseScript.checkStatus();
+        pauseScript.checkStatusAt(
+            registry,
+            pegIn,
+            pegOut,
+            collateral,
+            discovery
+        );
 
         console.log("\n[PASS] PauseSystem checkStatus works correctly!");
     }
@@ -156,11 +309,24 @@ contract PauseSystemTest is FlyoverTestBase {
     }
 
     function test_CompleteCycle() public {
-        _setEnvVars();
         console.log("\n=== TEST COMPLETE PAUSE/UNPAUSE CYCLE ===\n");
 
+        (
+            address registry,
+            address pegIn,
+            address pegOut,
+            address collateral,
+            address discovery
+        ) = _mockAddresses();
+
         console.log("1. Initial status check");
-        pauseScript.checkStatus();
+        pauseScript.checkStatusAt(
+            registry,
+            pegIn,
+            pegOut,
+            collateral,
+            discovery
+        );
 
         console.log("\n2. Pausing via registry");
         mockRegistry.setPauseLevel(
@@ -169,24 +335,48 @@ contract PauseSystemTest is FlyoverTestBase {
         );
 
         console.log("\n3. Status while paused");
-        _setEnvVars();
-        pauseScript.checkStatus();
+        pauseScript.checkStatusAt(
+            registry,
+            pegIn,
+            pegOut,
+            collateral,
+            discovery
+        );
 
         console.log("\n4. Unpausing registry");
         mockRegistry.setPauseLevel(IPauseRegistry.PauseLevel.None, "");
 
         console.log("\n5. Final status check");
-        _setEnvVars();
-        pauseScript.checkStatus();
+        pauseScript.checkStatusAt(
+            registry,
+            pegIn,
+            pegOut,
+            collateral,
+            discovery
+        );
 
         console.log("\n[PASS] Complete cycle successful!");
     }
 
     function test_PauseAllViaScript() public {
-        _setEnvVars();
         console.log("\n=== TEST PAUSE ALL VIA SCRIPT ===\n");
 
-        pauseScript.pauseAll("Script-initiated pause");
+        (
+            address registry,
+            address pegIn,
+            address pegOut,
+            address collateral,
+            address discovery
+        ) = _mockAddresses();
+
+        pauseScript.pauseAllAt(
+            registry,
+            pegIn,
+            pegOut,
+            collateral,
+            discovery,
+            "Script-initiated pause"
+        );
 
         (bool r1, string memory rReason, ) = mockRegistry.pauseStatus();
         assertTrue(r1, "Registry should be paused");
@@ -207,11 +397,31 @@ contract PauseSystemTest is FlyoverTestBase {
     }
 
     function test_UnpauseAllViaScript() public {
-        _setEnvVars();
         console.log("\n=== TEST UNPAUSE ALL VIA SCRIPT ===\n");
 
-        pauseScript.pauseAll("Pre-test pause");
-        pauseScript.unpauseAll();
+        (
+            address registry,
+            address pegIn,
+            address pegOut,
+            address collateral,
+            address discovery
+        ) = _mockAddresses();
+
+        pauseScript.pauseAllAt(
+            registry,
+            pegIn,
+            pegOut,
+            collateral,
+            discovery,
+            "Pre-test pause"
+        );
+        pauseScript.unpauseAllAt(
+            registry,
+            pegIn,
+            pegOut,
+            collateral,
+            discovery
+        );
 
         (bool r1, , ) = mockRegistry.pauseStatus();
         assertFalse(r1, "Registry should be unpaused");
@@ -227,85 +437,111 @@ contract PauseSystemTest is FlyoverTestBase {
     }
 
     function test_RevertsWhenContractHasDifferentRegistry() public {
-        _setEnvVars();
-
-        // Deploy another registry and a mock that points to it
         MockPauseRegistry otherRegistry = new MockPauseRegistry();
         MockPausableContract mockWithOtherRegistry = new MockPausableContract(
             "Other",
             otherRegistry
         );
 
-        // Point PegIn to a contract that has a *different* registry
-        vm.setEnv(
-            "PEGIN_CONTRACT_ADDRESS",
-            vm.toString(address(mockWithOtherRegistry))
-        );
+        (
+            address registry,
+            ,
+            address pegOut,
+            address collateral,
+            address discovery
+        ) = _mockAddresses();
 
         vm.expectRevert(
             "PauseSystem: PegInContract has different PauseRegistry"
         );
-        pauseScript.checkStatus();
+        pauseScript.checkStatusAt(
+            registry,
+            address(mockWithOtherRegistry),
+            pegOut,
+            collateral,
+            discovery
+        );
     }
 
     function test_RevertsWhenPegOutHasDifferentRegistry() public {
-        _setEnvVars();
-
         MockPauseRegistry otherRegistry = new MockPauseRegistry();
         MockPausableContract mockWithOtherRegistry = new MockPausableContract(
             "Other",
             otherRegistry
         );
 
-        vm.setEnv(
-            "PEGOUT_CONTRACT_ADDRESS",
-            vm.toString(address(mockWithOtherRegistry))
-        );
+        (
+            address registry,
+            address pegIn,
+            ,
+            address collateral,
+            address discovery
+        ) = _mockAddresses();
 
         vm.expectRevert(
             "PauseSystem: PegOutContract has different PauseRegistry"
         );
-        pauseScript.checkStatus();
+        pauseScript.checkStatusAt(
+            registry,
+            pegIn,
+            address(mockWithOtherRegistry),
+            collateral,
+            discovery
+        );
     }
 
     function test_RevertsWhenCollateralHasDifferentRegistry() public {
-        _setEnvVars();
-
         MockPauseRegistry otherRegistry = new MockPauseRegistry();
         MockPausableContract mockWithOtherRegistry = new MockPausableContract(
             "Other",
             otherRegistry
         );
 
-        vm.setEnv(
-            "COLLATERAL_MANAGEMENT_ADDRESS",
-            vm.toString(address(mockWithOtherRegistry))
-        );
+        (
+            address registry,
+            address pegIn,
+            address pegOut,
+            ,
+            address discovery
+        ) = _mockAddresses();
 
         vm.expectRevert(
             "PauseSystem: CollateralManagement has different PauseRegistry"
         );
-        pauseScript.checkStatus();
+        pauseScript.checkStatusAt(
+            registry,
+            pegIn,
+            pegOut,
+            address(mockWithOtherRegistry),
+            discovery
+        );
     }
 
     function test_RevertsWhenDiscoveryHasDifferentRegistry() public {
-        _setEnvVars();
-
         MockPauseRegistry otherRegistry = new MockPauseRegistry();
         MockPausableContract mockWithOtherRegistry = new MockPausableContract(
             "Other",
             otherRegistry
         );
 
-        vm.setEnv(
-            "FLYOVER_DISCOVERY_ADDRESS",
-            vm.toString(address(mockWithOtherRegistry))
-        );
+        (
+            address registry,
+            address pegIn,
+            address pegOut,
+            address collateral,
+
+        ) = _mockAddresses();
 
         vm.expectRevert(
             "PauseSystem: FlyoverDiscovery has different PauseRegistry"
         );
-        pauseScript.checkStatus();
+        pauseScript.checkStatusAt(
+            registry,
+            pegIn,
+            pegOut,
+            collateral,
+            address(mockWithOtherRegistry)
+        );
     }
 }
 


### PR DESCRIPTION
## What
Add active provider index

## Why
So multiple registration don't cause discovery to make O(n) calls to collateral management during `getProviders`

## Task
https://rsklabs.atlassian.net/browse/FLY-2298