### PR TITLE
feat/FLY-2436: add PegInDerivation library and tests

### DIFF
--- a/src/interfaces/IPegInAddressRegistry.sol
+++ b/src/interfaces/IPegInAddressRegistry.sol
@@ -92,7 +92,10 @@ interface IPegInAddressRegistry {
     /// @param rskAddrs The RSK destination addresses to derive for
     /// @return payloads The raw address payloads, one per input address, in input order
     /// @return encoding The encoding tag shared by every payload in the batch
-    function getPegInAddresses(address[] calldata rskAddrs) external view returns (bytes[] memory payloads, Encoding encoding);
+    function getPegInAddresses(address[] calldata rskAddrs)
+        external
+        view
+        returns (bytes[] memory payloads, Encoding encoding);
 
     /// @notice Tells whether an RSK destination address has a registration record
     /// @dev True while the packed record's registrationBlock != 0. Walkthrough anchors:

--- a/src/libraries/PegInDerivation.sol
+++ b/src/libraries/PegInDerivation.sol
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {OpCodes} from "@rsksmart/btc-transaction-solidity-helper/contracts/OpCodes.sol";
+
+/// @title PegInDerivation
+/// @notice SINGLE SOURCE OF TRUTH for the commit-first peg-in deposit-address derivation.
+/// Both `PegInAddressRegistry` (address issuance and deposit-gated registration)
+/// and the peg-in settlement path MUST derive through this library, so the address the
+/// user pays is byte-for-byte the address the Bridge re-derives at settlement.
+///
+/// @dev The native fast bridge (`registerFastBridgeBtcTransaction`) is never told the deposit
+/// address: it re-derives it from the call's arguments plus the active powpeg redeem script, then
+/// scans the SPV-proven transaction for an output paying it. The derivation below was validated
+/// end-to-end on a live regtest against the UNMODIFIED powpeg bridge (rskj 9.0.2, 2026-06-30,
+/// settle tx 0x174ab0df7cc86648a40d9b36da95fd4dacf2f18c135606141d532b7d1363c7de):
+///
+///   derivationArgumentsHash = keccak256(DERIVATION_DOMAIN ++ rskAddr)                    (step 1)
+///   derivationValue         = keccak256(
+///       derivationArgumentsHash
+///       ++ REFUND_PLACEHOLDER_BTC        // userRefundBtcAddress (FIXED 21-byte constant)
+///       ++ bytes20(pegInContract)        // lbcAddress = the contract that CALLS the bridge
+///       ++ LP_PLACEHOLDER_BTC            // liquidityProviderBtcAddress (FIXED 21-byte constant)
+///   )                                                                                    (step 2)
+///   flyoverRedeemScript = OP_PUSHBYTES_32 ++ derivationValue ++ OP_DROP
+///                         ++ activePowpegRedeemScript                                    (step 3)
+///   flyoverScriptHash   = HASH160(flyoverRedeemScript)                                   (step 4)
+///   depositAddress      = base58check(version ++ flyoverScriptHash)   // PLAIN P2SH      (step 5)
+///
+/// Each step is a separate function taking the previous step's output, so every consumer enters
+/// the pipeline at the step it needs and none re-implements any script math.
+///
+/// Two known pitfalls, both proven on-chain and both encoded as negative tests:
+///   1. Keying the redeem-script tag with `derivationArgumentsHash` directly (skipping step 2's
+///      address mixing) makes the bridge re-derive a DIFFERENT address and fail with -900
+///      (FAST_BRIDGE_GENERIC_ERROR).
+///   2. Wrapping the redeem script as a segwit P2SH-of-P2WSH instead of a PLAIN P2SH settles as
+///      -304 (VALUE_ZERO): the bridge derives the plain form and attributes zero value.
+///
+/// SEGWIT / FEDERATION-FORMAT NOTE: the bridge wraps the flyover redeem script as a PLAIN P2SH
+/// for every currently deployed federation format. Newer rskj versions add a segwit federation
+/// format (`P2SH_P2WSH_ERP_FEDERATION`) for which `PegUtils.getFlyoverFederationOutputScript`
+/// switches to a P2SH-P2WSH wrapping. A powpeg migration to that format rotates every derived
+/// address (as any federation change does) AND requires this library to gain a matching wrapping
+/// path first — same drain-then-rotate rule as a federation change.
+library PegInDerivation {
+    /// @notice Versioned scheme tag mixed into every derivation. Bumping it deterministically
+    /// rotates every derived address (the same rotation path as a federation change).
+    bytes internal constant DERIVATION_DOMAIN = "FLYOVER_PEGIN_V1";
+
+    /// @notice FIXED protocol-wide placeholder for the bridge's `userRefundBtcAddress` argument,
+    /// mixed into the deposit address AND passed to the bridge at settlement. It MUST be identical
+    /// at address issuance and settlement, and it MUST be a real, well-formed 21-byte
+    /// (version ++ HASH160) BTC address — NEVER empty (the bridge rejects an empty address with
+    /// -900) and NEVER the serving LP's address (the deposit address stays LP-agnostic).
+    ///
+    /// PRODUCTION (OPEN treasury-sink decision, walkthrough): replace this regtest placeholder
+    /// with a SINGLE, protocol-owned, MONITORED BTC address (e.g. a Flyover-treasury multisig).
+    /// The bridge's FAILURE-REFUND path (taken only when a fast-bridge peg-in is rejected after
+    /// the BTC is locked) sends the locked BTC to THIS address — not to the depositing user and
+    /// not to the LP — so it must be a recoverable, monitored sink, never an EOA whose key can be
+    /// lost. Current value: `mfujgzmRixnsDfxN9u9yck1k3xtx9qCf2F`.
+    /// @return The 21-byte (version ++ HASH160) refund placeholder
+    function refundPlaceholderBtc() internal pure returns (bytes memory) {
+        return hex"6f044f0ba3d3a2bd0724db5e6d59a0bb62f4ef0cc2";
+    }
+
+    /// @notice FIXED protocol-wide placeholder for the bridge's `liquidityProviderBtcAddress`
+    /// argument. Same constraints and same production guidance as {refundPlaceholderBtc}; it is
+    /// NOT the serving LP's address. Kept as a separate accessor so production can point the two
+    /// roles at distinct addresses if desired.
+    /// @return The 21-byte (version ++ HASH160) liquidity-provider placeholder
+    function lpPlaceholderBtc() internal pure returns (bytes memory) {
+        return hex"6f044f0ba3d3a2bd0724db5e6d59a0bb62f4ef0cc2";
+    }
+
+    /// @notice Step 1: the 32-byte `derivationArgumentsHash` passed to the bridge as the FIRST
+    /// member of its own mix. The only value of the five steps that Flyover designs: the bridge
+    /// ABI gives the caller exactly one 32-byte free slot, so the protocol version and the
+    /// destination address compress into it.
+    /// @param rskAddr The RSK destination address the deposit address is derived for
+    /// @return The keccak256 hash of DERIVATION_DOMAIN ++ rskAddr
+    function derivationArgumentsHash(address rskAddr) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(DERIVATION_DOMAIN, rskAddr));
+    }
+
+    /// @notice Step 2: the 32-byte derivation value the bridge bakes into the flyover redeem
+    /// script — the argsHash mixed with the two placeholders and the calling LBC (PegInContract)
+    /// address. Replicated byte-for-byte from the bridge, never designed: keying the redeem
+    /// script with step 1's hash directly is pitfall #1 (-900).
+    /// @param rskAddr The RSK destination address
+    /// @param pegInContract The PegInContract PROXY address (the lbcAddress that calls the bridge;
+    /// stable across implementation upgrades, rotates only on a redeploy)
+    /// @return The keccak256 hash the bridge embeds in the flyover redeem script
+    function derivationValue(address rskAddr, address pegInContract) internal pure returns (bytes32) {
+        return keccak256(
+            bytes.concat(
+                derivationArgumentsHash(rskAddr), refundPlaceholderBtc(), bytes20(pegInContract), lpPlaceholderBtc()
+            )
+        );
+    }
+
+    /// @notice Step 3: the flyover redeem script the bridge wraps as a PLAIN P2SH:
+    /// OP_PUSHBYTES_32 <derivationValue> OP_DROP <activePowpegRedeemScript>. The push-then-drop
+    /// prefix embeds the 32 bytes without changing the spending condition, so the powpeg keys
+    /// still spend the output while every distinct value yields a distinct address.
+    /// @param derivationValue_ Step 2's output
+    /// @param activePowpegRedeemScript The live powpeg redeem script, read from the bridge at
+    /// call time (`getActivePowpegRedeemScript()`), never stored — the only input that changes
+    /// on a federation change
+    /// @return The flyover redeem script
+    function flyoverRedeemScript(bytes32 derivationValue_, bytes memory activePowpegRedeemScript)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return bytes.concat(OpCodes.OP_PUSHBYTES_32, derivationValue_, OpCodes.OP_DROP, activePowpegRedeemScript);
+    }
+
+    /// @notice Step 4: HASH160 (ripemd160 of sha256) of the flyover redeem script — the 20-byte
+    /// hash a P2SH output commits to. Bitcoin's standard recipe; no design freedom.
+    /// @param redeemScript Step 3's output
+    /// @return The 20-byte P2SH script hash
+    function flyoverScriptHash(bytes memory redeemScript) internal pure returns (bytes20) {
+        return ripemd160(abi.encodePacked(sha256(redeemScript)));
+    }
+
+    /// @notice Step 5 (output-script form): the on-chain P2SH scriptPubkey a deposit output must
+    /// carry: OP_HASH160 <scriptHash> OP_EQUAL. This is the raw pkScript a parsed transaction
+    /// output exposes, so deposit-gating compares it directly against outputs.
+    /// @param scriptHash Step 4's output
+    /// @return The 23-byte P2SH scriptPubkey
+    function p2shScriptPubkey(bytes20 scriptHash) internal pure returns (bytes memory) {
+        return bytes.concat(OpCodes.OP_HASH160, bytes1(uint8(20)), scriptHash, OpCodes.OP_EQUAL);
+    }
+
+    /// @notice Step 5 (address form): the base58check payload of the PLAIN P2SH deposit address:
+    /// version (0x05 mainnet / 0xC4 testnet) ++ scriptHash ++ 4-byte double-sha256 checksum.
+    /// Returned as the raw 25 bytes — the caller (SDK/LPS) base58-ENCODEs them to the address
+    /// string shown to the user. MUST stay a plain P2SH: the segwit-wrapped form is pitfall #2
+    /// (-304).
+    /// @param scriptHash Step 4's output
+    /// @param mainnet True for the mainnet version byte (0x05), false for testnet/regtest (0xC4)
+    /// @return The 25-byte base58check payload of the deposit address
+    function depositAddressPayload(bytes20 scriptHash, bool mainnet) internal pure returns (bytes memory) {
+        bytes1 version = mainnet ? bytes1(0x05) : bytes1(0xC4);
+        bytes memory versionedHash = bytes.concat(version, scriptHash);
+        bytes32 checksum = sha256(abi.encodePacked(sha256(versionedHash)));
+        return bytes.concat(versionedHash, checksum[0], checksum[1], checksum[2], checksum[3]);
+    }
+}

