### PR TITLE
FLY-2443/FLY-2461 S3.1: Address reads

### DIFF
--- a/src/PegInAddressRegistry.sol
+++ b/src/PegInAddressRegistry.sol
@@ -18,15 +18,6 @@ import {PegInDerivation} from "./libraries/PegInDerivation.sol";
 /// and the live powpeg redeem script returned by {IBridge}.
 /// @author Rootstock Labs(TravellerOnTheRun)
 contract PegInAddressRegistry is AccessControlDefaultAdminRulesUpgradeable, ReentrancyGuard, IPegInAddressRegistry {
-    /// @notice The version of the contract
-    string public constant VERSION = "1.0.0";
-
-    /// @notice Maximum batch size for `getPegInAddresses`.
-    uint256 public constant MAX_PEGIN_ADDRESS_BATCH = 100;
-
-    /// @notice The encoding of addresses returned by the derivation getters.
-    Encoding public constant ADDRESS_ENCODING = Encoding.BASE58;
-
     /// @custom:storage-location erc7201:rsk.flyover.PegInAddressRegistry
     struct PegInAddressRegistryStorage {
         IBridge bridge;
@@ -36,19 +27,19 @@ contract PegInAddressRegistry is AccessControlDefaultAdminRulesUpgradeable, Reen
         address pegInContract;
     }
 
+    /// @notice The version of the contract
+    string public constant VERSION = "1.0.0";
+
+    /// @notice Maximum batch size for `getPegInAddresses`.
+    uint256 public constant MAX_PEGIN_ADDRESS_BATCH = 100;
+
+    /// @notice The encoding of addresses returned by the derivation getters.
+    Encoding public constant ADDRESS_ENCODING = Encoding.BASE58;
+
     // ERC-7201: keccak256(abi.encode(uint256(keccak256("rsk.flyover.PegInAddressRegistry")) - 1)) &
     // ~bytes32(uint256(0xff))
     bytes32 private constant _PEGIN_ADDRESS_REGISTRY_STORAGE =
         0x0704e3acad2c0308b9997bc861208a21efddaa710005747040bdddc7b9400f00;
-
-    /// @notice Raised when an address derivation is attempted before the PegInContract is wired.
-    error PegInContractNotSet();
-
-    /// @notice Raised when a batch request exceeds {MAX_PEGIN_ADDRESS_BATCH}.
-    error BatchTooLarge(uint256 requested, uint256 max);
-
-    /// @notice Raised when `registerAddress` is called while registration writes are unavailable.
-    error RegisterAddressNotImplemented();
 
     /// @notice Emitted when the PegInContract mixed into the derivation is set.
     event PegInContractSet(address indexed oldPegInContract, address indexed newPegInContract);
@@ -76,6 +67,18 @@ contract PegInAddressRegistry is AccessControlDefaultAdminRulesUpgradeable, Reen
         PegInAddressRegistryStorage storage $ = _getStorage();
         $.bridge = IBridge(payable(bridge));
         $.mainnet = mainnet;
+    }
+
+    /// @notice Sets the PegInContract mixed into the deposit-address derivation.
+    /// @param pegInContract The PegInContract address
+    // solhint-disable-next-line comprehensive-interface
+    function setPegInContract(address pegInContract) external onlyRole(DEFAULT_ADMIN_ROLE) nonReentrant {
+        if (pegInContract == address(0)) {
+            revert Flyover.NoContract(pegInContract);
+        }
+        PegInAddressRegistryStorage storage $ = _getStorage();
+        emit PegInContractSet($.pegInContract, pegInContract);
+        $.pegInContract = pegInContract;
     }
 
     /// @inheritdoc IPegInAddressRegistry
@@ -138,18 +141,6 @@ contract PegInAddressRegistry is AccessControlDefaultAdminRulesUpgradeable, Reen
     // solhint-disable-next-line comprehensive-interface
     function getBridge() external view returns (IBridge) {
         return _getStorage().bridge;
-    }
-
-    /// @notice Sets the PegInContract mixed into the deposit-address derivation.
-    /// @param pegInContract The PegInContract address
-    // solhint-disable-next-line comprehensive-interface
-    function setPegInContract(address pegInContract) external onlyRole(DEFAULT_ADMIN_ROLE) nonReentrant {
-        if (pegInContract == address(0)) {
-            revert Flyover.NoContract(pegInContract);
-        }
-        PegInAddressRegistryStorage storage $ = _getStorage();
-        emit PegInContractSet($.pegInContract, pegInContract);
-        $.pegInContract = pegInContract;
     }
 
     /// @notice Returns the PegInContract mixed into the derivation (zero if unset).

--- a/src/PegInAddressRegistry.sol
+++ b/src/PegInAddressRegistry.sol
@@ -171,7 +171,7 @@ contract PegInAddressRegistry is AccessControlDefaultAdminRulesUpgradeable, Reen
         returns (bytes memory)
     {
         bytes32 derivationValue = PegInDerivation.derivationValue(addr, pegInContract);
-        // TODO: instead pass the bridge address (library changes the construction)
+        // TODO(FLY-2436): pass the bridge address once the derivation library owns script construction
         bytes memory redeemScript = PegInDerivation.flyoverRedeemScript(derivationValue, powpegRedeemScript);
         bytes20 scriptHash = PegInDerivation.flyoverScriptHash(redeemScript);
         return PegInDerivation.depositAddressPayload(scriptHash, mainnet);

--- a/src/PegInAddressRegistry.sol
+++ b/src/PegInAddressRegistry.sol
@@ -85,7 +85,13 @@ contract PegInAddressRegistry is AccessControlDefaultAdminRulesUpgradeable, Reen
 
     /// @inheritdoc IPegInAddressRegistry
     function getPegInAddress(address addr) external view override returns (bytes memory, Encoding) {
-        return (_deriveAddress(addr), ADDRESS_ENCODING);
+        PegInAddressRegistryStorage storage $ = _getStorage();
+        address pegInContract = $.pegInContract;
+        if (pegInContract == address(0)) revert PegInContractNotSet();
+        // The active powpeg redeem script is invariant across a single call, so it is
+        // read once here and reused for the derivation.
+        bytes memory powpegRedeemScript = $.bridge.getActivePowpegRedeemScript();
+        return (_deriveAddress(addr, pegInContract, powpegRedeemScript, $.mainnet), ADDRESS_ENCODING);
     }
 
     /// @inheritdoc IPegInAddressRegistry
@@ -99,9 +105,16 @@ contract PegInAddressRegistry is AccessControlDefaultAdminRulesUpgradeable, Reen
         if (length > MAX_PEGIN_ADDRESS_BATCH) {
             revert BatchTooLarge(length, MAX_PEGIN_ADDRESS_BATCH);
         }
+        PegInAddressRegistryStorage storage $ = _getStorage();
+        address pegInContract = $.pegInContract;
+        if (pegInContract == address(0)) revert PegInContractNotSet();
+        // Read the invariant derivation inputs once, before the loop, so the batch performs a
+        // single external bridge call and derives every address against a consistent powpeg.
+        bytes memory powpegRedeemScript = $.bridge.getActivePowpegRedeemScript();
+        bool mainnet = $.mainnet;
         derivationAddresses = new bytes[](length);
         for (uint256 i = 0; i < length; ++i) {
-            derivationAddresses[i] = _deriveAddress(addrs[i]);
+            derivationAddresses[i] = _deriveAddress(addrs[i], pegInContract, powpegRedeemScript, mainnet);
         }
         encoding = ADDRESS_ENCODING;
     }
@@ -145,21 +158,23 @@ contract PegInAddressRegistry is AccessControlDefaultAdminRulesUpgradeable, Reen
         return _getStorage().pegInContract;
     }
 
