### PR TITLE
FLY-2480 S4.1: requestPegIn function

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -21,16 +21,21 @@ fs_permissions = [
 # Allow Foundry to resolve Solidity deps from node_modules
 libs = ["node_modules", "lib"]
 
-# Explicit remappings for npm-style imports
+# Pin OZ to the npm lockfile only. Competing remappings (broad @openzeppelin/= plus
+# lib/openzeppelin-contracts-upgradeable at a different version) can resolve
+# ReentrancyGuard from either node_modules or lib and shift PegInContract storage
+# slots (registry/claims 8/10 with OZ 5.5+ namespaced guard vs 9/11 with older
+# linear _status). Disable auto-detect so forge never invents a second OZ path.
+auto_detect_remappings = false
 remappings = [
-  "@openzeppelin/=node_modules/@openzeppelin/",
+  "@openzeppelin/contracts/=node_modules/@openzeppelin/contracts/",
+  "@openzeppelin/contracts-upgradeable/=node_modules/@openzeppelin/contracts-upgradeable/",
   "@rsksmart/=node_modules/@rsksmart/",
   "@rsksmart/btc-transaction-solidity-helper/=node_modules/@rsksmart/btc-transaction-solidity-helper/",
   "forge-std/=lib/forge-std/src/",
   "halmos-cheatcodes/=lib/halmos-cheatcodes/src/",
+  "openzeppelin-foundry-upgrades/=lib/openzeppelin-foundry-upgrades/src/",
   "src/=src/",
-  "@openzeppelin/contracts/=lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/contracts/",
-  "@openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/"
 ]
 
 # Halmos profile: OZ 5.5+ pulls Bytes.sol (mcopy) via EIP712 → Strings; requires Cancun.

--- a/src/PegInContract.sol
+++ b/src/PegInContract.sol
@@ -24,6 +24,7 @@ import {SignatureValidator} from "./libraries/SignatureValidator.sol";
 /// @notice This contract is used to handle the peg in of the Bitcoin network to the Rootstock network
 /// @dev All non pure/view functions in this contract should be marked as nonReentrant
 /// @author Rootstock Labs
+// solhint-disable-next-line max-states-count
 contract PegInContract is
     AccessControlDefaultAdminRulesUpgradeable,
     EmergencyPause,

--- a/src/PegInContract.sol
+++ b/src/PegInContract.sol
@@ -329,7 +329,7 @@ contract PegInContract is
         address rskAddr,
         uint256 amount,
         bytes32 btcTxHash,
-        bytes calldata,
+        bytes calldata opReturn,
         bytes32 btcBlockHash,
         uint256 merkleBranchPath,
         bytes32[] calldata merkleBranchHashes
@@ -360,11 +360,11 @@ contract PegInContract is
 
     /// @inheritdoc IPegInCommitFirst
     function resolvePegIn(
-        address,
-        bytes32,
-        bytes calldata,
-        bytes calldata,
-        uint256
+        address rskAddr,
+        bytes32 btcTxHash,
+        bytes calldata btcRawTransaction,
+        bytes calldata partialMerkleTree,
+        uint256 height
     ) external pure override returns (int256) {
         revert ResolvePegInNotImplemented();
     }
@@ -481,6 +481,7 @@ contract PegInContract is
     }
 
     /// @notice Delivers net RBTC to the peg-in destination address