--- a/test/libraries/PegInDerivation.t.sol
+++ b/test/libraries/PegInDerivation.t.sol
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {Test} from "forge-std/Test.sol";
+import {OpCodes} from "@rsksmart/btc-transaction-solidity-helper/contracts/OpCodes.sol";
+import {PegInDerivation} from "../../src/libraries/PegInDerivation.sol";
+
+/// @title PegInDerivation Library Tests
+/// @notice Pins the PoC's bridge-verified derivation vectors as FIXED-BYTE fixtures and encodes
+/// the two known derivation pitfalls as negative tests.
+/// @dev Every expected value below is a pinned constant computed once offline from the scheme
+/// validated end-to-end on a live regtest against the unmodified powpeg bridge (rskj 9.0.2,
+/// 2026-06-30, settle tx 0x174ab0df7cc86648a40d9b36da95fd4dacf2f18c135606141d532b7d1363c7de).
+/// Nothing is recomputed from the library's own constants: if any constant, opcode, or version
+/// byte changes, these tests fail. That is the point.
+contract PegInDerivationTest is Test {
+    // ---- Fixture inputs (the PoC vector) ----
+
+    /// @notice The RSK destination address of the pinned vector
+    address internal constant FIXTURE_RSK =
+        0x0000000000000000000000000000000000000aBc;
+
+    /// @notice The PegInContract (lbcAddress) mixed into the pinned vector
+    address internal constant FIXTURE_PEGIN_CONTRACT =
+        0x00000000000000000000000000000000C0FFEE01;
+
+    /// @notice The active powpeg redeem script of the pinned vector (the PoC bridge-mock script)
+    bytes internal constant FIXTURE_POWPEG_SCRIPT =
+        hex"522102cd53fc53a07f211641a677d250f6de99caf620e8e77071e811a28b3bcddf0be1210362634ab5"
+        hex"7dae9cb373a5d536e66a8c4f67468bbcfb063809bab643072d78a1242103c5946b3fbae03a654237da86"
+        hex"3c9ed534e0878657175b132b8ca630f245df04db53ae";
+
+    // ---- Pinned protocol constants ----
+
+    /// @notice The exact bytes of DERIVATION_DOMAIN ("FLYOVER_PEGIN_V1")
+    bytes internal constant PINNED_DOMAIN =
+        hex"464c594f5645525f504547494e5f5631";
+
+    /// @notice The exact 21-byte (version ++ HASH160) placeholder both BTC-address slots ship with
+    bytes internal constant PINNED_PLACEHOLDER =
+        hex"6f044f0ba3d3a2bd0724db5e6d59a0bb62f4ef0cc2";
+
+    // ---- Pinned step outputs (computed once offline, frozen) ----
+
+    /// @notice Step 1: keccak256(DERIVATION_DOMAIN ++ rskAddr)
+    bytes32 internal constant PINNED_ARGS_HASH =
+        0x0ac85b6d14264cdf09e4b64c6250b2fb650d8d87f04164e8f0c69b1f29e1a89a;
+
+    /// @notice Step 2: keccak256(argsHash ++ placeholder ++ bytes20(pegInContract) ++ placeholder)
+    bytes32 internal constant PINNED_DERIVATION_VALUE =
+        0xae132ee60570d9332790a147f626edd2c053c2ea9fbece393e2caf823a8746b6;
+
+    /// @notice Step 3: OP_PUSHBYTES_32 ++ derivationValue ++ OP_DROP ++ powpeg script
+    bytes internal constant PINNED_REDEEM_SCRIPT =
+        hex"20ae132ee60570d9332790a147f626edd2c053c2ea9fbece393e2caf823a8746b675522102cd53fc53"
+        hex"a07f211641a677d250f6de99caf620e8e77071e811a28b3bcddf0be1210362634ab57dae9cb373a5d5"
+        hex"36e66a8c4f67468bbcfb063809bab643072d78a1242103c5946b3fbae03a654237da863c9ed534e087"
+        hex"8657175b132b8ca630f245df04db53ae";
+
+    /// @notice Step 4: HASH160 of the flyover redeem script
+    bytes20 internal constant PINNED_SCRIPT_HASH =
+        bytes20(hex"53239f29b16aa66c9a5e3ec7f2b1de034fe0dea7");
+
+    /// @notice Step 5a: OP_HASH160 0x14 <scriptHash> OP_EQUAL
+    bytes internal constant PINNED_SCRIPT_PUBKEY =
+        hex"a91453239f29b16aa66c9a5e3ec7f2b1de034fe0dea787";
+
+    /// @notice Step 5b testnet: 0xC4 ++ scriptHash ++ checksum (PoC bridge-verified fixture)
+    bytes internal constant PINNED_TESTNET_PAYLOAD =
+        hex"c453239f29b16aa66c9a5e3ec7f2b1de034fe0dea79440b320";
+
+    /// @notice Step 5b mainnet: 0x05 ++ scriptHash ++ checksum (PoC bridge-verified fixture)
+    bytes internal constant PINNED_MAINNET_PAYLOAD =
+        hex"0553239f29b16aa66c9a5e3ec7f2b1de034fe0dea72259d920";
+
+    // ---- Pinned negative-form payloads (the two on-chain failure modes) ----
+
+    /// @notice Pitfall #1 (-900): payload derived keying the redeem-script tag with the
+    /// derivationArgumentsHash DIRECTLY, skipping step 2's address mixing
+    bytes internal constant PINNED_DIRECT_TAG_PAYLOAD =
+        hex"c4b0275b8861bb9b30585453cde8d9efaa99b444487e6c335a";
+
+    /// @notice Pitfall #2 (-304): payload derived wrapping the CORRECT redeem script as a segwit
+    /// P2SH-of-P2WSH instead of a plain P2SH
+    bytes internal constant PINNED_SEGWIT_PAYLOAD =
+        hex"c423670b6bf4ab398f05d8536da400767b562425bc199d1a4a";
+
+    // ---- Constant pinning ----
+
+    function test_DomainConstantIsPinned() public pure {
+        assertEq(
+            PegInDerivation.DERIVATION_DOMAIN,
+            PINNED_DOMAIN,
+            "DERIVATION_DOMAIN changed"
+        );
+    }
+
+    function test_RefundPlaceholderIsPinned() public pure {
+        bytes memory placeholder = PegInDerivation.refundPlaceholderBtc();
+        assertEq(
+            placeholder.length,
+            21,
+            "refund placeholder must be 21 bytes (version ++ HASH160)"
+        );
+        assertEq(
+            placeholder,
+            PINNED_PLACEHOLDER,
+            "REFUND_PLACEHOLDER_BTC changed"
+        );
+    }
+
+    function test_LpPlaceholderIsPinned() public pure {
+        bytes memory placeholder = PegInDerivation.lpPlaceholderBtc();
+        assertEq(
+            placeholder.length,
+            21,
+            "lp placeholder must be 21 bytes (version ++ HASH160)"
+        );
+        assertEq(placeholder, PINNED_PLACEHOLDER, "LP_PLACEHOLDER_BTC changed");
+    }
+
+    // ---- Per-step fixtures (each step fed the PINNED previous output) ----
+
+    function test_Step1_DerivationArgumentsHash() public pure {
+        assertEq(
+            PegInDerivation.derivationArgumentsHash(FIXTURE_RSK),
+            PINNED_ARGS_HASH,
+            "step 1 drifted"
+        );
+    }
+
+    function test_Step2_DerivationValue() public pure {
+        assertEq(
+            PegInDerivation.derivationValue(
+                FIXTURE_RSK,
+                FIXTURE_PEGIN_CONTRACT
+            ),
+            PINNED_DERIVATION_VALUE,
+            "step 2 drifted"
+        );
+    }
+
+    function test_Step3_FlyoverRedeemScript() public pure {
+        assertEq(
+            PegInDerivation.flyoverRedeemScript(
+                PINNED_DERIVATION_VALUE,
+                FIXTURE_POWPEG_SCRIPT
+            ),
+            PINNED_REDEEM_SCRIPT,
+            "step 3 drifted"
+        );
+    }
+
+    function test_Step4_FlyoverScriptHash() public pure {
+        assertEq(
+            PegInDerivation.flyoverScriptHash(PINNED_REDEEM_SCRIPT),
+            PINNED_SCRIPT_HASH,
+            "step 4 drifted"
+        );
+    }
+
+    function test_Step5a_P2shScriptPubkey() public pure {
+        assertEq(
+            PegInDerivation.p2shScriptPubkey(PINNED_SCRIPT_HASH),
+            PINNED_SCRIPT_PUBKEY,
+            "step 5a drifted"
+        );
+    }
+
+    function test_Step5b_TestnetPayload() public pure {
+        assertEq(
+            PegInDerivation.depositAddressPayload(PINNED_SCRIPT_HASH, false),
+            PINNED_TESTNET_PAYLOAD,
+            "step 5b testnet drifted"
+        );
+    }
+
+    function test_Step5b_MainnetPayload() public pure {
+        assertEq(
+            PegInDerivation.depositAddressPayload(PINNED_SCRIPT_HASH, true),
+            PINNED_MAINNET_PAYLOAD,
+            "step 5b mainnet drifted"
+        );
+    }
+
+    // ---- Full chain, composed the way consumers compose it ----
+
+    function test_FullChainMatchesBridgeVerifiedFixture() public pure {
+        bytes20 scriptHash = _deriveScriptHash();
+        assertEq(
+            PegInDerivation.depositAddressPayload(scriptHash, false),
+            PINNED_TESTNET_PAYLOAD,
+            "full-chain testnet payload drifted"
+        );
+        assertEq(
+            PegInDerivation.depositAddressPayload(scriptHash, true),
+            PINNED_MAINNET_PAYLOAD,
+            "full-chain mainnet payload drifted"
+        );
+    }
+
+    function test_DerivationIsDeterministic() public pure {
+        bytes20 first = _deriveScriptHash();
+        bytes20 second = _deriveScriptHash();
+        assertEq(first, second, "same inputs must derive the same script hash");
+    }
+
+    function test_DifferentRskAddressesDeriveDifferentAddresses() public pure {
+        bytes32 valueA = PegInDerivation.derivationValue(
+            address(0x1111),
+            FIXTURE_PEGIN_CONTRACT
+        );
+        bytes32 valueB = PegInDerivation.derivationValue(
+            address(0x2222),
+            FIXTURE_PEGIN_CONTRACT
+        );
+        assertTrue(
+            valueA != valueB,
+            "different rskAddr must derive different values"
+        );
+    }
+
+    // ---- Negative tests: the two known pitfalls (walkthrough 3-D) ----
+
+    /// @notice Pitfall #1: keying the redeem-script tag with derivationArgumentsHash directly
+    /// (skipping the bridge's address mixing) derives an address the bridge will never re-derive.
+    /// On-chain failure mode: -900 FAST_BRIDGE_GENERIC_ERROR at settlement.
+    function test_Negative_DirectTagKeyingDivergesFromFixture() public pure {
+        bytes memory wrongRedeemScript = PegInDerivation.flyoverRedeemScript(
+            PegInDerivation.derivationArgumentsHash(FIXTURE_RSK), // tag used directly: WRONG
+            FIXTURE_POWPEG_SCRIPT
+        );
+        bytes memory wrongPayload = PegInDerivation.depositAddressPayload(
+            PegInDerivation.flyoverScriptHash(wrongRedeemScript),
+            false
+        );
+        assertEq(
+            wrongPayload,
+            PINNED_DIRECT_TAG_PAYLOAD,
+            "direct-tag payload drifted from its pin"
+        );
+        assertTrue(
+            keccak256(wrongPayload) != keccak256(PINNED_TESTNET_PAYLOAD),
+            "direct-tag keying must NOT produce the bridge-verified address"
+        );
+    }
+
+    /// @notice Pitfall #2: wrapping the (correct) flyover redeem script as a segwit P2SH-of-P2WSH
+    /// (HASH160(OP_0 OP_PUSHBYTES_32 sha256(redeemScript))) instead of a plain P2SH derives a
+    /// different address. On-chain failure mode: -304 VALUE_ZERO at settlement.
+    function test_Negative_SegwitWrappingDivergesFromFixture() public pure {
+        bytes memory segwitScript = bytes.concat(
+            OpCodes.OP_0,
+            OpCodes.OP_PUSHBYTES_32,
+            sha256(PINNED_REDEEM_SCRIPT)
+        );
+        bytes memory wrongPayload = PegInDerivation.depositAddressPayload(
+            PegInDerivation.flyoverScriptHash(segwitScript),
+            false
+        );
+        assertEq(
+            wrongPayload,
+            PINNED_SEGWIT_PAYLOAD,
+            "segwit payload drifted from its pin"
+        );
+        assertTrue(
+            keccak256(wrongPayload) != keccak256(PINNED_TESTNET_PAYLOAD),
+            "segwit wrapping must NOT produce the bridge-verified address"
+        );
+    }
+
+    // ---- Helpers ----
+
+    /// @notice Composes steps 2-4 exactly the way consumers do (see PegInAddressRegistry)
+    function _deriveScriptHash() private pure returns (bytes20) {
+        bytes32 derivationValue = PegInDerivation.derivationValue(
+            FIXTURE_RSK,
+            FIXTURE_PEGIN_CONTRACT
+        );
+        bytes memory redeemScript = PegInDerivation.flyoverRedeemScript(
+            derivationValue,
+            FIXTURE_POWPEG_SCRIPT
+        );
+        return PegInDerivation.flyoverScriptHash(redeemScript);
+    }
+}