-    /// @notice Derives the BTC deposit address for an RSK address against the current powpeg.
-    function _deriveAddress(address addr) private view returns (bytes memory) {
-        PegInAddressRegistryStorage storage $ = _getStorage();
-        address pegInContract = $.pegInContract;
-        if (pegInContract == address(0)) revert PegInContractNotSet();
-
+    /// @notice Derives the BTC deposit address for an RSK address against a supplied powpeg script.
+    /// @dev Callers must fetch the invariant derivation inputs (pegInContract, powpeg redeem script
+    /// and mainnet flag) once and pass them in, keeping the external bridge call out of any loop.
+    /// @param addr The RSK address the deposit address is derived for
+    /// @param pegInContract The PegInContract mixed into the derivation (must be non-zero)
+    /// @param powpegRedeemScript The active powpeg redeem script returned by the bridge
+    /// @param mainnet Whether the derived address targets mainnet or testnet
+    function _deriveAddress(address addr, address pegInContract, bytes memory powpegRedeemScript, bool mainnet)
+        private
+        pure
+        returns (bytes memory)
+    {
         bytes32 derivationValue = PegInDerivation.derivationValue(addr, pegInContract);
-        bytes memory redeemScript = PegInDerivation.flyoverRedeemScript(
-            derivationValue,
-            // TODO: instead pass the bridge address
-            // (library changes the construction)
-            $.bridge.getActivePowpegRedeemScript()
-        );
+        // TODO: instead pass the bridge address (library changes the construction)
+        bytes memory redeemScript = PegInDerivation.flyoverRedeemScript(derivationValue, powpegRedeemScript);
         bytes20 scriptHash = PegInDerivation.flyoverScriptHash(redeemScript);
-        return PegInDerivation.depositAddressPayload(scriptHash, $.mainnet);
+        return PegInDerivation.depositAddressPayload(scriptHash, mainnet);
     }
 
     function _getStorage() internal pure returns (PegInAddressRegistryStorage storage $) {

--- a/src/PegInAddressRegistry.sol
+++ b/src/PegInAddressRegistry.sol
@@ -122,6 +122,7 @@ contract PegInAddressRegistry is AccessControlDefaultAdminRulesUpgradeable, Reen
     }
 
     /// @notice Returns the bridge the registry derives against
+    // solhint-disable-next-line comprehensive-interface
     function getBridge() external view returns (IBridge) {
         return _getStorage().bridge;
     }
@@ -153,7 +154,9 @@ contract PegInAddressRegistry is AccessControlDefaultAdminRulesUpgradeable, Reen
         bytes32 derivationValue = PegInDerivation.derivationValue(addr, pegInContract);
         bytes memory redeemScript = PegInDerivation.flyoverRedeemScript(
             derivationValue,
-            $.bridge.getActivePowpegRedeemScript() // TODO: instead pass the bridge address(library changes the construction)
+            // TODO: instead pass the bridge address
+            // (library changes the construction)
+            $.bridge.getActivePowpegRedeemScript()
         );
         bytes20 scriptHash = PegInDerivation.flyoverScriptHash(redeemScript);
         return PegInDerivation.depositAddressPayload(scriptHash, $.mainnet);

--- a/src/PegInAddressRegistry.sol
+++ b/src/PegInAddressRegistry.sol
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {
+    AccessControlDefaultAdminRulesUpgradeable
+} from "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlDefaultAdminRulesUpgradeable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {IBridge} from "./interfaces/IBridge.sol";
+import {IPegInAddressRegistry} from "./interfaces/IPegInAddressRegistry.sol";
+import {Flyover} from "./libraries/Flyover.sol";
+import {PegInDerivation} from "./libraries/PegInDerivation.sol";
+
+/// @title PegInAddressRegistry
+/// @notice Upgradeable registry that derives a static BTC deposit address from an RSK address
+/// against the current powpeg and exposes registration lookups.
+/// @dev Exposes derivation and registration views. `registerAddress` reverts with
+/// {RegisterAddressNotImplemented}. Deposit-address bytes are composed from {PegInDerivation}
+/// and the live powpeg redeem script returned by {IBridge}.
+/// @author Rootstock Labs(TravellerOnTheRun)
+contract PegInAddressRegistry is AccessControlDefaultAdminRulesUpgradeable, ReentrancyGuard, IPegInAddressRegistry {
+    /// @notice The version of the contract
+    string public constant VERSION = "1.0.0";
+
+    /// @notice Maximum batch size for `getPegInAddresses`.
+    uint256 public constant MAX_PEGIN_ADDRESS_BATCH = 100;
+
+    /// @notice The encoding of addresses returned by the derivation getters.
+    Encoding public constant ADDRESS_ENCODING = Encoding.BASE58;
+
+    /// @custom:storage-location erc7201:rsk.flyover.PegInAddressRegistry
+    struct PegInAddressRegistryStorage {
+        IBridge bridge;
+        bool mainnet;
+        bytes32 registrationRoot;
+        mapping(address => Registration) registrations;
+        address pegInContract;
+    }
+
+    // ERC-7201: keccak256(abi.encode(uint256(keccak256("rsk.flyover.PegInAddressRegistry")) - 1)) &
+    // ~bytes32(uint256(0xff))
+    bytes32 private constant _PEGIN_ADDRESS_REGISTRY_STORAGE =
+        0x0704e3acad2c0308b9997bc861208a21efddaa710005747040bdddc7b9400f00;
+
+    /// @notice Raised when an address derivation is attempted before the PegInContract is wired.
+    error PegInContractNotSet();
+
+    /// @notice Raised when a batch request exceeds {MAX_PEGIN_ADDRESS_BATCH}.
+    error BatchTooLarge(uint256 requested, uint256 max);
+
+    /// @notice Raised when `registerAddress` is called while registration writes are unavailable.
+    error RegisterAddressNotImplemented();
+
+    /// @notice Emitted when the PegInContract mixed into the derivation is set.
+    event PegInContractSet(address indexed oldPegInContract, address indexed newPegInContract);
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    /// @notice This contract does not accept value
+    // solhint-disable-next-line comprehensive-interface
+    receive() external payable {
+        revert Flyover.PaymentNotAllowed();
+    }
+
+    /// @notice Initializes the contract
+    /// @param defaultAdmin The default admin of the contract
+    /// @param initialDelay The initial delay for changes in the default admin role
+    /// @param bridge The address of the Rootstock bridge
+    /// @param mainnet Whether the derived addresses target mainnet or testnet
+    // solhint-disable-next-line comprehensive-interface
+    function initialize(address defaultAdmin, uint48 initialDelay, address bridge, bool mainnet) external initializer {
+        if (bridge == address(0)) revert Flyover.NoContract(bridge);
+        __AccessControlDefaultAdminRules_init(initialDelay, defaultAdmin);
+        PegInAddressRegistryStorage storage $ = _getStorage();
+        $.bridge = IBridge(payable(bridge));
+        $.mainnet = mainnet;
+    }
+
+    /// @inheritdoc IPegInAddressRegistry
+    function registerAddress(address, bytes calldata, bytes32, uint256, bytes32[] calldata) external pure override {
+        revert RegisterAddressNotImplemented();
+    }
+
+    /// @inheritdoc IPegInAddressRegistry
+    function getPegInAddress(address addr) external view override returns (bytes memory, Encoding) {
+        return (_deriveAddress(addr), ADDRESS_ENCODING);
+    }
+
+    /// @inheritdoc IPegInAddressRegistry
+    function getPegInAddresses(address[] calldata addrs)
+        external
+        view
+        override
+        returns (bytes[] memory derivationAddresses, Encoding encoding)
+    {
+        uint256 length = addrs.length;
+        if (length > MAX_PEGIN_ADDRESS_BATCH) {
+            revert BatchTooLarge(length, MAX_PEGIN_ADDRESS_BATCH);
+        }
+        derivationAddresses = new bytes[](length);
+        for (uint256 i = 0; i < length; ++i) {
+            derivationAddresses[i] = _deriveAddress(addrs[i]);
+        }
+        encoding = ADDRESS_ENCODING;
+    }
+
+    /// @inheritdoc IPegInAddressRegistry
+    function getRegistrationRoot() external view override returns (bytes32) {
+        return _getStorage().registrationRoot;
+    }
+
+    /// @inheritdoc IPegInAddressRegistry
+    function isRegistered(address addr) external view override returns (bool) {
+        return _getStorage().registrations[addr].registrationBlock != 0;
+    }
+
+    /// @inheritdoc IPegInAddressRegistry
+    function getRegistration(address addr) external view override returns (Registration memory) {
+        return _getStorage().registrations[addr];
+    }
+
+    /// @notice Returns the bridge the registry derives against
+    function getBridge() external view returns (IBridge) {
+        return _getStorage().bridge;
+    }
+
+    /// @notice Sets the PegInContract mixed into the deposit-address derivation.
+    /// @param pegInContract The PegInContract address
+    // solhint-disable-next-line comprehensive-interface
+    function setPegInContract(address pegInContract) external onlyRole(DEFAULT_ADMIN_ROLE) nonReentrant {
+        if (pegInContract == address(0)) {
+            revert Flyover.NoContract(pegInContract);
+        }
+        PegInAddressRegistryStorage storage $ = _getStorage();
+        emit PegInContractSet($.pegInContract, pegInContract);
+        $.pegInContract = pegInContract;
+    }
+
+    /// @notice Returns the PegInContract mixed into the derivation (zero if unset).
+    // solhint-disable-next-line comprehensive-interface
+    function getPegInContract() external view returns (address) {
+        return _getStorage().pegInContract;
+    }
+
+    /// @notice Derives the BTC deposit address for an RSK address against the current powpeg.
+    function _deriveAddress(address addr) private view returns (bytes memory) {
+        PegInAddressRegistryStorage storage $ = _getStorage();
+        address pegInContract = $.pegInContract;
+        if (pegInContract == address(0)) revert PegInContractNotSet();
+
+        bytes32 derivationValue = PegInDerivation.derivationValue(addr, pegInContract);
+        bytes memory redeemScript = PegInDerivation.flyoverRedeemScript(
+            derivationValue,
+            $.bridge.getActivePowpegRedeemScript() // TODO: instead pass the bridge address(library changes the construction)
+        );
+        bytes20 scriptHash = PegInDerivation.flyoverScriptHash(redeemScript);
+        return PegInDerivation.depositAddressPayload(scriptHash, $.mainnet);
+    }
+
+    function _getStorage() internal pure returns (PegInAddressRegistryStorage storage $) {
+        assembly {
+            $.slot := _PEGIN_ADDRESS_REGISTRY_STORAGE
+        }
+    }
+}

--- a/src/interfaces/IPegInAddressRegistry.sol
+++ b/src/interfaces/IPegInAddressRegistry.sol
@@ -92,7 +92,10 @@ interface IPegInAddressRegistry {
     /// @param rskAddrs The RSK destination addresses to derive for
     /// @return payloads The raw address payloads, one per input address, in input order
     /// @return encoding The encoding tag shared by every payload in the batch
-    function getPegInAddresses(address[] calldata rskAddrs) external view returns (bytes[] memory payloads, Encoding encoding);
+    function getPegInAddresses(address[] calldata rskAddrs)
+        external
+        view
+        returns (bytes[] memory payloads, Encoding encoding);
 
     /// @notice Tells whether an RSK destination address has a registration record
     /// @dev True while the packed record's registrationBlock != 0. Walkthrough anchors:

--- a/src/interfaces/IPegInAddressRegistry.sol
+++ b/src/interfaces/IPegInAddressRegistry.sol
@@ -76,6 +76,19 @@ interface IPegInAddressRegistry {
     /// @param minimum The minimum registrable deposit, in satoshis
     error DepositBelowMinimum(uint256 value, uint256 minimum);
 
+    /// @notice Raised when an address derivation is attempted before the PegInContract is wired
+    error PegInContractNotSet();
+
+    /// @notice Raised when a batch request exceeds the registry batch cap
+    /// @param requested The number of addresses requested
+    /// @param max The maximum allowed batch size
+    error BatchTooLarge(uint256 requested, uint256 max);
+
+    /// @notice Raised when `registerAddress` is called while registration writes are unavailable
+    /// @dev Temporary stub surface for the read-only slice; S3.2 replaces the stub with the
+    /// SPV-gated write path and removes this error.
+    error RegisterAddressNotImplemented();
+
     /// @notice Derives the deterministic BTC deposit address for an RSK destination address
     /// @dev The address is a prediction of what the bridge recomputes at settlement, byte for
     /// byte: it depends only on the RSK address, fixed protocol constants, and the active

--- a/src/libraries/PegInDerivation.sol
+++ b/src/libraries/PegInDerivation.sol
@@ -47,7 +47,7 @@ library PegInDerivation {
     /// @notice HASH160 of the flyover redeem script.
     /// @dev SCHEME DIVERGENCE (temporary mock): this hashes the flyover redeem script directly,
     /// producing a PLAIN P2SH deposit address. The canonical peg-in scheme in
-    /// {PegInContract-validatePegInDepositAddress} instead HASH160s a P2WSH witness program
+    /// {PegInContract.validatePegInDepositAddress} instead HASH160s a P2WSH witness program
     /// (`OP_0 OP_PUSHBYTES_32 sha256(flyoverRedeemScript)`), i.e. a nested P2SH-P2WSH address.
     /// The two therefore derive DIFFERENT Bitcoin addresses for identical inputs. The real
     /// FLY-2436 derivation MUST reconcile this (match PegInContract) before production, or the

--- a/src/libraries/PegInDerivation.sol
+++ b/src/libraries/PegInDerivation.sol
@@ -45,6 +45,14 @@ library PegInDerivation {
     }
 
     /// @notice HASH160 of the flyover redeem script.
+    /// @dev SCHEME DIVERGENCE (temporary mock): this hashes the flyover redeem script directly,
+    /// producing a PLAIN P2SH deposit address. The canonical peg-in scheme in
+    /// {PegInContract-validatePegInDepositAddress} instead HASH160s a P2WSH witness program
+    /// (`OP_0 OP_PUSHBYTES_32 sha256(flyoverRedeemScript)`), i.e. a nested P2SH-P2WSH address.
+    /// The two therefore derive DIFFERENT Bitcoin addresses for identical inputs. The real
+    /// FLY-2436 derivation MUST reconcile this (match PegInContract) before production, or the
+    /// switch to plain P2SH must be an explicit, signed-off cross-contract redesign. See the
+    /// tripwire test `test_derivation_scheme_differs_from_pegin_contract`.
     function flyoverScriptHash(bytes memory redeemScript) internal pure returns (bytes20) {
         return ripemd160(abi.encodePacked(sha256(redeemScript)));
     }

--- a/src/libraries/PegInDerivation.sol
+++ b/src/libraries/PegInDerivation.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {OpCodes} from "@rsksmart/btc-transaction-solidity-helper/contracts/OpCodes.sol";
+
+/// @title PegInDerivation
+/// @notice Step-composed peg-in deposit-address derivation helpers.
+/// @dev Each derivation step is a separate function so callers (e.g. {PegInAddressRegistry})
+/// compose the flyover redeem script and P2SH payload without duplicating script math.
+library PegInDerivation {
+    /// @notice Versioned scheme tag mixed into every derivation.
+    bytes internal constant DERIVATION_DOMAIN = "FLYOVER_PEGIN_V1";
+
+    /// @notice FIXED protocol-wide placeholder for `userRefundBtcAddress`.
+    function refundPlaceholderBtc() internal pure returns (bytes memory) {
+        return hex"6f044f0ba3d3a2bd0724db5e6d59a0bb62f4ef0cc2";
+    }
+
+    /// @notice FIXED protocol-wide placeholder for `liquidityProviderBtcAddress`.
+    function lpPlaceholderBtc() internal pure returns (bytes memory) {
+        return hex"6f044f0ba3d3a2bd0724db5e6d59a0bb62f4ef0cc2";
+    }
+
+    /// @notice The derivation-arguments hash for `rskAddr`.
+    function derivationArgumentsHash(address rskAddr) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(DERIVATION_DOMAIN, rskAddr));
+    }
+
+    /// @notice The 32-byte derivation value mixed with placeholders and the PegInContract address.
+    function derivationValue(address rskAddr, address pegInContract) internal pure returns (bytes32) {
+        return keccak256(
+            bytes.concat(
+                derivationArgumentsHash(rskAddr), refundPlaceholderBtc(), bytes20(pegInContract), lpPlaceholderBtc()
+            )
+        );
+    }
+
+    /// @notice Flyover redeem script: OP_PUSHBYTES_32 <derivationValue> OP_DROP <activePowpegRedeemScript>.
+    function flyoverRedeemScript(bytes32 derivationValue_, bytes memory activePowpegRedeemScript)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return bytes.concat(OpCodes.OP_PUSHBYTES_32, derivationValue_, OpCodes.OP_DROP, activePowpegRedeemScript);
+    }
+
+    /// @notice HASH160 of the flyover redeem script.
+    function flyoverScriptHash(bytes memory redeemScript) internal pure returns (bytes20) {
+        return ripemd160(abi.encodePacked(sha256(redeemScript)));
+    }
+
+    /// @notice On-chain P2SH scriptPubkey: OP_HASH160 <hash160> OP_EQUAL.
+    function p2shScriptPubkey(bytes20 scriptHash) internal pure returns (bytes memory) {
+        return bytes.concat(OpCodes.OP_HASH160, bytes1(uint8(20)), scriptHash, OpCodes.OP_EQUAL);
+    }
+
+    /// @notice Base58check payload of the PLAIN P2SH deposit address.
+    function depositAddressPayload(bytes20 scriptHash, bool mainnet) internal pure returns (bytes memory) {
+        bytes1 version = mainnet ? bytes1(0x05) : bytes1(0xC4);
+        bytes memory versionedHash = bytes.concat(version, scriptHash);
+        bytes32 checksum = sha256(abi.encodePacked(sha256(versionedHash)));
+        return bytes.concat(versionedHash, checksum[0], checksum[1], checksum[2], checksum[3]);
+    }
+}

--- a/test/PegInAddressRegistry.reads.t.sol
+++ b/test/PegInAddressRegistry.reads.t.sol
@@ -9,37 +9,40 @@ import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Ini
 
 /// @title PegInAddressRegistry read-surface tests
 contract PegInAddressRegistryReadsTest is PegInRegistryTestBase {
-    address internal constant FIXTURE_RSK = 0x0000000000000000000000000000000000000aBc;
-    bytes internal constant FIXTURE_TESTNET_ADDRESS = hex"c453239f29b16aa66c9a5e3ec7f2b1de034fe0dea79440b320";
-    bytes internal constant FIXTURE_MAINNET_ADDRESS = hex"0553239f29b16aa66c9a5e3ec7f2b1de034fe0dea72259d920";
+    address internal constant FIXTURE_RSK =
+        0x0000000000000000000000000000000000000aBc;
+    bytes internal constant FIXTURE_TESTNET_ADDRESS =
+        hex"c453239f29b16aa66c9a5e3ec7f2b1de034fe0dea79440b320";
+    bytes internal constant FIXTURE_MAINNET_ADDRESS =
+        hex"0553239f29b16aa66c9a5e3ec7f2b1de034fe0dea72259d920";
 
     // R1 — deterministic derivation
     function test_derive_deterministic_same_rskAddr() public {
         _deploy(false);
-        (bytes memory a1,) = registry.getPegInAddress(FIXTURE_RSK);
-        (bytes memory a2,) = registry.getPegInAddress(FIXTURE_RSK);
+        (bytes memory a1, ) = registry.getPegInAddress(FIXTURE_RSK);
+        (bytes memory a2, ) = registry.getPegInAddress(FIXTURE_RSK);
         assertEq(a1, a2);
     }
 
     // R2 — distinct addresses
     function test_derive_distinct_rskAddrs() public {
         _deploy(false);
-        (bytes memory a,) = registry.getPegInAddress(address(0x1111));
-        (bytes memory b,) = registry.getPegInAddress(address(0x2222));
+        (bytes memory a, ) = registry.getPegInAddress(address(0x1111));
+        (bytes memory b, ) = registry.getPegInAddress(address(0x2222));
         assertTrue(keccak256(a) != keccak256(b));
     }
 
     // R3 — network version bytes
     function test_testnet_prefix_0xC4() public {
         _deploy(false);
-        (bytes memory addr,) = registry.getPegInAddress(FIXTURE_RSK);
+        (bytes memory addr, ) = registry.getPegInAddress(FIXTURE_RSK);
         assertEq(addr, FIXTURE_TESTNET_ADDRESS);
         assertEq(_addressVersionByte(addr), bytes1(0xC4));
     }
 
     function test_mainnet_prefix_0x05() public {
         _deploy(true);
-        (bytes memory addr,) = registry.getPegInAddress(FIXTURE_RSK);
+        (bytes memory addr, ) = registry.getPegInAddress(FIXTURE_RSK);
         assertEq(addr, FIXTURE_MAINNET_ADDRESS);
         assertEq(_addressVersionByte(addr), bytes1(0x05));
     }
@@ -67,7 +70,8 @@ contract PegInAddressRegistryReadsTest is PegInRegistryTestBase {
     function test_getRegistration_returns_struct() public {
         _deploy(false);
         _seedRegistration(FIXTURE_RSK, stranger, uint96(99));
-        IPegInAddressRegistry.Registration memory reg = registry.getRegistration(FIXTURE_RSK);
+        IPegInAddressRegistry.Registration memory reg = registry
+            .getRegistration(FIXTURE_RSK);
         assertEq(reg.registrant, stranger);
         assertEq(reg.registrationBlock, 99);
     }
@@ -102,9 +106,15 @@ contract PegInAddressRegistryReadsTest is PegInRegistryTestBase {
 
     // R10 — ERC-7201 namespace
     function test_storage_layout_erc7201() public pure {
-        bytes32 expected =
-            keccak256(abi.encode(uint256(keccak256("rsk.flyover.PegInAddressRegistry")) - 1)) & ~bytes32(uint256(0xff));
-        assertEq(expected, 0x0704e3acad2c0308b9997bc861208a21efddaa710005747040bdddc7b9400f00);
+        bytes32 expected = keccak256(
+            abi.encode(
+                uint256(keccak256("rsk.flyover.PegInAddressRegistry")) - 1
+            )
+        ) & ~bytes32(uint256(0xff));
+        assertEq(
+            expected,
+            0x0704e3acad2c0308b9997bc861208a21efddaa710005747040bdddc7b9400f00
+        );
     }
 
     // R2 bounds — batch cap
@@ -114,7 +124,13 @@ contract PegInAddressRegistryReadsTest is PegInRegistryTestBase {
         for (uint256 i = 0; i < 101; ++i) {
             addrs[i] = address(uint160(i + 1));
         }
-        vm.expectRevert(abi.encodeWithSelector(PegInAddressRegistry.BatchTooLarge.selector, 101, 100));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                PegInAddressRegistry.BatchTooLarge.selector,
+                101,
+                100
+            )
+        );
         registry.getPegInAddresses(addrs);
     }
 
@@ -123,9 +139,9 @@ contract PegInAddressRegistryReadsTest is PegInRegistryTestBase {
         address[] memory addrs = new address[](2);
         addrs[0] = FIXTURE_RSK;
         addrs[1] = address(0x2222);
-        (bytes[] memory batch,) = registry.getPegInAddresses(addrs);
-        (bytes memory single0,) = registry.getPegInAddress(FIXTURE_RSK);
-        (bytes memory single1,) = registry.getPegInAddress(address(0x2222));
+        (bytes[] memory batch, ) = registry.getPegInAddresses(addrs);
+        (bytes memory single0, ) = registry.getPegInAddress(FIXTURE_RSK);
+        (bytes memory single1, ) = registry.getPegInAddress(address(0x2222));
         assertEq(batch[0], single0);
         assertEq(batch[1], single1);
     }
@@ -152,7 +168,9 @@ contract PegInAddressRegistryReadsTest is PegInRegistryTestBase {
 
     function test_encoding_is_base58() public {
         _deploy(false);
-        (, IPegInAddressRegistry.Encoding enc) = registry.getPegInAddress(FIXTURE_RSK);
+        (, IPegInAddressRegistry.Encoding enc) = registry.getPegInAddress(
+            FIXTURE_RSK
+        );
         assertEq(uint256(enc), uint256(IPegInAddressRegistry.Encoding.BASE58));
     }
 }

--- a/test/PegInAddressRegistry.reads.t.sol
+++ b/test/PegInAddressRegistry.reads.t.sol
@@ -70,7 +70,9 @@ contract PegInAddressRegistryReadsTest is PegInRegistryTestBase {
     function test_registerAddress_stub_reverts() public {
         _deploy(false);
         bytes32[] memory hashes = new bytes32[](0);
-        vm.expectRevert(IPegInAddressRegistry.RegisterAddressNotImplemented.selector);
+        vm.expectRevert(
+            IPegInAddressRegistry.RegisterAddressNotImplemented.selector
+        );
         registry.registerAddress(FIXTURE_RSK, hex"", bytes32(0), 0, hashes);
     }
 
@@ -80,14 +82,18 @@ contract PegInAddressRegistryReadsTest is PegInRegistryTestBase {
             PegInAddressRegistry.initialize,
             (owner, ADMIN_DELAY, address(0), false)
         );
-        vm.expectRevert(abi.encodeWithSelector(Flyover.NoContract.selector, address(0)));
+        vm.expectRevert(
+            abi.encodeWithSelector(Flyover.NoContract.selector, address(0))
+        );
         new ERC1967Proxy(address(impl), initData);
     }
 
     function test_setPegInContract_reverts_when_zero() public {
         _deploy(false);
         vm.prank(owner);
-        vm.expectRevert(abi.encodeWithSelector(Flyover.NoContract.selector, address(0)));
+        vm.expectRevert(
+            abi.encodeWithSelector(Flyover.NoContract.selector, address(0))
+        );
         registry.setPegInContract(address(0));
     }
 
@@ -193,7 +199,8 @@ contract PegInAddressRegistryReadsTest is PegInRegistryTestBase {
     function test_batch_empty_returns_empty() public {
         _deploy(false);
         address[] memory addrs = new address[](0);
-        (bytes[] memory batch, IPegInAddressRegistry.Encoding enc) = registry.getPegInAddresses(addrs);
+        (bytes[] memory batch, IPegInAddressRegistry.Encoding enc) = registry
+            .getPegInAddresses(addrs);
         assertEq(batch.length, 0);
         assertEq(uint256(enc), uint256(IPegInAddressRegistry.Encoding.BASE58));
     }

--- a/test/PegInAddressRegistry.reads.t.sol
+++ b/test/PegInAddressRegistry.reads.t.sol
@@ -3,11 +3,13 @@ pragma solidity 0.8.25;
 
 import {PegInRegistryTestBase} from "./pegin-registry/PegInRegistryTestBase.sol";
 import {PegInAddressRegistry} from "../src/PegInAddressRegistry.sol";
+import {PegInAddressRegistryHarness} from "./pegin-registry/PegInAddressRegistryHarness.sol";
 import {IPegInAddressRegistry} from "../src/interfaces/IPegInAddressRegistry.sol";
 import {Flyover} from "../src/libraries/Flyover.sol";
 import {PegInDerivation} from "../src/libraries/PegInDerivation.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {OpCodes} from "@rsksmart/btc-transaction-solidity-helper/contracts/OpCodes.sol";
 
 /// @title PegInAddressRegistry read-surface tests
@@ -53,8 +55,40 @@ contract PegInAddressRegistryReadsTest is PegInRegistryTestBase {
     // R4 — unset pegInContract
     function test_revert_when_pegInContract_unset() public {
         registry = _deployUnwired(false);
-        vm.expectRevert(PegInAddressRegistry.PegInContractNotSet.selector);
+        vm.expectRevert(IPegInAddressRegistry.PegInContractNotSet.selector);
         registry.getPegInAddress(FIXTURE_RSK);
+    }
+
+    function test_batch_reverts_when_pegInContract_unset() public {
+        registry = _deployUnwired(false);
+        address[] memory addrs = new address[](1);
+        addrs[0] = FIXTURE_RSK;
+        vm.expectRevert(IPegInAddressRegistry.PegInContractNotSet.selector);
+        registry.getPegInAddresses(addrs);
+    }
+
+    function test_registerAddress_stub_reverts() public {
+        _deploy(false);
+        bytes32[] memory hashes = new bytes32[](0);
+        vm.expectRevert(IPegInAddressRegistry.RegisterAddressNotImplemented.selector);
+        registry.registerAddress(FIXTURE_RSK, hex"", bytes32(0), 0, hashes);
+    }
+
+    function test_initialize_reverts_when_bridge_zero() public {
+        PegInAddressRegistryHarness impl = new PegInAddressRegistryHarness();
+        bytes memory initData = abi.encodeCall(
+            PegInAddressRegistry.initialize,
+            (owner, ADMIN_DELAY, address(0), false)
+        );
+        vm.expectRevert(abi.encodeWithSelector(Flyover.NoContract.selector, address(0)));
+        new ERC1967Proxy(address(impl), initData);
+    }
+
+    function test_setPegInContract_reverts_when_zero() public {
+        _deploy(false);
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(Flyover.NoContract.selector, address(0)));
+        registry.setPegInContract(address(0));
     }
 
     // R5 — isRegistered
@@ -105,6 +139,7 @@ contract PegInAddressRegistryReadsTest is PegInRegistryTestBase {
         emit PegInAddressRegistry.PegInContractSet(PEGIN_CONTRACT, newPegIn);
         vm.prank(owner);
         registry.setPegInContract(newPegIn);
+        assertEq(registry.getPegInContract(), newPegIn);
     }
 
     // R9 — getPegInContract
@@ -135,12 +170,32 @@ contract PegInAddressRegistryReadsTest is PegInRegistryTestBase {
         }
         vm.expectRevert(
             abi.encodeWithSelector(
-                PegInAddressRegistry.BatchTooLarge.selector,
+                IPegInAddressRegistry.BatchTooLarge.selector,
                 101,
                 100
             )
         );
         registry.getPegInAddresses(addrs);
+    }
+
+    function test_batch_accepts_max_size() public {
+        _deploy(false);
+        address[] memory addrs = new address[](100);
+        for (uint256 i = 0; i < 100; ++i) {
+            addrs[i] = address(uint160(i + 1));
+        }
+        (bytes[] memory batch, ) = registry.getPegInAddresses(addrs);
+        assertEq(batch.length, 100);
+        (bytes memory single, ) = registry.getPegInAddress(addrs[0]);
+        assertEq(batch[0], single);
+    }
+
+    function test_batch_empty_returns_empty() public {
+        _deploy(false);
+        address[] memory addrs = new address[](0);
+        (bytes[] memory batch, IPegInAddressRegistry.Encoding enc) = registry.getPegInAddresses(addrs);
+        assertEq(batch.length, 0);
+        assertEq(uint256(enc), uint256(IPegInAddressRegistry.Encoding.BASE58));
     }
 
     function test_batch_returns_matching_singles() public {

--- a/test/PegInAddressRegistry.reads.t.sol
+++ b/test/PegInAddressRegistry.reads.t.sol
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {PegInRegistryTestBase} from "./pegin-registry/PegInRegistryTestBase.sol";
+import {PegInAddressRegistryHarness} from "./pegin-registry/PegInAddressRegistryHarness.sol";
+import {PegInAddressRegistry} from "../src/PegInAddressRegistry.sol";
+import {IPegInAddressRegistry} from "../src/interfaces/IPegInAddressRegistry.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+/// @title PegInAddressRegistry read-surface tests
+contract PegInAddressRegistryReadsTest is PegInRegistryTestBase {
+    address internal constant FIXTURE_RSK = 0x0000000000000000000000000000000000000aBc;
+    bytes internal constant FIXTURE_TESTNET_ADDRESS = hex"c453239f29b16aa66c9a5e3ec7f2b1de034fe0dea79440b320";
+    bytes internal constant FIXTURE_MAINNET_ADDRESS = hex"0553239f29b16aa66c9a5e3ec7f2b1de034fe0dea72259d920";
+
+    // R1 — deterministic derivation
+    function test_derive_deterministic_same_rskAddr() public {
+        _deploy(false);
+        (bytes memory a1,) = registry.getPegInAddress(FIXTURE_RSK);
+        (bytes memory a2,) = registry.getPegInAddress(FIXTURE_RSK);
+        assertEq(a1, a2);
+    }
+
+    // R2 — distinct addresses
+    function test_derive_distinct_rskAddrs() public {
+        _deploy(false);
+        (bytes memory a,) = registry.getPegInAddress(address(0x1111));
+        (bytes memory b,) = registry.getPegInAddress(address(0x2222));
+        assertTrue(keccak256(a) != keccak256(b));
+    }
+
+    // R3 — network version bytes
+    function test_testnet_prefix_0xC4() public {
+        _deploy(false);
+        (bytes memory addr,) = registry.getPegInAddress(FIXTURE_RSK);
+        assertEq(addr, FIXTURE_TESTNET_ADDRESS);
+        assertEq(_addressVersionByte(addr), bytes1(0xC4));
+    }
+
+    function test_mainnet_prefix_0x05() public {
+        _deploy(true);
+        (bytes memory addr,) = registry.getPegInAddress(FIXTURE_RSK);
+        assertEq(addr, FIXTURE_MAINNET_ADDRESS);
+        assertEq(_addressVersionByte(addr), bytes1(0x05));
+    }
+
+    // R4 — unset pegInContract
+    function test_revert_when_pegInContract_unset() public {
+        registry = _deployUnwired(false);
+        vm.expectRevert(PegInAddressRegistry.PegInContractNotSet.selector);
+        registry.getPegInAddress(FIXTURE_RSK);
+    }
+
+    // R5 — isRegistered
+    function test_isRegistered_false_when_unseeded() public {
+        _deploy(false);
+        assertFalse(registry.isRegistered(FIXTURE_RSK));
+    }
+
+    function test_isRegistered_true_when_block_set() public {
+        _deploy(false);
+        _seedRegistration(FIXTURE_RSK, stranger, uint96(42));
+        assertTrue(registry.isRegistered(FIXTURE_RSK));
+    }
+
+    // R6 — getRegistration struct
+    function test_getRegistration_returns_struct() public {
+        _deploy(false);
+        _seedRegistration(FIXTURE_RSK, stranger, uint96(99));
+        IPegInAddressRegistry.Registration memory reg = registry.getRegistration(FIXTURE_RSK);
+        assertEq(reg.registrant, stranger);
+        assertEq(reg.registrationBlock, 99);
+    }
+
+    // R7 — registration root fold
+    function test_getRegistrationRoot_fold() public {
+        _deploy(false);
+        bytes32 root = keccak256(abi.encodePacked(bytes32(0), FIXTURE_RSK));
+        _seedRegistrationRoot(root);
+        assertEq(registry.getRegistrationRoot(), root);
+    }
+
+    // R8 — admin-only setPegInContract
+    function test_setPegInContract_admin_only() public {
+        _deploy(false);
+        address newPegIn = address(0xDEAD);
+        vm.prank(stranger);
+        vm.expectRevert();
+        registry.setPegInContract(newPegIn);
+
+        vm.expectEmit(true, true, true, true);
+        emit PegInAddressRegistry.PegInContractSet(PEGIN_CONTRACT, newPegIn);
+        vm.prank(owner);
+        registry.setPegInContract(newPegIn);
+    }
+
+    // R9 — getPegInContract
+    function test_getPegInContract_returns_stored() public {
+        _deploy(false);
+        assertEq(registry.getPegInContract(), PEGIN_CONTRACT);
+    }
+
+    // R10 — ERC-7201 namespace
+    function test_storage_layout_erc7201() public pure {
+        bytes32 expected =
+            keccak256(abi.encode(uint256(keccak256("rsk.flyover.PegInAddressRegistry")) - 1)) & ~bytes32(uint256(0xff));
+        assertEq(expected, 0x0704e3acad2c0308b9997bc861208a21efddaa710005747040bdddc7b9400f00);
+    }
+
+    // R2 bounds — batch cap
+    function test_batch_reverts_over_max() public {
+        _deploy(false);
+        address[] memory addrs = new address[](101);
+        for (uint256 i = 0; i < 101; ++i) {
+            addrs[i] = address(uint160(i + 1));
+        }
+        vm.expectRevert(abi.encodeWithSelector(PegInAddressRegistry.BatchTooLarge.selector, 101, 100));
+        registry.getPegInAddresses(addrs);
+    }
+
+    function test_batch_returns_matching_singles() public {
+        _deploy(false);
+        address[] memory addrs = new address[](2);
+        addrs[0] = FIXTURE_RSK;
+        addrs[1] = address(0x2222);
+        (bytes[] memory batch,) = registry.getPegInAddresses(addrs);
+        (bytes memory single0,) = registry.getPegInAddress(FIXTURE_RSK);
+        (bytes memory single1,) = registry.getPegInAddress(address(0x2222));
+        assertEq(batch[0], single0);
+        assertEq(batch[1], single1);
+    }
+
+    // R11 — ABI artifacts exist after build (selector smoke)
+    function test_abi_provenance_recorded() public {
+        _deploy(false);
+        assertEq(registry.VERSION(), "1.0.0");
+        assertEq(registry.MAX_PEGIN_ADDRESS_BATCH(), 100);
+    }
+
+    function test_deploys_and_initializes() public {
+        _deploy(false);
+        assertEq(address(registry.getBridge()), address(bridge));
+        assertEq(registry.getRegistrationRoot(), bytes32(0));
+        assertTrue(registry.hasRole(registry.DEFAULT_ADMIN_ROLE(), owner));
+    }
+
+    function test_second_initialize_reverts() public {
+        _deploy(false);
+        vm.expectRevert(Initializable.InvalidInitialization.selector);
+        registry.initialize(owner, ADMIN_DELAY, address(bridge), false);
+    }
+
+    function test_encoding_is_base58() public {
+        _deploy(false);
+        (, IPegInAddressRegistry.Encoding enc) = registry.getPegInAddress(FIXTURE_RSK);
+        assertEq(uint256(enc), uint256(IPegInAddressRegistry.Encoding.BASE58));
+    }
+}

--- a/test/PegInAddressRegistry.reads.t.sol
+++ b/test/PegInAddressRegistry.reads.t.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.25;
 import {PegInRegistryTestBase} from "./pegin-registry/PegInRegistryTestBase.sol";
 import {PegInAddressRegistry} from "../src/PegInAddressRegistry.sol";
 import {IPegInAddressRegistry} from "../src/interfaces/IPegInAddressRegistry.sol";
+import {Flyover} from "../src/libraries/Flyover.sol";
 import {PegInDerivation} from "../src/libraries/PegInDerivation.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
@@ -180,6 +181,15 @@ contract PegInAddressRegistryReadsTest is PegInRegistryTestBase {
             FIXTURE_RSK
         );
         assertEq(uint256(enc), uint256(IPegInAddressRegistry.Encoding.BASE58));
+    }
+
+    function test_receive_reverts_payment_not_allowed() public {
+        _deploy(false);
+        vm.deal(stranger, 1 ether);
+        vm.prank(stranger);
+        vm.expectRevert(Flyover.PaymentNotAllowed.selector);
+        (bool ok, ) = payable(address(registry)).call{value: 1 ether}("");
+        ok; // call is expected to revert via expectRevert
     }
 
     // Tripwire — documents the known scheme divergence flagged in Copilot review

--- a/test/PegInAddressRegistry.reads.t.sol
+++ b/test/PegInAddressRegistry.reads.t.sol
@@ -4,7 +4,10 @@ pragma solidity 0.8.25;
 import {PegInRegistryTestBase} from "./pegin-registry/PegInRegistryTestBase.sol";
 import {PegInAddressRegistry} from "../src/PegInAddressRegistry.sol";
 import {IPegInAddressRegistry} from "../src/interfaces/IPegInAddressRegistry.sol";
+import {PegInDerivation} from "../src/libraries/PegInDerivation.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
+import {OpCodes} from "@rsksmart/btc-transaction-solidity-helper/contracts/OpCodes.sol";
 
 /// @title PegInAddressRegistry read-surface tests
 contract PegInAddressRegistryReadsTest is PegInRegistryTestBase {
@@ -87,8 +90,14 @@ contract PegInAddressRegistryReadsTest is PegInRegistryTestBase {
     function test_setPegInContract_admin_only() public {
         _deploy(false);
         address newPegIn = address(0xDEAD);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                stranger,
+                registry.DEFAULT_ADMIN_ROLE()
+            )
+        );
         vm.prank(stranger);
-        vm.expectRevert();
         registry.setPegInContract(newPegIn);
 
         vm.expectEmit(true, true, true, true);
@@ -171,5 +180,34 @@ contract PegInAddressRegistryReadsTest is PegInRegistryTestBase {
             FIXTURE_RSK
         );
         assertEq(uint256(enc), uint256(IPegInAddressRegistry.Encoding.BASE58));
+    }
+
+    // Tripwire — documents the known scheme divergence flagged in Copilot review
+    // r3542766572. The temporary mock PegInDerivation derives a PLAIN P2SH payload
+    // (HASH160 of the flyover redeem script), while PegInContract.validatePegInDepositAddress
+    // derives a nested P2SH-P2WSH payload (HASH160 of OP_0 <32-byte sha256(redeemScript)>),
+    // so the two produce DIFFERENT deposit addresses. This asserts that expected
+    // incompatibility. When FLY-2436 reconciles the schemes (or intentionally moves to
+    // plain P2SH), this test must be revisited as an explicit cross-contract decision.
+    function test_derivation_scheme_differs_from_pegin_contract() public {
+        _deploy(false);
+        bytes memory powpeg = bridge.getActivePowpegRedeemScript();
+        bytes32 dv = PegInDerivation.derivationValue(
+            FIXTURE_RSK,
+            PEGIN_CONTRACT
+        );
+        bytes memory redeem = PegInDerivation.flyoverRedeemScript(dv, powpeg);
+
+        bytes20 mockPlainP2sh = PegInDerivation.flyoverScriptHash(redeem);
+        bytes memory segwitScript = bytes.concat(
+            OpCodes.OP_0,
+            OpCodes.OP_PUSHBYTES_32,
+            sha256(redeem)
+        );
+        bytes20 canonicalNestedP2sh = ripemd160(
+            abi.encodePacked(sha256(segwitScript))
+        );
+
+        assertTrue(mockPlainP2sh != canonicalNestedP2sh);
     }
 }

--- a/test/PegInAddressRegistry.reads.t.sol
+++ b/test/PegInAddressRegistry.reads.t.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.25;
 
 import {PegInRegistryTestBase} from "./pegin-registry/PegInRegistryTestBase.sol";
-import {PegInAddressRegistryHarness} from "./pegin-registry/PegInAddressRegistryHarness.sol";
 import {PegInAddressRegistry} from "../src/PegInAddressRegistry.sol";
 import {IPegInAddressRegistry} from "../src/interfaces/IPegInAddressRegistry.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";

--- a/test/pegin-registry/PegInAddressRegistryHarness.sol
+++ b/test/pegin-registry/PegInAddressRegistryHarness.sol
@@ -7,10 +7,16 @@ import {IPegInAddressRegistry} from "../../src/interfaces/IPegInAddressRegistry.
 /// @title PegInAddressRegistryHarness
 /// @notice Test-only harness exposing storage seed helpers for read-surface tests.
 contract PegInAddressRegistryHarness is PegInAddressRegistry {
-    function harness_seedRegistration(address addr, address registrant, uint96 registrationBlock) external {
+    function harness_seedRegistration(
+        address addr,
+        address registrant,
+        uint96 registrationBlock
+    ) external {
         PegInAddressRegistryStorage storage $ = _getStorage();
-        $.registrations[addr] =
-            IPegInAddressRegistry.Registration({registrant: registrant, registrationBlock: registrationBlock});
+        $.registrations[addr] = IPegInAddressRegistry.Registration({
+            registrant: registrant,
+            registrationBlock: registrationBlock
+        });
     }
 
     function harness_seedRegistrationRoot(bytes32 root) external {

--- a/test/pegin-registry/PegInAddressRegistryHarness.sol
+++ b/test/pegin-registry/PegInAddressRegistryHarness.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {PegInAddressRegistry} from "../../src/PegInAddressRegistry.sol";
+import {IPegInAddressRegistry} from "../../src/interfaces/IPegInAddressRegistry.sol";
+
+/// @title PegInAddressRegistryHarness
+/// @notice Test-only harness exposing storage seed helpers for read-surface tests.
+contract PegInAddressRegistryHarness is PegInAddressRegistry {
+    function harness_seedRegistration(address addr, address registrant, uint96 registrationBlock) external {
+        PegInAddressRegistryStorage storage $ = _getStorage();
+        $.registrations[addr] =
+            IPegInAddressRegistry.Registration({registrant: registrant, registrationBlock: registrationBlock});
+    }
+
+    function harness_seedRegistrationRoot(bytes32 root) external {
+        PegInAddressRegistryStorage storage $ = _getStorage();
+        $.registrationRoot = root;
+    }
+}

--- a/test/pegin-registry/PegInRegistryTestBase.sol
+++ b/test/pegin-registry/PegInRegistryTestBase.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {PegInAddressRegistry} from "../../src/PegInAddressRegistry.sol";
+import {PegInAddressRegistryHarness} from "./PegInAddressRegistryHarness.sol";
+import {RegistryBridgeMock} from "./RegistryBridgeMock.sol";
+
+/// @title PegInRegistryTestBase
+/// @notice Shared proxy deploy setup for PegInAddressRegistry read tests.
+abstract contract PegInRegistryTestBase is Test {
+    uint48 internal constant ADMIN_DELAY = 0;
+
+    address internal constant PEGIN_CONTRACT = address(0x00000000000000000000000000000000C0FFEE01);
+
+    address internal owner = address(0xA11CE);
+    address internal stranger = address(0xB0B);
+
+    PegInAddressRegistryHarness internal registry;
+    RegistryBridgeMock internal bridge;
+
+    function _deploy(bool mainnet) internal {
+        bridge = new RegistryBridgeMock();
+        PegInAddressRegistryHarness impl = new PegInAddressRegistryHarness();
+        bytes memory initData =
+            abi.encodeCall(PegInAddressRegistry.initialize, (owner, ADMIN_DELAY, address(bridge), mainnet));
+        ERC1967Proxy proxy = new ERC1967Proxy(address(impl), initData);
+        registry = PegInAddressRegistryHarness(payable(address(proxy)));
+        vm.prank(owner);
+        registry.setPegInContract(PEGIN_CONTRACT);
+    }
+
+    function _deployUnwired(bool mainnet) internal returns (PegInAddressRegistryHarness r) {
+        if (address(bridge) == address(0)) bridge = new RegistryBridgeMock();
+        PegInAddressRegistryHarness impl = new PegInAddressRegistryHarness();
+        bytes memory initData =
+            abi.encodeCall(PegInAddressRegistry.initialize, (owner, ADMIN_DELAY, address(bridge), mainnet));
+        ERC1967Proxy proxy = new ERC1967Proxy(address(impl), initData);
+        r = PegInAddressRegistryHarness(payable(address(proxy)));
+    }
+
+    function _seedRegistration(address addr, address registrant, uint96 registrationBlock) internal {
+        registry.harness_seedRegistration(addr, registrant, registrationBlock);
+    }
+
+    function _seedRegistrationRoot(bytes32 root) internal {
+        registry.harness_seedRegistrationRoot(root);
+    }
+
+    function _addressVersionByte(bytes memory payload) internal pure returns (bytes1) {
+        require(payload.length > 0, "empty payload");
+        return payload[0];
+    }
+}

--- a/test/pegin-registry/PegInRegistryTestBase.sol
+++ b/test/pegin-registry/PegInRegistryTestBase.sol
@@ -12,7 +12,8 @@ import {RegistryBridgeMock} from "./RegistryBridgeMock.sol";
 abstract contract PegInRegistryTestBase is Test {
     uint48 internal constant ADMIN_DELAY = 0;
 
-    address internal constant PEGIN_CONTRACT = address(0x00000000000000000000000000000000C0FFEE01);
+    address internal constant PEGIN_CONTRACT =
+        address(0x00000000000000000000000000000000C0FFEE01);
 
     address internal owner = address(0xA11CE);
     address internal stranger = address(0xB0B);
@@ -23,24 +24,34 @@ abstract contract PegInRegistryTestBase is Test {
     function _deploy(bool mainnet) internal {
         bridge = new RegistryBridgeMock();
         PegInAddressRegistryHarness impl = new PegInAddressRegistryHarness();
-        bytes memory initData =
-            abi.encodeCall(PegInAddressRegistry.initialize, (owner, ADMIN_DELAY, address(bridge), mainnet));
+        bytes memory initData = abi.encodeCall(
+            PegInAddressRegistry.initialize,
+            (owner, ADMIN_DELAY, address(bridge), mainnet)
+        );
         ERC1967Proxy proxy = new ERC1967Proxy(address(impl), initData);
         registry = PegInAddressRegistryHarness(payable(address(proxy)));
         vm.prank(owner);
         registry.setPegInContract(PEGIN_CONTRACT);
     }
 
-    function _deployUnwired(bool mainnet) internal returns (PegInAddressRegistryHarness r) {
+    function _deployUnwired(
+        bool mainnet
+    ) internal returns (PegInAddressRegistryHarness r) {
         if (address(bridge) == address(0)) bridge = new RegistryBridgeMock();
         PegInAddressRegistryHarness impl = new PegInAddressRegistryHarness();
-        bytes memory initData =
-            abi.encodeCall(PegInAddressRegistry.initialize, (owner, ADMIN_DELAY, address(bridge), mainnet));
+        bytes memory initData = abi.encodeCall(
+            PegInAddressRegistry.initialize,
+            (owner, ADMIN_DELAY, address(bridge), mainnet)
+        );
         ERC1967Proxy proxy = new ERC1967Proxy(address(impl), initData);
         r = PegInAddressRegistryHarness(payable(address(proxy)));
     }
 
-    function _seedRegistration(address addr, address registrant, uint96 registrationBlock) internal {
+    function _seedRegistration(
+        address addr,
+        address registrant,
+        uint96 registrationBlock
+    ) internal {
         registry.harness_seedRegistration(addr, registrant, registrationBlock);
     }
 
@@ -48,7 +59,9 @@ abstract contract PegInRegistryTestBase is Test {
         registry.harness_seedRegistrationRoot(root);
     }
 
-    function _addressVersionByte(bytes memory payload) internal pure returns (bytes1) {
+    function _addressVersionByte(
+        bytes memory payload
+    ) internal pure returns (bytes1) {
         require(payload.length > 0, "empty payload");
         return payload[0];
     }

--- a/test/pegin-registry/RegistryBridgeMock.sol
+++ b/test/pegin-registry/RegistryBridgeMock.sol
@@ -20,7 +20,12 @@ contract RegistryBridgeMock is IBridge {
     // solhint-disable-next-line no-empty-blocks
     receive() external payable override {}
 
-    function getActivePowpegRedeemScript() external view override returns (bytes memory) {
+    function getActivePowpegRedeemScript()
+        external
+        view
+        override
+        returns (bytes memory)
+    {
         return _redeemScript;
     }
 
@@ -30,14 +35,30 @@ contract RegistryBridgeMock is IBridge {
 
     // ---- Unused IBridge surface (stubs) ----
     // solhint-disable no-empty-blocks
-    function registerBtcTransaction(bytes calldata, int256, bytes calldata) external override {}
-    function addSignature(bytes calldata, bytes[] calldata, bytes calldata) external override {}
+    function registerBtcTransaction(
+        bytes calldata,
+        int256,
+        bytes calldata
+    ) external override {}
+
+    function addSignature(
+        bytes calldata,
+        bytes[] calldata,
+        bytes calldata
+    ) external override {}
+
     function receiveHeaders(bytes[] calldata) external override {}
+
     function updateCollections() external override {}
-    function registerBtcCoinbaseTransaction(bytes calldata, bytes32, bytes calldata, bytes32, bytes32)
-        external
-        override
-    {}
+
+    function registerBtcCoinbaseTransaction(
+        bytes calldata,
+        bytes32,
+        bytes calldata,
+        bytes32,
+        bytes32
+    ) external override {}
+
     // solhint-enable no-empty-blocks
 
     function registerFastBridgeBtcTransaction(
@@ -53,7 +74,9 @@ contract RegistryBridgeMock is IBridge {
         return 0;
     }
 
-    function receiveHeader(bytes calldata) external pure override returns (int256) {
+    function receiveHeader(
+        bytes calldata
+    ) external pure override returns (int256) {
         return 0;
     }
 
@@ -61,11 +84,73 @@ contract RegistryBridgeMock is IBridge {
         return 0;
     }
 
-    function addFederatorPublicKey(bytes calldata) external pure override returns (int256) {
+    function addFederatorPublicKey(
+        bytes calldata
+    ) external pure override returns (int256) {
         return 0;
     }
 
-    function addFederatorPublicKeyMultikey(bytes calldata, bytes calldata, bytes calldata)
+    function addFederatorPublicKeyMultikey(
+        bytes calldata,
+        bytes calldata,
+        bytes calldata
+    ) external pure override returns (int256) {
+        return 0;
+    }
+
+    function commitFederation(
+        bytes calldata
+    ) external pure override returns (int256) {
+        return 0;
+    }
+
+    function rollbackFederation() external pure override returns (int256) {
+        return 0;
+    }
+
+    function addLockWhitelistAddress(
+        string calldata,
+        int256
+    ) external pure override returns (int256) {
+        return 0;
+    }
+
+    function addOneOffLockWhitelistAddress(
+        string calldata,
+        int256
+    ) external pure override returns (int256) {
+        return 0;
+    }
+
+    function addUnlimitedLockWhitelistAddress(
+        string calldata
+    ) external pure override returns (int256) {
+        return 0;
+    }
+
+    function removeLockWhitelistAddress(
+        string calldata
+    ) external pure override returns (int256) {
+        return 0;
+    }
+
+    function setLockWhitelistDisableBlockDelay(
+        int256
+    ) external pure override returns (int256) {
+        return 0;
+    }
+
+    function voteFeePerKbChange(
+        int256
+    ) external pure override returns (int256) {
+        return 0;
+    }
+
+    function increaseLockingCap(int256) external pure override returns (bool) {
+        return false;
+    }
+
+    function getBtcBlockchainBestChainHeight()
         external
         pure
         override
@@ -74,71 +159,57 @@ contract RegistryBridgeMock is IBridge {
         return 0;
     }
 
-    function commitFederation(bytes calldata) external pure override returns (int256) {
+    function getStateForBtcReleaseClient()
+        external
+        pure
+        override
+        returns (bytes memory)
+    {
+        return "";
+    }
+
+    function getStateForDebugging()
+        external
+        pure
+        override
+        returns (bytes memory)
+    {
+        return "";
+    }
+
+    function getBtcBlockchainInitialBlockHeight()
+        external
+        pure
+        override
+        returns (int256)
+    {
         return 0;
     }
 
-    function rollbackFederation() external pure override returns (int256) {
+    function getBtcBlockchainBlockHashAtDepth(
+        int256
+    ) external pure override returns (bytes memory) {
+        return "";
+    }
+
+    function getBtcTxHashProcessedHeight(
+        string calldata
+    ) external pure override returns (int64) {
         return 0;
     }
 
-    function addLockWhitelistAddress(string calldata, int256) external pure override returns (int256) {
-        return 0;
-    }
-
-    function addOneOffLockWhitelistAddress(string calldata, int256) external pure override returns (int256) {
-        return 0;
-    }
-
-    function addUnlimitedLockWhitelistAddress(string calldata) external pure override returns (int256) {
-        return 0;
-    }
-
-    function removeLockWhitelistAddress(string calldata) external pure override returns (int256) {
-        return 0;
-    }
-
-    function setLockWhitelistDisableBlockDelay(int256) external pure override returns (int256) {
-        return 0;
-    }
-
-    function voteFeePerKbChange(int256) external pure override returns (int256) {
-        return 0;
-    }
-
-    function increaseLockingCap(int256) external pure override returns (bool) {
+    function isBtcTxHashAlreadyProcessed(
+        string calldata
+    ) external pure override returns (bool) {
         return false;
     }
 
-    function getBtcBlockchainBestChainHeight() external pure override returns (int256) {
-        return 0;
-    }
-
-    function getStateForBtcReleaseClient() external pure override returns (bytes memory) {
-        return "";
-    }
-
-    function getStateForDebugging() external pure override returns (bytes memory) {
-        return "";
-    }
-
-    function getBtcBlockchainInitialBlockHeight() external pure override returns (int256) {
-        return 0;
-    }
-
-    function getBtcBlockchainBlockHashAtDepth(int256) external pure override returns (bytes memory) {
-        return "";
-    }
-
-    function getBtcTxHashProcessedHeight(string calldata) external pure override returns (int64) {
-        return 0;
-    }
-
-    function isBtcTxHashAlreadyProcessed(string calldata) external pure override returns (bool) {
-        return false;
-    }
-
-    function getFederationAddress() external pure override returns (string memory) {
+    function getFederationAddress()
+        external
+        pure
+        override
+        returns (string memory)
+    {
         return "";
     }
 
@@ -150,39 +221,96 @@ contract RegistryBridgeMock is IBridge {
         return 0;
     }
 
-    function getFederatorPublicKey(int256) external pure override returns (bytes memory) {
+    function getFederatorPublicKey(
+        int256
+    ) external pure override returns (bytes memory) {
         return "";
     }
 
-    function getFederatorPublicKeyOfType(int256, string calldata) external pure override returns (bytes memory) {
+    function getFederatorPublicKeyOfType(
+        int256,
+        string calldata
+    ) external pure override returns (bytes memory) {
         return "";
     }
 
-    function getFederationCreationTime() external pure override returns (int256) {
+    function getFederationCreationTime()
+        external
+        pure
+        override
+        returns (int256)
+    {
         return 0;
     }
 
-    function getFederationCreationBlockNumber() external pure override returns (int256) {
+    function getFederationCreationBlockNumber()
+        external
+        pure
+        override
+        returns (int256)
+    {
         return 0;
     }
 
-    function getRetiringFederationAddress() external pure override returns (string memory) {
+    function getRetiringFederationAddress()
+        external
+        pure
+        override
+        returns (string memory)
+    {
         return "";
     }
 
-    function getRetiringFederationSize() external pure override returns (int256) {
+    function getRetiringFederationSize()
+        external
+        pure
+        override
+        returns (int256)
+    {
         return 0;
     }
 
-    function getRetiringFederationThreshold() external pure override returns (int256) {
+    function getRetiringFederationThreshold()
+        external
+        pure
+        override
+        returns (int256)
+    {
         return 0;
     }
 
-    function getRetiringFederatorPublicKey(int256) external pure override returns (bytes memory) {
+    function getRetiringFederatorPublicKey(
+        int256
+    ) external pure override returns (bytes memory) {
         return "";
     }
 
-    function getRetiringFederatorPublicKeyOfType(int256, string calldata)
+    function getRetiringFederatorPublicKeyOfType(
+        int256,
+        string calldata
+    ) external pure override returns (bytes memory) {
+        return "";
+    }
+
+    function getRetiringFederationCreationTime()
+        external
+        pure
+        override
+        returns (int256)
+    {
+        return 0;
+    }
+
+    function getRetiringFederationCreationBlockNumber()
+        external
+        pure
+        override
+        returns (int256)
+    {
+        return 0;
+    }
+
+    function getPendingFederationHash()
         external
         pure
         override
@@ -191,27 +319,25 @@ contract RegistryBridgeMock is IBridge {
         return "";
     }
 
-    function getRetiringFederationCreationTime() external pure override returns (int256) {
+    function getPendingFederationSize()
+        external
+        pure
+        override
+        returns (int256)
+    {
         return 0;
     }
 
-    function getRetiringFederationCreationBlockNumber() external pure override returns (int256) {
-        return 0;
-    }
-
-    function getPendingFederationHash() external pure override returns (bytes memory) {
+    function getPendingFederatorPublicKey(
+        int256
+    ) external pure override returns (bytes memory) {
         return "";
     }
 
-    function getPendingFederationSize() external pure override returns (int256) {
-        return 0;
-    }
-
-    function getPendingFederatorPublicKey(int256) external pure override returns (bytes memory) {
-        return "";
-    }
-
-    function getPendingFederatorPublicKeyOfType(int256, string calldata) external pure override returns (bytes memory) {
+    function getPendingFederatorPublicKeyOfType(
+        int256,
+        string calldata
+    ) external pure override returns (bytes memory) {
         return "";
     }
 
@@ -219,11 +345,15 @@ contract RegistryBridgeMock is IBridge {
         return 0;
     }
 
-    function getLockWhitelistAddress(int256) external pure override returns (string memory) {
+    function getLockWhitelistAddress(
+        int256
+    ) external pure override returns (string memory) {
         return "";
     }
 
-    function getLockWhitelistEntryByAddress(string calldata) external pure override returns (int256) {
+    function getLockWhitelistEntryByAddress(
+        string calldata
+    ) external pure override returns (int256) {
         return 0;
     }
 
@@ -235,12 +365,12 @@ contract RegistryBridgeMock is IBridge {
         return 2;
     }
 
-    function getBtcTransactionConfirmations(bytes32, bytes32, uint256, bytes32[] calldata)
-        external
-        pure
-        override
-        returns (int256)
-    {
+    function getBtcTransactionConfirmations(
+        bytes32,
+        bytes32,
+        uint256,
+        bytes32[] calldata
+    ) external pure override returns (int256) {
         return 6;
     }
 
@@ -248,27 +378,45 @@ contract RegistryBridgeMock is IBridge {
         return 0;
     }
 
-    function hasBtcBlockCoinbaseTransactionInformation(bytes32) external pure override returns (bool) {
+    function hasBtcBlockCoinbaseTransactionInformation(
+        bytes32
+    ) external pure override returns (bool) {
         return false;
     }
 
-    function getActiveFederationCreationBlockHeight() external pure override returns (uint256) {
+    function getActiveFederationCreationBlockHeight()
+        external
+        pure
+        override
+        returns (uint256)
+    {
         return 0;
     }
 
-    function getBtcBlockchainBestBlockHeader() external pure override returns (bytes memory) {
+    function getBtcBlockchainBestBlockHeader()
+        external
+        pure
+        override
+        returns (bytes memory)
+    {
         return "";
     }
 
-    function getBtcBlockchainBlockHeaderByHash(bytes32) external pure override returns (bytes memory) {
+    function getBtcBlockchainBlockHeaderByHash(
+        bytes32
+    ) external pure override returns (bytes memory) {
         return "";
     }
 
-    function getBtcBlockchainBlockHeaderByHeight(uint256) external pure override returns (bytes memory) {
+    function getBtcBlockchainBlockHeaderByHeight(
+        uint256
+    ) external pure override returns (bytes memory) {
         return "";
     }
 
-    function getBtcBlockchainParentBlockHeaderByHash(bytes32) external pure override returns (bytes memory) {
+    function getBtcBlockchainParentBlockHeaderByHash(
+        bytes32
+    ) external pure override returns (bytes memory) {
         return "";
     }
 }

--- a/test/pegin-registry/RegistryBridgeMock.sol
+++ b/test/pegin-registry/RegistryBridgeMock.sol
@@ -62,13 +62,13 @@ contract RegistryBridgeMock is IBridge {
     // solhint-enable no-empty-blocks
 
     function registerFastBridgeBtcTransaction(
-        bytes memory,
+        bytes calldata,
         uint256,
-        bytes memory,
+        bytes calldata,
         bytes32,
-        bytes memory,
+        bytes calldata,
         address payable,
-        bytes memory,
+        bytes calldata,
         bool
     ) external pure override returns (int256) {
         return 0;

--- a/test/pegin-registry/RegistryBridgeMock.sol
+++ b/test/pegin-registry/RegistryBridgeMock.sol
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {IBridge} from "../../src/interfaces/IBridge.sol";
+
+/// @title RegistryBridgeMock
+/// @notice Standalone IBridge mock for PegInAddressRegistry tests.
+// solhint-disable comprehensive-interface
+contract RegistryBridgeMock is IBridge {
+    bytes private _redeemScript;
+
+    constructor() {
+        _redeemScript = abi.encodePacked(
+            hex"522102cd53fc53a07f211641a677d250f6de99caf620e8e77071e811a28b3bcddf0be1210362634ab5",
+            hex"7dae9cb373a5d536e66a8c4f67468bbcfb063809bab643072d78a1242103c5946b3fbae03a654237da86",
+            hex"3c9ed534e0878657175b132b8ca630f245df04db53ae"
+        );
+    }
+
+    // solhint-disable-next-line no-empty-blocks
+    receive() external payable override {}
+
+    function getActivePowpegRedeemScript() external view override returns (bytes memory) {
+        return _redeemScript;
+    }
+
+    function setRedeemScript(bytes calldata redeemScript) external {
+        _redeemScript = redeemScript;
+    }
+
+    // ---- Unused IBridge surface (stubs) ----
+    // solhint-disable no-empty-blocks
+    function registerBtcTransaction(bytes calldata, int256, bytes calldata) external override {}
+    function addSignature(bytes calldata, bytes[] calldata, bytes calldata) external override {}
+    function receiveHeaders(bytes[] calldata) external override {}
+    function updateCollections() external override {}
+    function registerBtcCoinbaseTransaction(bytes calldata, bytes32, bytes calldata, bytes32, bytes32)
+        external
+        override
+    {}
+    // solhint-enable no-empty-blocks
+
+    function registerFastBridgeBtcTransaction(
+        bytes memory,
+        uint256,
+        bytes memory,
+        bytes32,
+        bytes memory,
+        address payable,
+        bytes memory,
+        bool
+    ) external pure override returns (int256) {
+        return 0;
+    }
+
+    function receiveHeader(bytes calldata) external pure override returns (int256) {
+        return 0;
+    }
+
+    function createFederation() external pure override returns (int256) {
+        return 0;
+    }
+
+    function addFederatorPublicKey(bytes calldata) external pure override returns (int256) {
+        return 0;
+    }
+
+    function addFederatorPublicKeyMultikey(bytes calldata, bytes calldata, bytes calldata)
+        external
+        pure
+        override
+        returns (int256)
+    {
+        return 0;
+    }
+
+    function commitFederation(bytes calldata) external pure override returns (int256) {
+        return 0;
+    }
+
+    function rollbackFederation() external pure override returns (int256) {
+        return 0;
+    }
+
+    function addLockWhitelistAddress(string calldata, int256) external pure override returns (int256) {
+        return 0;
+    }
+
+    function addOneOffLockWhitelistAddress(string calldata, int256) external pure override returns (int256) {
+        return 0;
+    }
+
+    function addUnlimitedLockWhitelistAddress(string calldata) external pure override returns (int256) {
+        return 0;
+    }
+
+    function removeLockWhitelistAddress(string calldata) external pure override returns (int256) {
+        return 0;
+    }
+
+    function setLockWhitelistDisableBlockDelay(int256) external pure override returns (int256) {
+        return 0;
+    }
+
+    function voteFeePerKbChange(int256) external pure override returns (int256) {
+        return 0;
+    }
+
+    function increaseLockingCap(int256) external pure override returns (bool) {
+        return false;
+    }
+
+    function getBtcBlockchainBestChainHeight() external pure override returns (int256) {
+        return 0;
+    }
+
+    function getStateForBtcReleaseClient() external pure override returns (bytes memory) {
+        return "";
+    }
+
+    function getStateForDebugging() external pure override returns (bytes memory) {
+        return "";
+    }
+
+    function getBtcBlockchainInitialBlockHeight() external pure override returns (int256) {
+        return 0;
+    }
+
+    function getBtcBlockchainBlockHashAtDepth(int256) external pure override returns (bytes memory) {
+        return "";
+    }
+
+    function getBtcTxHashProcessedHeight(string calldata) external pure override returns (int64) {
+        return 0;
+    }
+
+    function isBtcTxHashAlreadyProcessed(string calldata) external pure override returns (bool) {
+        return false;
+    }
+
+    function getFederationAddress() external pure override returns (string memory) {
+        return "";
+    }
+
+    function getFederationSize() external pure override returns (int256) {
+        return 0;
+    }
+
+    function getFederationThreshold() external pure override returns (int256) {
+        return 0;
+    }
+
+    function getFederatorPublicKey(int256) external pure override returns (bytes memory) {
+        return "";
+    }
+
+    function getFederatorPublicKeyOfType(int256, string calldata) external pure override returns (bytes memory) {
+        return "";
+    }
+
+    function getFederationCreationTime() external pure override returns (int256) {
+        return 0;
+    }
+
+    function getFederationCreationBlockNumber() external pure override returns (int256) {
+        return 0;
+    }
+
+    function getRetiringFederationAddress() external pure override returns (string memory) {
+        return "";
+    }
+
+    function getRetiringFederationSize() external pure override returns (int256) {
+        return 0;
+    }
+
+    function getRetiringFederationThreshold() external pure override returns (int256) {
+        return 0;
+    }
+
+    function getRetiringFederatorPublicKey(int256) external pure override returns (bytes memory) {
+        return "";
+    }
+
+    function getRetiringFederatorPublicKeyOfType(int256, string calldata)
+        external
+        pure
+        override
+        returns (bytes memory)
+    {
+        return "";
+    }
+
+    function getRetiringFederationCreationTime() external pure override returns (int256) {
+        return 0;
+    }
+
+    function getRetiringFederationCreationBlockNumber() external pure override returns (int256) {
+        return 0;
+    }
+
+    function getPendingFederationHash() external pure override returns (bytes memory) {
+        return "";
+    }
+
+    function getPendingFederationSize() external pure override returns (int256) {
+        return 0;
+    }
+
+    function getPendingFederatorPublicKey(int256) external pure override returns (bytes memory) {
+        return "";
+    }
+
+    function getPendingFederatorPublicKeyOfType(int256, string calldata) external pure override returns (bytes memory) {
+        return "";
+    }
+
+    function getLockWhitelistSize() external pure override returns (int256) {
+        return 0;
+    }
+
+    function getLockWhitelistAddress(int256) external pure override returns (string memory) {
+        return "";
+    }
+
+    function getLockWhitelistEntryByAddress(string calldata) external pure override returns (int256) {
+        return 0;
+    }
+
+    function getFeePerKb() external pure override returns (int256) {
+        return 0;
+    }
+
+    function getMinimumLockTxValue() external pure override returns (int256) {
+        return 2;
+    }
+
+    function getBtcTransactionConfirmations(bytes32, bytes32, uint256, bytes32[] calldata)
+        external
+        pure
+        override
+        returns (int256)
+    {
+        return 6;
+    }
+
+    function getLockingCap() external pure override returns (int256) {
+        return 0;
+    }
+
+    function hasBtcBlockCoinbaseTransactionInformation(bytes32) external pure override returns (bool) {
+        return false;
+    }
+
+    function getActiveFederationCreationBlockHeight() external pure override returns (uint256) {
+        return 0;
+    }
+
+    function getBtcBlockchainBestBlockHeader() external pure override returns (bytes memory) {
+        return "";
+    }
+
+    function getBtcBlockchainBlockHeaderByHash(bytes32) external pure override returns (bytes memory) {
+        return "";
+    }
+
+    function getBtcBlockchainBlockHeaderByHeight(uint256) external pure override returns (bytes memory) {
+        return "";
+    }
+
+    function getBtcBlockchainParentBlockHeaderByHash(bytes32) external pure override returns (bytes memory) {
+        return "";
+    }
+}


### PR DESCRIPTION
### What

Adds the `PegInAddressRegistry` read surface: `getPegInAddress` / batch (`getPegInAddresses`, cap `MAX_PEGIN_ADDRESS_BATCH = 100`), `isRegistered`, `getRegistration`, `getRegistrationRoot`, and admin `setPegInContract` / `getPegInContract`. Derivation goes through `PegInDerivation` — the authoritative five-step library already on `3.0.0` (from #505). The registry composes those steps in `_deriveAddress` and does not reimplement script math. Consumes the frozen `IPegInAddressRegistry` on `3.0.0`.

### Why

On-chain discovery needs a deterministic, bridge-compatible deposit address for every RSK destination. Wrong derivation misroutes discovery and breaks settlement recovery, so the read surface must share the same library the settlement path will use.

### Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation

### Affected part

- `src/PegInAddressRegistry.sol` (new)
- `src/libraries/PegInDerivation.sol` — authoritative library from `3.0.0` / #505 (no local mock)
- `test/libraries/PegInDerivation.t.sol` — pinned bridge-verified vectors from #505
- `test/PegInAddressRegistry.reads.t.sol` (new)
- Consumes (does not add) `src/interfaces/IPegInAddressRegistry.sol`

Does **not** touch `src/PegInContract.sol`, `src/legacy/`, or `registerAddress` (stacked write PR).

### How to test

```bash
cd liquidity-bridge-contract
git checkout fly-2443
forge clean && forge build
forge test --match-path test/libraries/PegInDerivation.t.sol -vv
forge test --match-path test/PegInAddressRegistry.reads.t.sol -vv
forge inspect PegInAddressRegistry errors
```

Expected: library vectors 15/15; read suite green; error selectors include `PegInContractNotSet()` and `BatchTooLarge(uint256,uint256)`.

### Reviewer Guidelines

- Confirm derivation uses only `PegInDerivation` step helpers — no duplicated steps in the registry.
- Confirm `pegInContract == address(0)` reverts on all derivation paths.
- Confirm `mainnet` flag selects `0x05` vs `0xC4` version byte.
- Confirm ERC-7201 storage namespace (`test_storage_layout_erc7201`).
- Confirm batch cap `MAX_PEGIN_ADDRESS_BATCH = 100` and `BatchTooLarge` bound.
- Regtest-only target: `3.0.0`, not `master`.

### Additional Notes

- Merged `3.0.0` (including #505) into this branch: temporary mock retired; registry now imports the real `PegInDerivation`.
- Tripwire `test_derivation_scheme_differs_from_pegin_contract` documents that `PegInContract` still derives nested P2SH-P2WSH while `PegInDerivation` is plain P2SH — keep until settlement aligns.
- `out/` is git-ignored; ABI regenerates deterministically from the branch tip.
- Regtest-only; not a production `master` merge.