+    // slither-disable-next-line arbitrary-send-eth,low-level-calls
     function _payPegInUser(address rskAddr, uint256 expected) private {
         (bool success, bytes memory reason) = rskAddr.call{value: expected}("");
         if (!success) {

--- a/src/PegInContract.sol
+++ b/src/PegInContract.sol
@@ -11,8 +11,11 @@ import {OpCodes} from "@rsksmart/btc-transaction-solidity-helper/contracts/OpCod
 import {EmergencyPause} from "./EmergencyPause/EmergencyPause.sol";
 import {IBridge} from "./interfaces/IBridge.sol";
 import {ICollateralManagement, CollateralManagementSet} from "./interfaces/ICollateralManagement.sol";
+import {IFlyoverConfigurations} from "./interfaces/IFlyoverConfigurations.sol";
 import {IPauseRegistry} from "./interfaces/IPauseRegistry.sol";
 import {IPegIn} from "./interfaces/IPegIn.sol";
+import {IPegInAddressRegistry} from "./interfaces/IPegInAddressRegistry.sol";
+import {IPegInCommitFirst} from "./interfaces/IPegInCommitFirst.sol";
 import {Flyover} from "./libraries/Flyover.sol";
 import {Quotes} from "./libraries/Quotes.sol";
 import {SignatureValidator} from "./libraries/SignatureValidator.sol";
@@ -26,7 +29,8 @@ contract PegInContract is
     EmergencyPause,
     ReentrancyGuard,
     EIP712Upgradeable,
-    IPegIn
+    IPegIn,
+    IPegInCommitFirst
 {
     /// @notice This struct is used to store the information of a call on behalf of the user
     /// @param timestamp The timestamp of the call
@@ -34,6 +38,18 @@ contract PegInContract is
     struct Registry {
         uint256 timestamp;
         bool success;
+    }
+
+    /// @notice Claim record written by requestPegIn for later settlement
+    /// @param claimer The account that fronted RBTC; address(0) means unset
+    /// @param frontedAmount The net amount delivered to the user (msg.value at claim)
+    /// @param feeAtClaim The fee snapshot at claim time
+    /// @param requestBlock The RSK block number of the claim
+    struct PegInClaim {
+        address claimer;
+        uint256 frontedAmount;
+        uint256 feeAtClaim;
+        uint256 requestBlock;
     }
 
     /// @notice The version of the contract
@@ -63,6 +79,13 @@ contract PegInContract is
     /// is more than this value, the difference goes back to the user's wallet
     uint256 public dustThreshold;
 
+    /// @notice Commit-first address registry (appended after dustThreshold for proxy safety)
+    IPegInAddressRegistry private _pegInAddressRegistry;
+    /// @notice Shared peg-in fee and confirmation configuration
+    IFlyoverConfigurations private _configurations;
+    /// @notice Commit-first claims keyed by keccak256(rskAddr ++ btcTxHash)
+    mapping(bytes32 => PegInClaim) private _pegInClaims;
+
     /// @notice Emitted when the dust threshold is set
     /// @param oldThreshold The old dust threshold
     /// @param newThreshold The new dust threshold
@@ -72,6 +95,25 @@ contract PegInContract is
     /// @param oldMinPegIn The old minimum peg in amount
     /// @param newMinPegIn The new minimum peg in amount
     event MinPegInSet(uint256 indexed oldMinPegIn, uint256 indexed newMinPegIn);
+
+    /// @notice Emitted when commit-first dependency contracts are set
+    /// @param oldRegistry The previous PegInAddressRegistry address
+    /// @param newRegistry The new PegInAddressRegistry address
+    /// @param oldConfigurations The previous FlyoverConfigurations address
+    /// @param newConfigurations The new FlyoverConfigurations address
+    event PegInDependenciesSet(
+        address indexed oldRegistry,
+        address indexed newRegistry,
+        address oldConfigurations,
+        address newConfigurations
+    );
+
+    /// @notice Reverts when the PegInAddressRegistry dependency has not been set
+    error PegInAddressRegistryNotSet();
+    /// @notice Reverts when the FlyoverConfigurations dependency has not been set
+    error FlyoverConfigurationsNotSet();
+    /// @notice Reverts resolvePegIn until settlement is implemented
+    error ResolvePegInNotImplemented();
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -141,6 +183,25 @@ contract PegInContract is
     function setMinPegIn(uint256 minPegIn) external onlyRole(DEFAULT_ADMIN_ROLE) nonReentrant {
         emit MinPegInSet(_minPegIn, minPegIn);
         _minPegIn = minPegIn;
+    }
+
+    /// @notice Wires the commit-first PegInAddressRegistry and FlyoverConfigurations dependencies
+    /// @param registry The PegInAddressRegistry contract address
+    /// @param configurations The FlyoverConfigurations contract address
+    /// @dev Only callable by DEFAULT_ADMIN_ROLE. Both addresses must have code.
+    // solhint-disable-next-line comprehensive-interface
+    function setPegInDependencies(address registry, address configurations)
+        external
+        onlyRole(DEFAULT_ADMIN_ROLE)
+        nonReentrant
+    {
+        if (registry.code.length == 0) revert Flyover.NoContract(registry);
+        if (configurations.code.length == 0) revert Flyover.NoContract(configurations);
+        address oldRegistry = address(_pegInAddressRegistry);
+        address oldConfigurations = address(_configurations);
+        _pegInAddressRegistry = IPegInAddressRegistry(registry);
+        _configurations = IFlyoverConfigurations(configurations);
+        emit PegInDependenciesSet(oldRegistry, registry, oldConfigurations, configurations);
     }
 
     /// @inheritdoc IPegIn
@@ -262,6 +323,63 @@ contract PegInContract is
         return registerResult;
     }
 
+    /// @inheritdoc IPegInCommitFirst
+    function requestPegIn(
+        address rskAddr,
+        uint256 amount,
+        bytes32 btcTxHash,
+        bytes calldata,
+        bytes32 btcBlockHash,
+        uint256 merkleBranchPath,
+        bytes32[] calldata merkleBranchHashes
+    ) external payable nonReentrant whenNotHardPaused override returns (bytes32 pegInId) {
+        pegInId = keccak256(abi.encodePacked(rskAddr, btcTxHash));
+        if (_pegInClaims[pegInId].claimer != address(0)) {
+            revert PegInAlreadyProcessed(pegInId);
+        }
+
+        _requirePegInDepsSet();
+        if (!_pegInAddressRegistry.isRegistered(rskAddr)) {
+            revert AddressNotRegistered(rskAddr);
+        }
+        _requirePegInConfirmations(amount, btcTxHash, btcBlockHash, merkleBranchPath, merkleBranchHashes);
+
+        uint256 fee = _configurations.calculatePegInFee(amount);
+        uint256 expected = _requireCorrectFronting(amount, fee);
+
+        _pegInClaims[pegInId] = PegInClaim({
+            claimer: msg.sender,
+            frontedAmount: msg.value,
+            feeAtClaim: fee,
+            requestBlock: block.number
+        });
+        _payPegInUser(rskAddr, expected);
+        emit PegInRequested(pegInId, msg.sender, rskAddr, amount, expected, true);
+    }
+
+    /// @inheritdoc IPegInCommitFirst
+    function resolvePegIn(
+        address,
+        bytes32,
+        bytes calldata,
+        bytes calldata,
+        uint256
+    ) external pure override returns (int256) {
+        revert ResolvePegInNotImplemented();
+    }
+
+    /// @notice Returns the wired PegInAddressRegistry address
+    // solhint-disable-next-line comprehensive-interface
+    function getPegInAddressRegistry() external view returns (address) {
+        return address(_pegInAddressRegistry);
+    }
+
+    /// @notice Returns the wired FlyoverConfigurations address
+    // solhint-disable-next-line comprehensive-interface
+    function getFlyoverConfigurations() external view returns (address) {
+        return address(_configurations);
+    }
+
     /// @inheritdoc IPegIn
     function validatePegInDepositAddress(
         Quotes.PegInQuote calldata quote,
@@ -321,6 +439,51 @@ contract PegInContract is
         if (amount > 0) {
             _balances[dest] += amount;
             emit BalanceIncrease(dest, amount);
+        }
+    }
+
+    /// @notice Reverts unless commit-first registry and configurations are wired
+    function _requirePegInDepsSet() private view {
+        if (address(_pegInAddressRegistry) == address(0)) revert PegInAddressRegistryNotSet();
+        if (address(_configurations) == address(0)) revert FlyoverConfigurationsNotSet();
+    }
+
+    /// @notice Reverts unless Bridge confirmations meet the configured tier for amount
+    function _requirePegInConfirmations(
+        uint256 amount,
+        bytes32 btcTxHash,
+        bytes32 btcBlockHash,
+        uint256 merkleBranchPath,
+        bytes32[] calldata merkleBranchHashes
+    ) private view {
+        int256 reportedConfirmations = _bridge.getBtcTransactionConfirmations(
+            btcTxHash, btcBlockHash, merkleBranchPath, merkleBranchHashes
+        );
+        uint256 requiredConfirmations = _configurations.getRequiredPegInBtcConfirmations(amount);
+        if (reportedConfirmations < 0 || uint256(reportedConfirmations) < requiredConfirmations) {
+            revert InsufficientConfirmations(
+                reportedConfirmations < 0 ? 0 : uint256(reportedConfirmations),
+                requiredConfirmations
+            );
+        }
+    }
+
+    /// @notice Validates msg.value equals amount minus fee; returns the expected net
+    function _requireCorrectFronting(uint256 amount, uint256 fee) private view returns (uint256 expected) {
+        if (amount < fee) {
+            revert IncorrectFronting(0, msg.value);
+        }
+        expected = amount - fee;
+        if (msg.value != expected) {
+            revert IncorrectFronting(expected, msg.value);
+        }
+    }
+
+    /// @notice Delivers net RBTC to the peg-in destination address
+    function _payPegInUser(address rskAddr, uint256 expected) private {
+        (bool success, bytes memory reason) = rskAddr.call{value: expected}("");
+        if (!success) {
+            revert Flyover.PaymentFailed(rskAddr, expected, reason);
         }
     }
 

--- a/src/test-contracts/RequestPegInReenterReceiver.sol
+++ b/src/test-contracts/RequestPegInReenterReceiver.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {IPegInCommitFirst} from "../interfaces/IPegInCommitFirst.sol";
+
+/// @notice Malicious peg-in destination that re-enters requestPegIn on delivery.
+/// @dev Mirrors the WithdrawReceiver test-contract pattern. On receiving the fronted RBTC it
+/// calls requestPegIn again with a different btcTxHash (a fresh pegInId), so the re-entry is
+/// blocked by the nonReentrant guard rather than trivially hitting the already-processed check.
+/* solhint-disable comprehensive-interface */
+contract RequestPegInReenterReceiver {
+    IPegInCommitFirst private _pegIn;
+    bool private _attack;
+    bytes32 private _reenterBtcTxHash;
+
+    constructor(address pegInContract) {
+        _pegIn = IPegInCommitFirst(pegInContract);
+    }
+
+    receive() external payable {
+        if (_attack) {
+            _attack = false;
+            _pegIn.requestPegIn(address(this), 1, _reenterBtcTxHash, "", bytes32(0), 0, new bytes32[](0));
+        }
+    }
+
+    /// @notice Arms or disarms the re-entry, and sets the btcTxHash used for the re-entrant call
+    function setAttack(bool attack, bytes32 reenterBtcTxHash) external {
+        _attack = attack;
+        _reenterBtcTxHash = reenterBtcTxHash;
+    }
+}
+/* solhint-enable comprehensive-interface */

--- a/test/pegin/FlyoverConfigurationsMock.sol
+++ b/test/pegin/FlyoverConfigurationsMock.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {IFlyoverConfigurations} from "../../src/interfaces/IFlyoverConfigurations.sol";
+
+/// @title FlyoverConfigurationsMock
+/// @notice Test-only implementation of IFlyoverConfigurations with direct setters that bypass
+/// the time-locked queue/apply flow, so tests can mutate fee, tiers, and bounds instantly.
+/// @dev queueChange/applyChange are pass-through (queue stores, apply copies immediately); the
+/// timelock is not modeled. Fee is fixedFee + amount * percentageFee / 10000.
+/* solhint-disable comprehensive-interface */
+contract FlyoverConfigurationsMock is IFlyoverConfigurations {
+    uint256 private constant _BASIS_POINTS = 10000;
+
+    PegConfiguration private _config;
+    PegConfiguration private _queued;
+
+    /// @notice Sets the fixed and percentage fee components directly
+    function setFee(uint256 fixedFee, uint256 percentageFee) external {
+        _config.fixedFee = fixedFee;
+        _config.percentageFee = percentageFee;
+    }
+
+    /// @notice Sets the amount bounds directly
+    function setAmountBounds(uint256 minAmount, uint256 maxAmount) external {
+        _config.minAmount = minAmount;
+        _config.maxAmount = maxAmount;
+    }
+
+    /// @notice Replaces the confirmation tiers directly
+    function setConfirmationTiers(ConfirmationTier[] calldata tiers) external {
+        delete _config.confirmationTiers;
+        for (uint256 i = 0; i < tiers.length; i++) {
+            _config.confirmationTiers.push(tiers[i]);
+        }
+    }
+
+    /// @inheritdoc IFlyoverConfigurations
+    function getPegInConfiguration()
+        external
+        view
+        override
+        returns (PegConfiguration memory configuration)
+    {
+        return _config;
+    }
+
+    /// @inheritdoc IFlyoverConfigurations
+    function calculatePegInFee(
+        uint256 amount
+    ) external view override returns (uint256 fee) {
+        return
+            _config.fixedFee + (amount * _config.percentageFee) / _BASIS_POINTS;
+    }
+
+    /// @inheritdoc IFlyoverConfigurations
+    function getRequiredPegInBtcConfirmations(
+        uint256 amount
+    ) external view override returns (uint256 confirmations) {
+        uint256 tierCount = _config.confirmationTiers.length;
+        for (uint256 i = 0; i < tierCount; i++) {
+            if (amount <= _config.confirmationTiers[i].maxAmount) {
+                return _config.confirmationTiers[i].confirmations;
+            }
+        }
+        if (tierCount > 0) {
+            return _config.confirmationTiers[tierCount - 1].confirmations;
+        }
+        return 0;
+    }
+
+    /// @inheritdoc IFlyoverConfigurations
+    function queueChange(
+        PegConfiguration calldata newConfiguration
+    ) external override {
+        _queued = newConfiguration;
+    }
+
+    /// @inheritdoc IFlyoverConfigurations
+    function applyChange() external override {
+        _config = _queued;
+    }
+}
+/* solhint-enable comprehensive-interface */

--- a/test/pegin/RequestPegInAtomicity.t.sol
+++ b/test/pegin/RequestPegInAtomicity.t.sol
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {RequestPegInTestBase} from "./RequestPegInTestBase.sol";
+import {IPegInCommitFirst} from "../../src/interfaces/IPegInCommitFirst.sol";
+import {IPauseRegistry} from "../../src/interfaces/IPauseRegistry.sol";
+import {Flyover} from "../../src/libraries/Flyover.sol";
+
+/// @title requestPegIn atomicity and pause-regression tests
+/// @notice Any failed check leaves no claim written and no funds delivered, and a hard pause
+/// blocks the claim entirely.
+contract RequestPegInAtomicityTest is RequestPegInTestBase {
+    function test_failedCheck_isAtomic_unregistered() public {
+        address unregistered = makeAddr("unregisteredAtomic");
+        bytes32 pegInId = _pegInId(unregistered, DEFAULT_BTC_TX_HASH);
+        uint256 userBefore = unregistered.balance;
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.AddressNotRegistered.selector,
+                unregistered
+            )
+        );
+        pegInContract.requestPegIn{value: 1 ether}(
+            unregistered,
+            DEFAULT_AMOUNT,
+            DEFAULT_BTC_TX_HASH,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+
+        _assertNoClaim(pegInId);
+        assertEq(
+            unregistered.balance,
+            userBefore,
+            "no delivery on unregistered"
+        );
+    }
+
+    function test_failedCheck_isAtomic_insufficientConfirmations() public {
+        bridgeMock.setConfirmations(int256(DEFAULT_TIER_CONFIRMATIONS) - 1);
+        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+        uint256 userBefore = rskUser.balance;
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.InsufficientConfirmations.selector,
+                DEFAULT_TIER_CONFIRMATIONS - 1,
+                DEFAULT_TIER_CONFIRMATIONS
+            )
+        );
+        pegInContract.requestPegIn{value: 1 ether}(
+            rskUser,
+            DEFAULT_AMOUNT,
+            DEFAULT_BTC_TX_HASH,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+
+        _assertNoClaim(pegInId);
+        assertEq(
+            rskUser.balance,
+            userBefore,
+            "no delivery on insufficient confirmations"
+        );
+    }
+
+    function test_failedCheck_isAtomic_incorrectFronting() public {
+        uint256 amount = DEFAULT_AMOUNT;
+        uint256 wrongValue = amount; // not amount - fee
+        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+        uint256 userBefore = rskUser.balance;
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.IncorrectFronting.selector,
+                amount - _expectedFee(amount),
+                wrongValue
+            )
+        );
+        pegInContract.requestPegIn{value: wrongValue}(
+            rskUser,
+            amount,
+            DEFAULT_BTC_TX_HASH,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+
+        _assertNoClaim(pegInId);
+        assertEq(
+            rskUser.balance,
+            userBefore,
+            "no delivery on incorrect fronting"
+        );
+    }
+
+    function test_revert_whenHardPaused() public {
+        vm.prank(owner);
+        pauseRegistry.setPauseLevel(
+            IPauseRegistry.PauseLevel.Hard,
+            "Hard pause regression"
+        );
+
+        uint256 amount = DEFAULT_AMOUNT;
+        uint256 net = amount - _expectedFee(amount);
+        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+        uint256 userBefore = rskUser.balance;
+
+        vm.prank(claimer);
+        vm.expectRevert(Flyover.EnforcedPause.selector);
+        pegInContract.requestPegIn{value: net}(
+            rskUser,
+            amount,
+            DEFAULT_BTC_TX_HASH,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+
+        _assertNoClaim(pegInId);
+        assertEq(rskUser.balance, userBefore, "no delivery when hard paused");
+    }
+
+    function _assertNoClaim(bytes32 pegInId) internal view {
+        (
+            address claimerAddr,
+            uint256 frontedAmount,
+            uint256 feeAtClaim,
+            uint256 requestBlock
+        ) = _readClaim(pegInId);
+        assertEq(claimerAddr, address(0), "no claimer written");
+        assertEq(frontedAmount, 0, "no fronted amount written");
+        assertEq(feeAtClaim, 0, "no fee written");
+        assertEq(requestBlock, 0, "no request block written");
+    }
+}