### PR DESCRIPTION
## What

Adds `src/libraries/PegInDerivation.sol` — the single source of truth for the commit-first peg-in deposit-address derivation (FLY-2436). The library exposes the five derivation steps as chained, one-function-per-step `internal pure` helpers with pinned return types (`derivationArgumentsHash`, `derivationValue`, `flyoverRedeemScript`, `flyoverScriptHash`, `p2shScriptPubkey`, `depositAddressPayload`), plus the protocol constants (`DERIVATION_DOMAIN`, `refundPlaceholderBtc()`, `lpPlaceholderBtc()`).

Unit tests pin the PoC's bridge-verified vectors as **fixed-byte fixtures** (never recomputed): the exact bytes of every constant and of each step's output, so changing any constant, opcode, or version byte fails CI. Two negative tests encode the known on-chain failure modes: keying the redeem-script tag with `derivationArgumentsHash` directly (bridge error `-900`) and segwit P2SH-of-P2WSH wrapping (bridge error `-304`) — both pinned to their divergent payloads and asserted different from the bridge-verified address.

## Why

The bridge is never told the deposit address: at settlement (`registerFastBridgeBtcTransaction`) it re-derives the flyover P2SH from the call's arguments and the live powpeg redeem script, then scans the SPV-proven tx for an output paying it. Address issuance (`PegInAddressRegistry`, FLY-2443/FLY-2444) and settlement (S4/S9) must therefore produce byte-for-byte identical derivations — one drifted byte means the user pays address A, the bridge reconstructs address B, and the LP's fronted funds cannot be recovered. One shared library with pinned fixtures is the drift protection (walkthrough decisions D3/D4).