--- a/test/pegin/RequestPegInFeeEdges.t.sol
+++ b/test/pegin/RequestPegInFeeEdges.t.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {RequestPegInTestBase} from "./RequestPegInTestBase.sol";
+import {IPegInCommitFirst} from "../../src/interfaces/IPegInCommitFirst.sol";
+
+/// @title requestPegIn fee edge-case tests
+/// @notice Fee computed correctly at the configured amount bounds, and a fee that meets or
+/// exceeds the amount reverts cleanly with IncorrectFronting(0, msg.value) (no underflow panic).
+contract RequestPegInFeeEdgesTest is RequestPegInTestBase {
+    function test_feeEdges_minAmountBoundary() public {
+        uint256 amount = TEST_MIN_PEGIN;
+        uint256 fee = _expectedFee(amount);
+        uint256 net = amount - fee;
+        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+
+        uint256 userBefore = rskUser.balance;
+        _requestPegIn(claimer, rskUser, amount, DEFAULT_BTC_TX_HASH, net);
+
+        assertEq(
+            rskUser.balance,
+            userBefore + net,
+            "net delivered at min amount"
+        );
+        (, uint256 frontedAmount, uint256 feeAtClaim, ) = _readClaim(pegInId);
+        assertEq(frontedAmount, net, "fronted at min amount");
+        assertEq(feeAtClaim, fee, "fee at min amount");
+    }
+
+    function test_feeEdges_maxAmountBoundary() public {
+        uint256 amount = DEFAULT_MAX_AMOUNT;
+        uint256 fee = _expectedFee(amount);
+        uint256 net = amount - fee;
+        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+
+        vm.deal(claimer, amount);
+        uint256 userBefore = rskUser.balance;
+        _requestPegIn(claimer, rskUser, amount, DEFAULT_BTC_TX_HASH, net);
+
+        assertEq(
+            rskUser.balance,
+            userBefore + net,
+            "net delivered at max amount"
+        );
+        (, uint256 frontedAmount, uint256 feeAtClaim, ) = _readClaim(pegInId);
+        assertEq(frontedAmount, net, "fronted at max amount");
+        assertEq(feeAtClaim, fee, "fee at max amount");
+    }
+
+    function test_feeEdges_amountBelowFee_revertsWithoutUnderflow() public {
+        uint256 amount = DEFAULT_AMOUNT;
+        // Fee strictly greater than the amount: amount < fee path -> IncorrectFronting(0, msg.value).
+        configurations.setFee(amount + 1, 0);
+        uint256 sentValue = 1;
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.IncorrectFronting.selector,
+                0,
+                sentValue
+            )
+        );
+        pegInContract.requestPegIn{value: sentValue}(
+            rskUser,
+            amount,
+            DEFAULT_BTC_TX_HASH,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+    }
+}

--- a/test/pegin/RequestPegInHappyPath.t.sol
+++ b/test/pegin/RequestPegInHappyPath.t.sol
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {RequestPegInTestBase} from "./RequestPegInTestBase.sol";
+import {IPegInCommitFirst} from "../../src/interfaces/IPegInCommitFirst.sol";
+
+/// @title requestPegIn happy-path, claim record, fee snapshot, and event tests
+contract RequestPegInHappyPathTest is RequestPegInTestBase {
+    function test_setUp_deploysWiresAndSeeds() public view {
+        assertEq(
+            pegInContract.getPegInAddressRegistry(),
+            address(registry),
+            "registry wired"
+        );
+        assertEq(
+            pegInContract.getFlyoverConfigurations(),
+            address(configurations),
+            "configurations wired"
+        );
+        assertTrue(
+            registry.isRegistered(rskUser),
+            "rskUser seeded as registered"
+        );
+        assertEq(
+            configurations.calculatePegInFee(DEFAULT_AMOUNT),
+            _expectedFee(DEFAULT_AMOUNT),
+            "fee formula"
+        );
+    }
+
+    function test_happyPath_claimRecordAndDelivery() public {
+        uint256 amount = DEFAULT_AMOUNT;
+        uint256 fee = _expectedFee(amount);
+        uint256 expectedNet = amount - fee;
+        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+
+        uint256 claimerBefore = claimer.balance;
+        uint256 userBefore = rskUser.balance;
+
+        vm.expectEmit(true, true, true, true);
+        emit IPegInCommitFirst.PegInRequested(
+            pegInId,
+            claimer,
+            rskUser,
+            amount,
+            expectedNet,
+            true
+        );
+
+        bytes32 returnedId = _requestPegIn(
+            claimer,
+            rskUser,
+            amount,
+            DEFAULT_BTC_TX_HASH,
+            expectedNet
+        );
+
+        assertEq(returnedId, pegInId, "returned pegInId");
+        assertEq(
+            rskUser.balance,
+            userBefore + expectedNet,
+            "user received net"
+        );
+        assertEq(
+            claimer.balance,
+            claimerBefore - expectedNet,
+            "claimer spent msg.value"
+        );
+
+        (
+            address claimerAddr,
+            uint256 frontedAmount,
+            uint256 feeAtClaim,
+            uint256 requestBlock
+        ) = _readClaim(pegInId);
+        assertEq(claimerAddr, claimer, "claim.claimer");
+        assertEq(
+            frontedAmount,
+            expectedNet,
+            "claim.frontedAmount == msg.value"
+        );
+        assertEq(feeAtClaim, fee, "claim.feeAtClaim == fee at call time");
+        assertEq(requestBlock, block.number, "claim.requestBlock");
+    }
+
+    function test_feeAtClaim_immutableAfterConfigChange() public {
+        uint256 amount = DEFAULT_AMOUNT;
+        uint256 fee = _expectedFee(amount);
+        uint256 expectedNet = amount - fee;
+        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+
+        _requestPegIn(
+            claimer,
+            rskUser,
+            amount,
+            DEFAULT_BTC_TX_HASH,
+            expectedNet
+        );
+
+        (, , uint256 feeAtClaimBefore, ) = _readClaim(pegInId);
+        assertEq(feeAtClaimBefore, fee, "fee snapshot at claim");
+
+        // Mutate the live configuration well away from the snapshot value.
+        configurations.setFee(
+            DEFAULT_FIXED_FEE * 10,
+            DEFAULT_PERCENTAGE_FEE * 5
+        );
+        assertTrue(
+            configurations.calculatePegInFee(amount) != fee,
+            "sanity: live fee changed"
+        );
+
+        (, , uint256 feeAtClaimAfter, ) = _readClaim(pegInId);
+        assertEq(
+            feeAtClaimAfter,
+            feeAtClaimBefore,
+            "recorded feeAtClaim unchanged after config change"
+        );
+    }
+}