The scheme is the one validated end-to-end on a live regtest against the unmodified powpeg bridge (rskj 9.0.2, 2026-06-30, settle tx `0x174ab0df7cc86648a40d9b36da95fd4dacf2f18c135606141d532b7d1363c7de`), ported from the `dos-removal` PoC.

## Type of Change

* New feature

## Affected part

* `src/libraries/PegInDerivation.sol` (new)
* `test/libraries/PegInDerivation.t.sol` (new)

Does **not** touch `src/PegInContract.sol`, `src/PegInAddressRegistry.sol`, `src/legacy/`, or any existing contract. Consumers import it in their own tickets (FLY-2443 currently ships a temporary mock with this exact surface at the same path; this PR is the authoritative replacement).

## Related Issues

* [FLY-2436](https://rsklabs.atlassian.net/browse/FLY-2436) 

## How to test

```bash
cd liquidity-bridge-contract
git checkout fly2436_dos_pegin_derivation_lib   # base 3.0.0
forge build
forge test --match-path test/libraries/PegInDerivation.t.sol -vv
```

Expected: 15/15 tests pass; full unit suite (`forge test --no-match-path "test/{fuzz,invariant,differential,formal}/**/*"`) reports 504 pass / 0 fail; `npm run lint:sol` and `npx prettier --check .` clean.

## Reviewer Guidelines

* Confirm the public surface matches the FLY-2443 mock exactly (signatures, `internal pure`, placeholder value) — drop-in replacement, no call-site changes.
* Confirm fixtures are pinned literals, not values recomputed from the library's own constants.
* Confirm the two negative tests assert both the pinned divergent payload and inequality with the bridge-verified fixture.
* The placeholders are the PoC's **regtest** values by design — the production treasury-sink address is an open decision (walkthrough 3·D ⚠️); the NatSpec documents the constraints (real 21-byte address, never empty, never the serving LP).

## Additional Notes

* Plain P2SH only, per the bridge's current derivation for all deployed federation formats. The NatSpec records that a powpeg migration to `P2SH_P2WSH_ERP_FEDERATION` (segwit, present in newer rskj) switches the bridge's wrapping and requires this library to gain a matching path first — same drain-then-rotate rule as any federation change.
* Merging this after FLY-2443 (or vice versa) produces an expected, deliberate conflict on `src/libraries/PegInDerivation.sol` (their temporary mock vs. this authoritative file); resolution is "take this file".