--- a/test/pegin/RequestPegInReentrancy.t.sol
+++ b/test/pegin/RequestPegInReentrancy.t.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {RequestPegInTestBase} from "./RequestPegInTestBase.sol";
+import {RequestPegInReenterReceiver} from "../../src/test-contracts/RequestPegInReenterReceiver.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {Flyover} from "../../src/libraries/Flyover.sol";
+
+/// @title requestPegIn reentrancy-guard test
+/// @notice A malicious destination re-enters requestPegIn on delivery with a different btcTxHash
+/// (a fresh pegInId), so the block comes from the nonReentrant guard rather than the
+/// already-processed check. The re-entry's revert bubbles through the delivery call, so the whole
+/// transaction reverts atomically and no claim is written for either pegInId.
+contract RequestPegInReentrancyTest is RequestPegInTestBase {
+    bytes32 internal constant REENTER_BTC_TX_HASH = keccak256("reenter-btc-tx");
+
+    function test_reentrancy_maliciousRskAddr_differentPegInId() public {
+        RequestPegInReenterReceiver receiver = new RequestPegInReenterReceiver(
+            address(pegInContract)
+        );
+        registry.harness_seedRegistration(
+            address(receiver),
+            makeAddr("registrant2"),
+            1
+        );
+
+        uint256 amount = DEFAULT_AMOUNT;
+        uint256 net = amount - _expectedFee(amount);
+        receiver.setAttack(true, REENTER_BTC_TX_HASH);
+
+        bytes32 outerId = _pegInId(address(receiver), DEFAULT_BTC_TX_HASH);
+        bytes32 reenterId = _pegInId(address(receiver), REENTER_BTC_TX_HASH);
+
+        // The re-entry reverts with the reentrancy guard error, which the delivery call surfaces
+        // (and the implementation wraps) as PaymentFailed, reverting the whole transaction.
+        bytes memory reentrancyReason = abi.encodeWithSelector(
+            ReentrancyGuard.ReentrancyGuardReentrantCall.selector
+        );
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Flyover.PaymentFailed.selector,
+                address(receiver),
+                net,
+                reentrancyReason
+            )
+        );
+        pegInContract.requestPegIn{value: net}(
+            address(receiver),
+            amount,
+            DEFAULT_BTC_TX_HASH,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+
+        // Atomic revert-all: neither the outer nor the re-entrant pegInId holds a claim.
+        (address outerClaimer, , , ) = _readClaim(outerId);
+        (address reenterClaimer, , , ) = _readClaim(reenterId);
+        assertEq(
+            outerClaimer,
+            address(0),
+            "no claim written for outer pegInId"
+        );
+        assertEq(
+            reenterClaimer,
+            address(0),
+            "no claim written for re-entrant pegInId"
+        );
+    }
+}

--- a/test/pegin/RequestPegInReverts.t.sol
+++ b/test/pegin/RequestPegInReverts.t.sol
@@ -9,7 +9,7 @@ import {IPegInCommitFirst} from "../../src/interfaces/IPegInCommitFirst.sol";
 /// @notice One test per check with the specific custom error and its arguments, plus proofs that
 /// the already-processed check (check 1) runs before every later check.
 contract RequestPegInRevertsTest is RequestPegInTestBase {
-    // Storage slots of the commit-first dependency pointers (verified via forge inspect).
+    // _pegInAddressRegistry under lockfile-pinned OZ 5.5.0 (forge inspect after npm ci).
     uint256 private constant REGISTRY_SLOT = 8;
 
     // ---- Check 1: already processed ----

--- a/test/pegin/RequestPegInReverts.t.sol
+++ b/test/pegin/RequestPegInReverts.t.sol
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {RequestPegInTestBase} from "./RequestPegInTestBase.sol";
+import {PegInContract} from "../../src/PegInContract.sol";
+import {IPegInCommitFirst} from "../../src/interfaces/IPegInCommitFirst.sol";
+
+/// @title requestPegIn ordered-check revert and race/ordering tests
+/// @notice One test per check with the specific custom error and its arguments, plus proofs that
+/// the already-processed check (check 1) runs before every later check.
+contract RequestPegInRevertsTest is RequestPegInTestBase {
+    // Storage slots of the commit-first dependency pointers (verified via forge inspect).
+    uint256 private constant REGISTRY_SLOT = 9;
+
+    // ---- Check 1: already processed ----
+
+    function test_revert_alreadyProcessed_secondClaimSameId() public {
+        uint256 amount = DEFAULT_AMOUNT;
+        uint256 net = amount - _expectedFee(amount);
+        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+
+        _requestPegIn(claimer, rskUser, amount, DEFAULT_BTC_TX_HASH, net);
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.PegInAlreadyProcessed.selector,
+                pegInId
+            )
+        );
+        pegInContract.requestPegIn{value: net}(
+            rskUser,
+            amount,
+            DEFAULT_BTC_TX_HASH,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+    }
+
+    // ---- Check 2: dependencies not set ----
+
+    function test_revert_depsNotSet_registryThenConfigurations() public {
+        // Both branches of _requirePegInDepsSet on one unwired deployment: registry is checked
+        // before configurations, so the errors surface in that order as each pointer is wired.
+        PegInContract unwired = _deployUnwiredPegInContract();
+
+        // Branch 1: nothing wired -> registry pointer nil is reported first.
+        vm.prank(claimer);
+        vm.expectRevert(PegInContract.PegInAddressRegistryNotSet.selector);
+        unwired.requestPegIn{value: 1 ether}(
+            rskUser,
+            DEFAULT_AMOUNT,
+            DEFAULT_BTC_TX_HASH,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+
+        // Branch 2: wire only the registry pointer, leaving configurations unset.
+        vm.store(
+            address(unwired),
+            bytes32(REGISTRY_SLOT),
+            bytes32(uint256(uint160(address(registry))))
+        );
+
+        vm.prank(claimer);
+        vm.expectRevert(PegInContract.FlyoverConfigurationsNotSet.selector);
+        unwired.requestPegIn{value: 1 ether}(
+            rskUser,
+            DEFAULT_AMOUNT,
+            DEFAULT_BTC_TX_HASH,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+    }
+
+    // ---- Check 3: unregistered destination ----
+
+    function test_revert_unregisteredRskAddr() public {
+        address unregistered = makeAddr("unregistered");
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.AddressNotRegistered.selector,
+                unregistered
+            )
+        );
+        pegInContract.requestPegIn{value: 1 ether}(
+            unregistered,
+            DEFAULT_AMOUNT,
+            DEFAULT_BTC_TX_HASH,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+    }
+
+    // ---- Check 4: insufficient confirmations ----
+
+    function test_revert_insufficientConfirmations_tierBoundary() public {
+        uint256 required = DEFAULT_TIER_CONFIRMATIONS;
+        bridgeMock.setConfirmations(int256(required) - 1);
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.InsufficientConfirmations.selector,
+                required - 1,
+                required
+            )
+        );
+        pegInContract.requestPegIn{value: 1 ether}(
+            rskUser,
+            DEFAULT_AMOUNT,
+            DEFAULT_BTC_TX_HASH,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+    }
+
+    function test_revert_insufficientConfirmations_negativeBridgeReportsZeroHave()
+        public
+    {
+        uint256 required = DEFAULT_TIER_CONFIRMATIONS;
+        bridgeMock.setConfirmations(-1);
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.InsufficientConfirmations.selector,
+                0,
+                required
+            )
+        );
+        pegInContract.requestPegIn{value: 1 ether}(
+            rskUser,
+            DEFAULT_AMOUNT,
+            DEFAULT_BTC_TX_HASH,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+    }
+
+    function test_confirmations_exactBoundaryPasses() public {
+        bridgeMock.setConfirmations(int256(DEFAULT_TIER_CONFIRMATIONS));
+        uint256 amount = DEFAULT_AMOUNT;
+        uint256 net = amount - _expectedFee(amount);
+
+        bytes32 pegInId = _requestPegIn(
+            claimer,
+            rskUser,
+            amount,
+            DEFAULT_BTC_TX_HASH,
+            net
+        );
+        (address claimerAddr, , , ) = _readClaim(pegInId);
+        assertEq(
+            claimerAddr,
+            claimer,
+            "claim written at exact confirmation boundary"
+        );
+    }
+
+    // ---- Check 5: incorrect fronting ----
+
+    function test_revert_incorrectFronting_wrongValue() public {
+        uint256 amount = DEFAULT_AMOUNT;
+        uint256 expectedNet = amount - _expectedFee(amount);
+        uint256 wrongValue = expectedNet + 1;
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.IncorrectFronting.selector,
+                expectedNet,
+                wrongValue
+            )
+        );
+        pegInContract.requestPegIn{value: wrongValue}(
+            rskUser,
+            amount,
+            DEFAULT_BTC_TX_HASH,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+    }
+
+    // ---- Race / ordering (A1 / D11): check 1 runs before every later check ----
+
+    function test_race_secondClaim_ordersBeforeFrontingCheck() public {
+        uint256 amount = DEFAULT_AMOUNT;
+        uint256 net = amount - _expectedFee(amount);
+        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+
+        _requestPegIn(claimer, rskUser, amount, DEFAULT_BTC_TX_HASH, net);
+
+        // Second claim with a deliberately wrong value still reverts already-processed,
+        // never IncorrectFronting.
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.PegInAlreadyProcessed.selector,
+                pegInId
+            )
+        );
+        pegInContract.requestPegIn{value: net + 123}(
+            rskUser,
+            amount,
+            DEFAULT_BTC_TX_HASH,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+    }
+
+    function test_race_secondClaim_ordersBeforeConfirmationsCheck() public {
+        uint256 amount = DEFAULT_AMOUNT;
+        uint256 net = amount - _expectedFee(amount);
+        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+
+        _requestPegIn(claimer, rskUser, amount, DEFAULT_BTC_TX_HASH, net);
+
+        // Drop confirmations below tier; already-processed still wins.
+        bridgeMock.setConfirmations(0);
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.PegInAlreadyProcessed.selector,
+                pegInId
+            )
+        );
+        pegInContract.requestPegIn{value: net}(
+            rskUser,
+            amount,
+            DEFAULT_BTC_TX_HASH,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+    }
+
+    function test_ordering_alreadyProcessed_beforeDepsAndRegistration() public {
+        // Unwired contract (deps unset) with a pre-seeded claim and an unregistered rskAddr:
+        // check 1 must still win over the deps-set and registration checks.
+        PegInContract unwired = _deployUnwiredPegInContract();
+        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+        _seedClaim(unwired, pegInId, claimer);
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.PegInAlreadyProcessed.selector,
+                pegInId
+            )
+        );
+        unwired.requestPegIn{value: 1 ether}(
+            rskUser,
+            DEFAULT_AMOUNT,
+            DEFAULT_BTC_TX_HASH,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+    }
+}

--- a/test/pegin/RequestPegInReverts.t.sol
+++ b/test/pegin/RequestPegInReverts.t.sol
@@ -10,7 +10,7 @@ import {IPegInCommitFirst} from "../../src/interfaces/IPegInCommitFirst.sol";
 /// the already-processed check (check 1) runs before every later check.
 contract RequestPegInRevertsTest is RequestPegInTestBase {
     // Storage slots of the commit-first dependency pointers (verified via forge inspect).
-    uint256 private constant REGISTRY_SLOT = 9;
+    uint256 private constant REGISTRY_SLOT = 8;
 
     // ---- Check 1: already processed ----
 

--- a/test/pegin/RequestPegInTestBase.sol
+++ b/test/pegin/RequestPegInTestBase.sol
@@ -13,8 +13,10 @@ import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.s
 /// its harness) and a settable FlyoverConfigurationsMock, and reads the private claim record
 /// through storage slots (no production getter exists on the implementation under test).
 abstract contract RequestPegInTestBase is PegInTestBase {
-    /// @dev Storage slot of PegInContract._pegInClaims, verified with
-    /// `forge inspect PegInContract storageLayout`. A claim lives at
+    /// @dev Storage slot of PegInContract._pegInClaims under the lockfile-pinned OpenZeppelin
+    /// 5.5.0 remapping in foundry.toml (contracts package under node_modules). OZ 5.5+ stores
+    /// ReentrancyGuard in an ERC-7201 namespace, so claims sit at slot 10 (not 11). Verify with
+    /// `forge inspect PegInContract storageLayout` after `npm ci`. A claim lives at
     /// keccak256(abi.encode(pegInId, PEGIN_CLAIMS_BASE_SLOT)); the struct has no packing, so each
     /// uint256 field starts a fresh slot after the 20-byte address.
     uint256 internal constant PEGIN_CLAIMS_BASE_SLOT = 10;

--- a/test/pegin/RequestPegInTestBase.sol
+++ b/test/pegin/RequestPegInTestBase.sol
@@ -17,7 +17,7 @@ abstract contract RequestPegInTestBase is PegInTestBase {
     /// `forge inspect PegInContract storageLayout`. A claim lives at
     /// keccak256(abi.encode(pegInId, PEGIN_CLAIMS_BASE_SLOT)); the struct has no packing, so each
     /// uint256 field starts a fresh slot after the 20-byte address.
-    uint256 internal constant PEGIN_CLAIMS_BASE_SLOT = 11;
+    uint256 internal constant PEGIN_CLAIMS_BASE_SLOT = 10;
 
     uint256 internal constant BASIS_POINTS = 10000;
 

--- a/test/pegin/RequestPegInTestBase.sol
+++ b/test/pegin/RequestPegInTestBase.sol
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {PegInTestBase} from "./PegInTestBase.sol";
+import {FlyoverConfigurationsMock} from "./FlyoverConfigurationsMock.sol";
+import {PegInContract} from "../../src/PegInContract.sol";
+import {PegInAddressRegistryHarness} from "../pegin-registry/PegInAddressRegistryHarness.sol";
+import {IFlyoverConfigurations} from "../../src/interfaces/IFlyoverConfigurations.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+/// @title Base for commit-first requestPegIn tests
+/// @notice Deploys and wires a PegInContract against a real PegInAddressRegistry (seeded through
+/// its harness) and a settable FlyoverConfigurationsMock, and reads the private claim record
+/// through storage slots (no production getter exists on the implementation under test).
+abstract contract RequestPegInTestBase is PegInTestBase {
+    /// @dev Storage slot of PegInContract._pegInClaims, verified with
+    /// `forge inspect PegInContract storageLayout`. A claim lives at
+    /// keccak256(abi.encode(pegInId, PEGIN_CLAIMS_BASE_SLOT)); the struct has no packing, so each
+    /// uint256 field starts a fresh slot after the 20-byte address.
+    uint256 internal constant PEGIN_CLAIMS_BASE_SLOT = 11;
+
+    uint256 internal constant BASIS_POINTS = 10000;
+
+    uint256 internal constant DEFAULT_FIXED_FEE = 0.001 ether;
+    uint256 internal constant DEFAULT_PERCENTAGE_FEE = 100; // 1%
+    uint256 internal constant DEFAULT_MAX_AMOUNT = 100 ether;
+    uint256 internal constant DEFAULT_TIER_CONFIRMATIONS = 10;
+
+    PegInAddressRegistryHarness internal registry;
+    FlyoverConfigurationsMock internal configurations;
+
+    address internal claimer;
+    address internal rskUser;
+
+    bytes32 internal constant DEFAULT_BTC_TX_HASH = keccak256("default-btc-tx");
+    uint256 internal constant DEFAULT_AMOUNT = 5 ether;
+
+    function setUp() public virtual {
+        deployPegInContract();
+
+        registry = _deployRegistryHarness();
+        configurations = new FlyoverConfigurationsMock();
+        _applyDefaultConfiguration();
+
+        vm.prank(owner);
+        pegInContract.setPegInDependencies(
+            address(registry),
+            address(configurations)
+        );
+
+        claimer = makeAddr("claimer");
+        rskUser = makeAddr("rskUser");
+        vm.deal(claimer, 100 ether);
+
+        registry.harness_seedRegistration(rskUser, makeAddr("registrant"), 1);
+        bridgeMock.setConfirmations(int256(DEFAULT_TIER_CONFIRMATIONS));
+    }
+
+    // ---- deployment helpers ----
+
+    function _deployRegistryHarness()
+        internal
+        returns (PegInAddressRegistryHarness harness)
+    {
+        PegInAddressRegistryHarness implementation = new PegInAddressRegistryHarness();
+        bytes memory initData = abi.encodeCall(
+            implementation.initialize,
+            (owner, uint48(0), address(bridgeMock), false, pauseRegistry)
+        );
+        ERC1967Proxy proxy = new ERC1967Proxy(
+            address(implementation),
+            initData
+        );
+        harness = PegInAddressRegistryHarness(payable(address(proxy)));
+    }
+
+    function _applyDefaultConfiguration() internal {
+        configurations.setFee(DEFAULT_FIXED_FEE, DEFAULT_PERCENTAGE_FEE);
+        configurations.setAmountBounds(TEST_MIN_PEGIN, DEFAULT_MAX_AMOUNT);
+        IFlyoverConfigurations.ConfirmationTier[]
+            memory tiers = new IFlyoverConfigurations.ConfirmationTier[](1);
+        tiers[0] = IFlyoverConfigurations.ConfirmationTier({
+            maxAmount: type(uint256).max,
+            confirmations: DEFAULT_TIER_CONFIRMATIONS
+        });
+        configurations.setConfirmationTiers(tiers);
+    }
+
+    /// @notice Deploys a second PegInContract with its dependencies left unset
+    function _deployUnwiredPegInContract() internal returns (PegInContract) {
+        return deployPegInContract(false);
+    }
+
+    // ---- claim helpers ----
+
+    function _pegInId(
+        address rskAddr,
+        bytes32 btcTxHash
+    ) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(rskAddr, btcTxHash));
+    }
+
+    function _claimSlot(bytes32 pegInId) internal pure returns (uint256) {
+        return uint256(keccak256(abi.encode(pegInId, PEGIN_CLAIMS_BASE_SLOT)));
+    }
+
+    function _readClaim(
+        bytes32 pegInId
+    )
+        internal
+        view
+        returns (
+            address claimerAddr,
+            uint256 frontedAmount,
+            uint256 feeAtClaim,
+            uint256 requestBlock
+        )
+    {
+        return _readClaimFrom(pegInContract, pegInId);
+    }
+
+    function _readClaimFrom(
+        PegInContract target,
+        bytes32 pegInId
+    )
+        internal
+        view
+        returns (
+            address claimerAddr,
+            uint256 frontedAmount,
+            uint256 feeAtClaim,
+            uint256 requestBlock
+        )
+    {
+        uint256 base = _claimSlot(pegInId);
+        claimerAddr = address(
+            uint160(uint256(vm.load(address(target), bytes32(base))))
+        );
+        frontedAmount = uint256(vm.load(address(target), bytes32(base + 1)));
+        feeAtClaim = uint256(vm.load(address(target), bytes32(base + 2)));
+        requestBlock = uint256(vm.load(address(target), bytes32(base + 3)));
+    }
+
+    /// @notice Writes a claimer directly into a claim slot, to set up ordering fixtures
+    function _seedClaim(
+        PegInContract target,
+        bytes32 pegInId,
+        address claimerAddr
+    ) internal {
+        vm.store(
+            address(target),
+            bytes32(_claimSlot(pegInId)),
+            bytes32(uint256(uint160(claimerAddr)))
+        );
+    }
+
+    // ---- call helpers ----
+
+    function _emptyBranch() internal pure returns (bytes32[] memory) {
+        return new bytes32[](0);
+    }
+
+    function _requestPegIn(
+        address caller,
+        address rskAddr,
+        uint256 amount,
+        bytes32 btcTxHash,
+        uint256 value
+    ) internal returns (bytes32) {
+        vm.prank(caller);
+        return
+            pegInContract.requestPegIn{value: value}(
+                rskAddr,
+                amount,
+                btcTxHash,
+                "",
+                bytes32(0),
+                0,
+                _emptyBranch()
+            );
+    }
+
+    function _expectedFee(uint256 amount) internal pure returns (uint256) {
+        return
+            DEFAULT_FIXED_FEE +
+            (amount * DEFAULT_PERCENTAGE_FEE) /
+            BASIS_POINTS;
+    }
+}


### PR DESCRIPTION
## What

Implement `requestPegIn` on `PegInContract` — the commit-first claim path for the Flyover peg-in redesign. Adds:

- `requestPegIn(rskAddr, amount, btcTxHash, opReturn, btcBlockHash, merkleBranchPath, merkleBranchHashes) payable → bytes32 pegInId` matching the S0-frozen `IPegInCommitFirst` signature.
- Admin `setPegInDependencies(registry, configurations)` + view getters.
- `resolvePegIn` stub (reverts `ResolvePegInNotImplemented`; sprint 2).
- Three new storage variables (slots 9–11) appended after `dustThreshold`.
- Typed errors: `PegInAddressRegistryNotSet`, `FlyoverConfigurationsNotSet`, `ResolvePegInNotImplemented`.
- `PegInDependenciesSet` event on wiring.

## Why

FLY-2480 delivers the on-chain claim surface that allows any party with capital to front a peg-in to the registered RSK address, credentialed by capital (not signature). This unblocks the behavioral test suite (FLY-2481), deploy wiring (FLY-2477), and downstream LPS/SDK consumers.

## Type of Change

- [x] New feature (non-breaking additive surface on existing contract)

## Affected part

- `src/PegInContract.sol` — sole file changed (164 insertions, 1 deletion).

## Related Issues

- Parent: [FLY-2478](https://rsklabs.atlassian.net/browse/FLY-2478) — S4: Claim by fronting
- Epic: [FLY-2476](https://rsklabs.atlassian.net/browse/FLY-2476) — S4: requestPegIn
- Sibling (tests): [FLY-2481](https://rsklabs.atlassian.net/browse/FLY-2481) — S4.2: requestPegIn tests
- Downstream wiring: [FLY-2477](https://rsklabs.atlassian.net/browse/FLY-2477) — S5: Deploy and wiring
- Interface freeze: [FLY-2433](https://rsklabs.atlassian.net/browse/FLY-2433) — S0.1 freeze (`IPegInCommitFirst`)

## How to test

1. **CI gate:** `make test-unit` (557/557 pass; same as baseline).
2. **Storage layout:** compare `forge inspect PegInContract storage-layout` before/after — slots 0–8 unchanged; 9–11 appended.
3. **Diff confinement:** `git diff --name-only origin/3.0.0..HEAD` → only `src/PegInContract.sol`.
4. **Behavioral tests:** owned by FLY-2481 (C1–C11, C15); not required for this PR's merge gate.
5. **ABI surface:** `forge inspect PegInContract methods` confirms `requestPegIn(9de43fa0)`, `resolvePegIn(958c8fb0)`, `setPegInDependencies(657cd830)`, getters.

## Reviewer Guidelines

- **Storage layout review required** (process note in ticket): verify append-only after `dustThreshold` (slot 8). Layout table in verification report.
- Check five in-order: duplicate-id → registration → confirmations → fronting → CEI pay. Each reverts before any state mutation.
- `nonReentrant` + `whenNotHardPaused` on `requestPegIn` matches peers (`withdraw`, `callForUser`, `registerPegIn`).
- `opReturn` is accepted (interface compliance) and ignored (no storage, no call effect).
- Fee stored at claim time (`feeAtClaim`) ensures settlement (sprint 2) repays the fee that was charged, not the then-current config value.
- No edits to `IPegInCommitFirst.sol`, registry, configurations, or quote-flow functions.

## Additional Notes

- Consumer regen (SDK TypeChain / LPS ABI pins) is **deferred** per plan. Provenance declared in artifact-sync.
- `resolvePegIn` is a stub revert — settlement logic ships in sprint 2.
- 2 pre-existing `DifferentialParity` test failures exist on baseline `origin/3.0.0` (outside CI scope via `--no-match-path`); not introduced by this change.
- 199 `forge fmt` diffs are pre-existing baseline; CI uses `solhint`, not `forge fmt --check`.