### PR TITLE
FLY-2481 S4.2: requestPegIn tests

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -21,16 +21,21 @@ fs_permissions = [
 # Allow Foundry to resolve Solidity deps from node_modules
 libs = ["node_modules", "lib"]
 
-# Explicit remappings for npm-style imports
+# Pin OZ to the npm lockfile only. Competing remappings (broad @openzeppelin/= plus
+# lib/openzeppelin-contracts-upgradeable at a different version) can resolve
+# ReentrancyGuard from either node_modules or lib and shift PegInContract storage
+# slots (registry/claims 8/10 with OZ 5.5+ namespaced guard vs 9/11 with older
+# linear _status). Disable auto-detect so forge never invents a second OZ path.
+auto_detect_remappings = false
 remappings = [
-  "@openzeppelin/=node_modules/@openzeppelin/",
+  "@openzeppelin/contracts/=node_modules/@openzeppelin/contracts/",
+  "@openzeppelin/contracts-upgradeable/=node_modules/@openzeppelin/contracts-upgradeable/",
   "@rsksmart/=node_modules/@rsksmart/",
   "@rsksmart/btc-transaction-solidity-helper/=node_modules/@rsksmart/btc-transaction-solidity-helper/",
   "forge-std/=lib/forge-std/src/",
   "halmos-cheatcodes/=lib/halmos-cheatcodes/src/",
+  "openzeppelin-foundry-upgrades/=lib/openzeppelin-foundry-upgrades/src/",
   "src/=src/",
-  "@openzeppelin/contracts/=lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/contracts/",
-  "@openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/"
 ]
 
 # Halmos profile: OZ 5.5+ pulls Bytes.sol (mcopy) via EIP712 → Strings; requires Cancun.

--- a/src/test-contracts/RequestPegInReenterReceiver.sol
+++ b/src/test-contracts/RequestPegInReenterReceiver.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {IPegInCommitFirst} from "../interfaces/IPegInCommitFirst.sol";
+
+/// @notice Malicious peg-in destination that re-enters requestPegIn on delivery.
+/// @dev Mirrors the WithdrawReceiver test-contract pattern. On receiving the fronted RBTC it
+/// calls requestPegIn again with a different btcTxHash (a fresh pegInId), so the re-entry is
+/// blocked by the nonReentrant guard rather than trivially hitting the already-processed check.
+/* solhint-disable comprehensive-interface */
+contract RequestPegInReenterReceiver {
+    IPegInCommitFirst private _pegIn;
+    bool private _attack;
+    bytes32 private _reenterBtcTxHash;
+
+    constructor(address pegInContract) {
+        _pegIn = IPegInCommitFirst(pegInContract);
+    }
+
+    receive() external payable {
+        if (_attack) {
+            _attack = false;
+            _pegIn.requestPegIn(address(this), 1, _reenterBtcTxHash, "", bytes32(0), 0, new bytes32[](0));
+        }
+    }
+
+    /// @notice Arms or disarms the re-entry, and sets the btcTxHash used for the re-entrant call
+    function setAttack(bool attack, bytes32 reenterBtcTxHash) external {
+        _attack = attack;
+        _reenterBtcTxHash = reenterBtcTxHash;
+    }
+}
+/* solhint-enable comprehensive-interface */

--- a/test/pegin/FlyoverConfigurationsMock.sol
+++ b/test/pegin/FlyoverConfigurationsMock.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {IFlyoverConfigurations} from "../../src/interfaces/IFlyoverConfigurations.sol";
+
+/// @title FlyoverConfigurationsMock
+/// @notice Test-only implementation of IFlyoverConfigurations with direct setters that bypass
+/// the time-locked queue/apply flow, so tests can mutate fee, tiers, and bounds instantly.
+/// @dev queueChange/applyChange are pass-through (queue stores, apply copies immediately); the
+/// timelock is not modeled. Fee is fixedFee + amount * percentageFee / 10000.
+/* solhint-disable comprehensive-interface */
+contract FlyoverConfigurationsMock is IFlyoverConfigurations {
+    uint256 private constant _BASIS_POINTS = 10000;
+
+    PegConfiguration private _config;
+    PegConfiguration private _queued;
+
+    /// @notice Sets the fixed and percentage fee components directly
+    function setFee(uint256 fixedFee, uint256 percentageFee) external {
+        _config.fixedFee = fixedFee;
+        _config.percentageFee = percentageFee;
+    }
+
+    /// @notice Sets the amount bounds directly
+    function setAmountBounds(uint256 minAmount, uint256 maxAmount) external {
+        _config.minAmount = minAmount;
+        _config.maxAmount = maxAmount;
+    }
+
+    /// @notice Replaces the confirmation tiers directly
+    function setConfirmationTiers(ConfirmationTier[] calldata tiers) external {
+        delete _config.confirmationTiers;
+        for (uint256 i = 0; i < tiers.length; i++) {
+            _config.confirmationTiers.push(tiers[i]);
+        }
+    }
+
+    /// @inheritdoc IFlyoverConfigurations
+    function getPegInConfiguration()
+        external
+        view
+        override
+        returns (PegConfiguration memory configuration)
+    {
+        return _config;
+    }
+
+    /// @inheritdoc IFlyoverConfigurations
+    function calculatePegInFee(
+        uint256 amount
+    ) external view override returns (uint256 fee) {
+        return
+            _config.fixedFee + (amount * _config.percentageFee) / _BASIS_POINTS;
+    }
+
+    /// @inheritdoc IFlyoverConfigurations
+    function getRequiredPegInBtcConfirmations(
+        uint256 amount
+    ) external view override returns (uint256 confirmations) {
+        uint256 tierCount = _config.confirmationTiers.length;
+        for (uint256 i = 0; i < tierCount; i++) {
+            if (amount <= _config.confirmationTiers[i].maxAmount) {
+                return _config.confirmationTiers[i].confirmations;
+            }
+        }
+        if (tierCount > 0) {
+            return _config.confirmationTiers[tierCount - 1].confirmations;
+        }
+        return 0;
+    }
+
+    /// @inheritdoc IFlyoverConfigurations
+    function queueChange(
+        PegConfiguration calldata newConfiguration
+    ) external override {
+        _queued = newConfiguration;
+    }
+
+    /// @inheritdoc IFlyoverConfigurations
+    function applyChange() external override {
+        _config = _queued;
+    }
+}
+/* solhint-enable comprehensive-interface */

--- a/test/pegin/RequestPegInAtomicity.t.sol
+++ b/test/pegin/RequestPegInAtomicity.t.sol
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {RequestPegInTestBase} from "./RequestPegInTestBase.sol";
+import {IPegInCommitFirst} from "../../src/interfaces/IPegInCommitFirst.sol";
+import {IPauseRegistry} from "../../src/interfaces/IPauseRegistry.sol";
+import {Flyover} from "../../src/libraries/Flyover.sol";
+
+/// @title requestPegIn atomicity and pause-regression tests
+/// @notice Any failed check leaves no claim written and no funds delivered, and a hard pause
+/// blocks the claim entirely.
+contract RequestPegInAtomicityTest is RequestPegInTestBase {
+    function test_failedCheck_isAtomic_unregistered() public {
+        address unregistered = makeAddr("unregisteredAtomic");
+        bytes32 pegInId = _pegInId(unregistered, DEFAULT_BTC_TX_HASH);
+        uint256 userBefore = unregistered.balance;
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.AddressNotRegistered.selector,
+                unregistered
+            )
+        );
+        pegInContract.requestPegIn{value: 1 ether}(
+            unregistered,
+            DEFAULT_AMOUNT,
+            DEFAULT_BTC_TX_HASH,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+
+        _assertNoClaim(pegInId);
+        assertEq(
+            unregistered.balance,
+            userBefore,
+            "no delivery on unregistered"
+        );
+    }
+
+    function test_failedCheck_isAtomic_insufficientConfirmations() public {
+        bridgeMock.setConfirmations(int256(DEFAULT_TIER_CONFIRMATIONS) - 1);
+        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+        uint256 userBefore = rskUser.balance;
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.InsufficientConfirmations.selector,
+                DEFAULT_TIER_CONFIRMATIONS - 1,
+                DEFAULT_TIER_CONFIRMATIONS
+            )
+        );
+        pegInContract.requestPegIn{value: 1 ether}(
+            rskUser,
+            DEFAULT_AMOUNT,
+            DEFAULT_BTC_TX_HASH,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+
+        _assertNoClaim(pegInId);
+        assertEq(
+            rskUser.balance,
+            userBefore,
+            "no delivery on insufficient confirmations"
+        );
+    }
+
+    function test_failedCheck_isAtomic_incorrectFronting() public {
+        uint256 amount = DEFAULT_AMOUNT;
+        uint256 wrongValue = amount; // not amount - fee
+        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+        uint256 userBefore = rskUser.balance;
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.IncorrectFronting.selector,
+                amount - _expectedFee(amount),
+                wrongValue
+            )
+        );
+        pegInContract.requestPegIn{value: wrongValue}(
+            rskUser,
+            amount,
+            DEFAULT_BTC_TX_HASH,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+
+        _assertNoClaim(pegInId);
+        assertEq(
+            rskUser.balance,
+            userBefore,
+            "no delivery on incorrect fronting"
+        );
+    }
+
+    function test_revert_whenHardPaused() public {
+        vm.prank(owner);
+        pauseRegistry.setPauseLevel(
+            IPauseRegistry.PauseLevel.Hard,
+            "Hard pause regression"
+        );
+
+        uint256 amount = DEFAULT_AMOUNT;
+        uint256 net = amount - _expectedFee(amount);
+        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+        uint256 userBefore = rskUser.balance;
+
+        vm.prank(claimer);
+        vm.expectRevert(Flyover.EnforcedPause.selector);
+        pegInContract.requestPegIn{value: net}(
+            rskUser,
+            amount,
+            DEFAULT_BTC_TX_HASH,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+
+        _assertNoClaim(pegInId);
+        assertEq(rskUser.balance, userBefore, "no delivery when hard paused");
+    }
+
+    function _assertNoClaim(bytes32 pegInId) internal view {
+        (
+            address claimerAddr,
+            uint256 frontedAmount,
+            uint256 feeAtClaim,
+            uint256 requestBlock
+        ) = _readClaim(pegInId);
+        assertEq(claimerAddr, address(0), "no claimer written");
+        assertEq(frontedAmount, 0, "no fronted amount written");
+        assertEq(feeAtClaim, 0, "no fee written");
+        assertEq(requestBlock, 0, "no request block written");
+    }
+}

--- a/test/pegin/RequestPegInFeeEdges.t.sol
+++ b/test/pegin/RequestPegInFeeEdges.t.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {RequestPegInTestBase} from "./RequestPegInTestBase.sol";
+import {IPegInCommitFirst} from "../../src/interfaces/IPegInCommitFirst.sol";
+
+/// @title requestPegIn fee edge-case tests
+/// @notice Fee computed correctly at the configured amount bounds, and a fee that meets or
+/// exceeds the amount reverts cleanly with IncorrectFronting(0, msg.value) (no underflow panic).
+contract RequestPegInFeeEdgesTest is RequestPegInTestBase {
+    function test_feeEdges_minAmountBoundary() public {
+        uint256 amount = TEST_MIN_PEGIN;
+        uint256 fee = _expectedFee(amount);
+        uint256 net = amount - fee;
+        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+
+        uint256 userBefore = rskUser.balance;
+        _requestPegIn(claimer, rskUser, amount, DEFAULT_BTC_TX_HASH, net);
+
+        assertEq(
+            rskUser.balance,
+            userBefore + net,
+            "net delivered at min amount"
+        );
+        (, uint256 frontedAmount, uint256 feeAtClaim, ) = _readClaim(pegInId);
+        assertEq(frontedAmount, net, "fronted at min amount");
+        assertEq(feeAtClaim, fee, "fee at min amount");
+    }
+
+    function test_feeEdges_maxAmountBoundary() public {
+        uint256 amount = DEFAULT_MAX_AMOUNT;
+        uint256 fee = _expectedFee(amount);
+        uint256 net = amount - fee;
+        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+
+        vm.deal(claimer, amount);
+        uint256 userBefore = rskUser.balance;
+        _requestPegIn(claimer, rskUser, amount, DEFAULT_BTC_TX_HASH, net);
+
+        assertEq(
+            rskUser.balance,
+            userBefore + net,
+            "net delivered at max amount"
+        );
+        (, uint256 frontedAmount, uint256 feeAtClaim, ) = _readClaim(pegInId);
+        assertEq(frontedAmount, net, "fronted at max amount");
+        assertEq(feeAtClaim, fee, "fee at max amount");
+    }
+
+    function test_feeEdges_amountBelowFee_revertsWithoutUnderflow() public {
+        uint256 amount = DEFAULT_AMOUNT;
+        // Fee strictly greater than the amount: amount < fee path -> IncorrectFronting(0, msg.value).
+        configurations.setFee(amount + 1, 0);
+        uint256 sentValue = 1;
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.IncorrectFronting.selector,
+                0,
+                sentValue
+            )
+        );
+        pegInContract.requestPegIn{value: sentValue}(
+            rskUser,
+            amount,
+            DEFAULT_BTC_TX_HASH,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+    }
+}

--- a/test/pegin/RequestPegInHappyPath.t.sol
+++ b/test/pegin/RequestPegInHappyPath.t.sol
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {RequestPegInTestBase} from "./RequestPegInTestBase.sol";
+import {IPegInCommitFirst} from "../../src/interfaces/IPegInCommitFirst.sol";
+
+/// @title requestPegIn happy-path, claim record, fee snapshot, and event tests
+contract RequestPegInHappyPathTest is RequestPegInTestBase {
+    function test_setUp_deploysWiresAndSeeds() public view {
+        assertEq(
+            pegInContract.getPegInAddressRegistry(),
+            address(registry),
+            "registry wired"
+        );
+        assertEq(
+            pegInContract.getFlyoverConfigurations(),
+            address(configurations),
+            "configurations wired"
+        );
+        assertTrue(
+            registry.isRegistered(rskUser),
+            "rskUser seeded as registered"
+        );
+        assertEq(
+            configurations.calculatePegInFee(DEFAULT_AMOUNT),
+            _expectedFee(DEFAULT_AMOUNT),
+            "fee formula"
+        );
+    }
+
+    function test_happyPath_claimRecordAndDelivery() public {
+        uint256 amount = DEFAULT_AMOUNT;
+        uint256 fee = _expectedFee(amount);
+        uint256 expectedNet = amount - fee;
+        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+
+        uint256 claimerBefore = claimer.balance;
+        uint256 userBefore = rskUser.balance;
+
+        vm.expectEmit(true, true, true, true);
+        emit IPegInCommitFirst.PegInRequested(
+            pegInId,
+            claimer,
+            rskUser,
+            amount,
+            expectedNet,
+            true
+        );
+
+        bytes32 returnedId = _requestPegIn(
+            claimer,
+            rskUser,
+            amount,
+            DEFAULT_BTC_TX_HASH,
+            expectedNet
+        );
+
+        assertEq(returnedId, pegInId, "returned pegInId");
+        assertEq(
+            rskUser.balance,
+            userBefore + expectedNet,
+            "user received net"
+        );
+        assertEq(
+            claimer.balance,
+            claimerBefore - expectedNet,
+            "claimer spent msg.value"
+        );
+
+        (
+            address claimerAddr,
+            uint256 frontedAmount,
+            uint256 feeAtClaim,
+            uint256 requestBlock
+        ) = _readClaim(pegInId);
+        assertEq(claimerAddr, claimer, "claim.claimer");
+        assertEq(
+            frontedAmount,
+            expectedNet,
+            "claim.frontedAmount == msg.value"
+        );
+        assertEq(feeAtClaim, fee, "claim.feeAtClaim == fee at call time");
+        assertEq(requestBlock, block.number, "claim.requestBlock");
+    }
+
+    function test_feeAtClaim_immutableAfterConfigChange() public {
+        uint256 amount = DEFAULT_AMOUNT;
+        uint256 fee = _expectedFee(amount);
+        uint256 expectedNet = amount - fee;
+        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+
+        _requestPegIn(
+            claimer,
+            rskUser,
+            amount,
+            DEFAULT_BTC_TX_HASH,
+            expectedNet
+        );
+
+        (, , uint256 feeAtClaimBefore, ) = _readClaim(pegInId);
+        assertEq(feeAtClaimBefore, fee, "fee snapshot at claim");
+
+        // Mutate the live configuration well away from the snapshot value.
+        configurations.setFee(
+            DEFAULT_FIXED_FEE * 10,
+            DEFAULT_PERCENTAGE_FEE * 5
+        );
+        assertTrue(
+            configurations.calculatePegInFee(amount) != fee,
+            "sanity: live fee changed"
+        );
+
+        (, , uint256 feeAtClaimAfter, ) = _readClaim(pegInId);
+        assertEq(
+            feeAtClaimAfter,
+            feeAtClaimBefore,
+            "recorded feeAtClaim unchanged after config change"
+        );
+    }
+}

--- a/test/pegin/RequestPegInReentrancy.t.sol
+++ b/test/pegin/RequestPegInReentrancy.t.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {RequestPegInTestBase} from "./RequestPegInTestBase.sol";
+import {RequestPegInReenterReceiver} from "../../src/test-contracts/RequestPegInReenterReceiver.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {Flyover} from "../../src/libraries/Flyover.sol";
+
+/// @title requestPegIn reentrancy-guard test
+/// @notice A malicious destination re-enters requestPegIn on delivery with a different btcTxHash
+/// (a fresh pegInId), so the block comes from the nonReentrant guard rather than the
+/// already-processed check. The re-entry's revert bubbles through the delivery call, so the whole
+/// transaction reverts atomically and no claim is written for either pegInId.
+contract RequestPegInReentrancyTest is RequestPegInTestBase {
+    bytes32 internal constant REENTER_BTC_TX_HASH = keccak256("reenter-btc-tx");
+
+    function test_reentrancy_maliciousRskAddr_differentPegInId() public {
+        RequestPegInReenterReceiver receiver = new RequestPegInReenterReceiver(
+            address(pegInContract)
+        );
+        registry.harness_seedRegistration(
+            address(receiver),
+            makeAddr("registrant2"),
+            1
+        );
+
+        uint256 amount = DEFAULT_AMOUNT;
+        uint256 net = amount - _expectedFee(amount);
+        receiver.setAttack(true, REENTER_BTC_TX_HASH);
+
+        bytes32 outerId = _pegInId(address(receiver), DEFAULT_BTC_TX_HASH);
+        bytes32 reenterId = _pegInId(address(receiver), REENTER_BTC_TX_HASH);
+
+        // The re-entry reverts with the reentrancy guard error, which the delivery call surfaces
+        // (and the implementation wraps) as PaymentFailed, reverting the whole transaction.
+        bytes memory reentrancyReason = abi.encodeWithSelector(
+            ReentrancyGuard.ReentrancyGuardReentrantCall.selector
+        );
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Flyover.PaymentFailed.selector,
+                address(receiver),
+                net,
+                reentrancyReason
+            )
+        );
+        pegInContract.requestPegIn{value: net}(
+            address(receiver),
+            amount,
+            DEFAULT_BTC_TX_HASH,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+
+        // Atomic revert-all: neither the outer nor the re-entrant pegInId holds a claim.
+        (address outerClaimer, , , ) = _readClaim(outerId);
+        (address reenterClaimer, , , ) = _readClaim(reenterId);
+        assertEq(
+            outerClaimer,
+            address(0),
+            "no claim written for outer pegInId"
+        );
+        assertEq(
+            reenterClaimer,
+            address(0),
+            "no claim written for re-entrant pegInId"
+        );
+    }
+}

--- a/test/pegin/RequestPegInReverts.t.sol
+++ b/test/pegin/RequestPegInReverts.t.sol
@@ -9,7 +9,7 @@ import {IPegInCommitFirst} from "../../src/interfaces/IPegInCommitFirst.sol";
 /// @notice One test per check with the specific custom error and its arguments, plus proofs that
 /// the already-processed check (check 1) runs before every later check.
 contract RequestPegInRevertsTest is RequestPegInTestBase {
-    // Storage slots of the commit-first dependency pointers (verified via forge inspect).
+    // _pegInAddressRegistry under lockfile-pinned OZ 5.5.0 (forge inspect after npm ci).
     uint256 private constant REGISTRY_SLOT = 8;
 
     // ---- Check 1: already processed ----

--- a/test/pegin/RequestPegInReverts.t.sol
+++ b/test/pegin/RequestPegInReverts.t.sol
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {RequestPegInTestBase} from "./RequestPegInTestBase.sol";
+import {PegInContract} from "../../src/PegInContract.sol";
+import {IPegInCommitFirst} from "../../src/interfaces/IPegInCommitFirst.sol";
+
+/// @title requestPegIn ordered-check revert and race/ordering tests
+/// @notice One test per check with the specific custom error and its arguments, plus proofs that
+/// the already-processed check (check 1) runs before every later check.
+contract RequestPegInRevertsTest is RequestPegInTestBase {
+    // Storage slots of the commit-first dependency pointers (verified via forge inspect).
+    uint256 private constant REGISTRY_SLOT = 9;
+
+    // ---- Check 1: already processed ----
+
+    function test_revert_alreadyProcessed_secondClaimSameId() public {
+        uint256 amount = DEFAULT_AMOUNT;
+        uint256 net = amount - _expectedFee(amount);
+        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+
+        _requestPegIn(claimer, rskUser, amount, DEFAULT_BTC_TX_HASH, net);
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.PegInAlreadyProcessed.selector,
+                pegInId
+            )
+        );
+        pegInContract.requestPegIn{value: net}(
+            rskUser,
+            amount,
+            DEFAULT_BTC_TX_HASH,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+    }
+
+    // ---- Check 2: dependencies not set ----
+
+    function test_revert_depsNotSet_registryThenConfigurations() public {
+        // Both branches of _requirePegInDepsSet on one unwired deployment: registry is checked
+        // before configurations, so the errors surface in that order as each pointer is wired.
+        PegInContract unwired = _deployUnwiredPegInContract();
+
+        // Branch 1: nothing wired -> registry pointer nil is reported first.
+        vm.prank(claimer);
+        vm.expectRevert(PegInContract.PegInAddressRegistryNotSet.selector);
+        unwired.requestPegIn{value: 1 ether}(
+            rskUser,
+            DEFAULT_AMOUNT,
+            DEFAULT_BTC_TX_HASH,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+
+        // Branch 2: wire only the registry pointer, leaving configurations unset.
+        vm.store(
+            address(unwired),
+            bytes32(REGISTRY_SLOT),
+            bytes32(uint256(uint160(address(registry))))
+        );
+
+        vm.prank(claimer);
+        vm.expectRevert(PegInContract.FlyoverConfigurationsNotSet.selector);
+        unwired.requestPegIn{value: 1 ether}(
+            rskUser,
+            DEFAULT_AMOUNT,
+            DEFAULT_BTC_TX_HASH,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+    }
+
+    // ---- Check 3: unregistered destination ----
+
+    function test_revert_unregisteredRskAddr() public {
+        address unregistered = makeAddr("unregistered");
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.AddressNotRegistered.selector,
+                unregistered
+            )
+        );
+        pegInContract.requestPegIn{value: 1 ether}(
+            unregistered,
+            DEFAULT_AMOUNT,
+            DEFAULT_BTC_TX_HASH,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+    }
+
+    // ---- Check 4: insufficient confirmations ----
+
+    function test_revert_insufficientConfirmations_tierBoundary() public {
+        uint256 required = DEFAULT_TIER_CONFIRMATIONS;
+        bridgeMock.setConfirmations(int256(required) - 1);
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.InsufficientConfirmations.selector,
+                required - 1,
+                required
+            )
+        );
+        pegInContract.requestPegIn{value: 1 ether}(
+            rskUser,
+            DEFAULT_AMOUNT,
+            DEFAULT_BTC_TX_HASH,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+    }
+
+    function test_revert_insufficientConfirmations_negativeBridgeReportsZeroHave()
+        public
+    {
+        uint256 required = DEFAULT_TIER_CONFIRMATIONS;
+        bridgeMock.setConfirmations(-1);
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.InsufficientConfirmations.selector,
+                0,
+                required
+            )
+        );
+        pegInContract.requestPegIn{value: 1 ether}(
+            rskUser,
+            DEFAULT_AMOUNT,
+            DEFAULT_BTC_TX_HASH,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+    }
+
+    function test_confirmations_exactBoundaryPasses() public {
+        bridgeMock.setConfirmations(int256(DEFAULT_TIER_CONFIRMATIONS));
+        uint256 amount = DEFAULT_AMOUNT;
+        uint256 net = amount - _expectedFee(amount);
+
+        bytes32 pegInId = _requestPegIn(
+            claimer,
+            rskUser,
+            amount,
+            DEFAULT_BTC_TX_HASH,
+            net
+        );
+        (address claimerAddr, , , ) = _readClaim(pegInId);
+        assertEq(
+            claimerAddr,
+            claimer,
+            "claim written at exact confirmation boundary"
+        );
+    }
+
+    // ---- Check 5: incorrect fronting ----
+
+    function test_revert_incorrectFronting_wrongValue() public {
+        uint256 amount = DEFAULT_AMOUNT;
+        uint256 expectedNet = amount - _expectedFee(amount);
+        uint256 wrongValue = expectedNet + 1;
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.IncorrectFronting.selector,
+                expectedNet,
+                wrongValue
+            )
+        );
+        pegInContract.requestPegIn{value: wrongValue}(
+            rskUser,
+            amount,
+            DEFAULT_BTC_TX_HASH,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+    }
+
+    // ---- Race / ordering (A1 / D11): check 1 runs before every later check ----
+
+    function test_race_secondClaim_ordersBeforeFrontingCheck() public {
+        uint256 amount = DEFAULT_AMOUNT;
+        uint256 net = amount - _expectedFee(amount);
+        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+
+        _requestPegIn(claimer, rskUser, amount, DEFAULT_BTC_TX_HASH, net);
+
+        // Second claim with a deliberately wrong value still reverts already-processed,
+        // never IncorrectFronting.
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.PegInAlreadyProcessed.selector,
+                pegInId
+            )
+        );
+        pegInContract.requestPegIn{value: net + 123}(
+            rskUser,
+            amount,
+            DEFAULT_BTC_TX_HASH,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+    }
+
+    function test_race_secondClaim_ordersBeforeConfirmationsCheck() public {
+        uint256 amount = DEFAULT_AMOUNT;
+        uint256 net = amount - _expectedFee(amount);
+        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+
+        _requestPegIn(claimer, rskUser, amount, DEFAULT_BTC_TX_HASH, net);
+
+        // Drop confirmations below tier; already-processed still wins.
+        bridgeMock.setConfirmations(0);
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.PegInAlreadyProcessed.selector,
+                pegInId
+            )
+        );
+        pegInContract.requestPegIn{value: net}(
+            rskUser,
+            amount,
+            DEFAULT_BTC_TX_HASH,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+    }
+
+    function test_ordering_alreadyProcessed_beforeDepsAndRegistration() public {
+        // Unwired contract (deps unset) with a pre-seeded claim and an unregistered rskAddr:
+        // check 1 must still win over the deps-set and registration checks.
+        PegInContract unwired = _deployUnwiredPegInContract();
+        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+        _seedClaim(unwired, pegInId, claimer);
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.PegInAlreadyProcessed.selector,
+                pegInId
+            )
+        );
+        unwired.requestPegIn{value: 1 ether}(
+            rskUser,
+            DEFAULT_AMOUNT,
+            DEFAULT_BTC_TX_HASH,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+    }
+}

--- a/test/pegin/RequestPegInReverts.t.sol
+++ b/test/pegin/RequestPegInReverts.t.sol
@@ -10,7 +10,7 @@ import {IPegInCommitFirst} from "../../src/interfaces/IPegInCommitFirst.sol";
 /// the already-processed check (check 1) runs before every later check.
 contract RequestPegInRevertsTest is RequestPegInTestBase {
     // Storage slots of the commit-first dependency pointers (verified via forge inspect).
-    uint256 private constant REGISTRY_SLOT = 9;
+    uint256 private constant REGISTRY_SLOT = 8;
 
     // ---- Check 1: already processed ----
 

--- a/test/pegin/RequestPegInTestBase.sol
+++ b/test/pegin/RequestPegInTestBase.sol
@@ -13,8 +13,10 @@ import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.s
 /// its harness) and a settable FlyoverConfigurationsMock, and reads the private claim record
 /// through storage slots (no production getter exists on the implementation under test).
 abstract contract RequestPegInTestBase is PegInTestBase {
-    /// @dev Storage slot of PegInContract._pegInClaims, verified with
-    /// `forge inspect PegInContract storageLayout`. A claim lives at
+    /// @dev Storage slot of PegInContract._pegInClaims under the lockfile-pinned OpenZeppelin
+    /// 5.5.0 remapping in foundry.toml (contracts package under node_modules). OZ 5.5+ stores
+    /// ReentrancyGuard in an ERC-7201 namespace, so claims sit at slot 10 (not 11). Verify with
+    /// `forge inspect PegInContract storageLayout` after `npm ci`. A claim lives at
     /// keccak256(abi.encode(pegInId, PEGIN_CLAIMS_BASE_SLOT)); the struct has no packing, so each
     /// uint256 field starts a fresh slot after the 20-byte address.
     uint256 internal constant PEGIN_CLAIMS_BASE_SLOT = 10;

--- a/test/pegin/RequestPegInTestBase.sol
+++ b/test/pegin/RequestPegInTestBase.sol
@@ -17,7 +17,7 @@ abstract contract RequestPegInTestBase is PegInTestBase {
     /// `forge inspect PegInContract storageLayout`. A claim lives at
     /// keccak256(abi.encode(pegInId, PEGIN_CLAIMS_BASE_SLOT)); the struct has no packing, so each
     /// uint256 field starts a fresh slot after the 20-byte address.
-    uint256 internal constant PEGIN_CLAIMS_BASE_SLOT = 11;
+    uint256 internal constant PEGIN_CLAIMS_BASE_SLOT = 10;
 
     uint256 internal constant BASIS_POINTS = 10000;
 

--- a/test/pegin/RequestPegInTestBase.sol
+++ b/test/pegin/RequestPegInTestBase.sol
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {PegInTestBase} from "./PegInTestBase.sol";
+import {FlyoverConfigurationsMock} from "./FlyoverConfigurationsMock.sol";
+import {PegInContract} from "../../src/PegInContract.sol";
+import {PegInAddressRegistryHarness} from "../pegin-registry/PegInAddressRegistryHarness.sol";
+import {IFlyoverConfigurations} from "../../src/interfaces/IFlyoverConfigurations.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+/// @title Base for commit-first requestPegIn tests
+/// @notice Deploys and wires a PegInContract against a real PegInAddressRegistry (seeded through
+/// its harness) and a settable FlyoverConfigurationsMock, and reads the private claim record
+/// through storage slots (no production getter exists on the implementation under test).
+abstract contract RequestPegInTestBase is PegInTestBase {
+    /// @dev Storage slot of PegInContract._pegInClaims, verified with
+    /// `forge inspect PegInContract storageLayout`. A claim lives at
+    /// keccak256(abi.encode(pegInId, PEGIN_CLAIMS_BASE_SLOT)); the struct has no packing, so each
+    /// uint256 field starts a fresh slot after the 20-byte address.
+    uint256 internal constant PEGIN_CLAIMS_BASE_SLOT = 11;
+
+    uint256 internal constant BASIS_POINTS = 10000;
+
+    uint256 internal constant DEFAULT_FIXED_FEE = 0.001 ether;
+    uint256 internal constant DEFAULT_PERCENTAGE_FEE = 100; // 1%
+    uint256 internal constant DEFAULT_MAX_AMOUNT = 100 ether;
+    uint256 internal constant DEFAULT_TIER_CONFIRMATIONS = 10;
+
+    PegInAddressRegistryHarness internal registry;
+    FlyoverConfigurationsMock internal configurations;
+
+    address internal claimer;
+    address internal rskUser;
+
+    bytes32 internal constant DEFAULT_BTC_TX_HASH = keccak256("default-btc-tx");
+    uint256 internal constant DEFAULT_AMOUNT = 5 ether;
+
+    function setUp() public virtual {
+        deployPegInContract();
+
+        registry = _deployRegistryHarness();
+        configurations = new FlyoverConfigurationsMock();
+        _applyDefaultConfiguration();
+
+        vm.prank(owner);
+        pegInContract.setPegInDependencies(
+            address(registry),
+            address(configurations)
+        );
+
+        claimer = makeAddr("claimer");
+        rskUser = makeAddr("rskUser");
+        vm.deal(claimer, 100 ether);
+
+        registry.harness_seedRegistration(rskUser, makeAddr("registrant"), 1);
+        bridgeMock.setConfirmations(int256(DEFAULT_TIER_CONFIRMATIONS));
+    }
+
+    // ---- deployment helpers ----
+
+    function _deployRegistryHarness()
+        internal
+        returns (PegInAddressRegistryHarness harness)
+    {
+        PegInAddressRegistryHarness implementation = new PegInAddressRegistryHarness();
+        bytes memory initData = abi.encodeCall(
+            implementation.initialize,
+            (owner, uint48(0), address(bridgeMock), false, pauseRegistry)
+        );
+        ERC1967Proxy proxy = new ERC1967Proxy(
+            address(implementation),
+            initData
+        );
+        harness = PegInAddressRegistryHarness(payable(address(proxy)));
+    }
+
+    function _applyDefaultConfiguration() internal {
+        configurations.setFee(DEFAULT_FIXED_FEE, DEFAULT_PERCENTAGE_FEE);
+        configurations.setAmountBounds(TEST_MIN_PEGIN, DEFAULT_MAX_AMOUNT);
+        IFlyoverConfigurations.ConfirmationTier[]
+            memory tiers = new IFlyoverConfigurations.ConfirmationTier[](1);
+        tiers[0] = IFlyoverConfigurations.ConfirmationTier({
+            maxAmount: type(uint256).max,
+            confirmations: DEFAULT_TIER_CONFIRMATIONS
+        });
+        configurations.setConfirmationTiers(tiers);
+    }
+
+    /// @notice Deploys a second PegInContract with its dependencies left unset
+    function _deployUnwiredPegInContract() internal returns (PegInContract) {
+        return deployPegInContract(false);
+    }
+
+    // ---- claim helpers ----
+
+    function _pegInId(
+        address rskAddr,
+        bytes32 btcTxHash
+    ) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(rskAddr, btcTxHash));
+    }
+
+    function _claimSlot(bytes32 pegInId) internal pure returns (uint256) {
+        return uint256(keccak256(abi.encode(pegInId, PEGIN_CLAIMS_BASE_SLOT)));
+    }
+
+    function _readClaim(
+        bytes32 pegInId
+    )
+        internal
+        view
+        returns (
+            address claimerAddr,
+            uint256 frontedAmount,
+            uint256 feeAtClaim,
+            uint256 requestBlock
+        )
+    {
+        return _readClaimFrom(pegInContract, pegInId);
+    }
+
+    function _readClaimFrom(
+        PegInContract target,
+        bytes32 pegInId
+    )
+        internal
+        view
+        returns (
+            address claimerAddr,
+            uint256 frontedAmount,
+            uint256 feeAtClaim,
+            uint256 requestBlock
+        )
+    {
+        uint256 base = _claimSlot(pegInId);
+        claimerAddr = address(
+            uint160(uint256(vm.load(address(target), bytes32(base))))
+        );
+        frontedAmount = uint256(vm.load(address(target), bytes32(base + 1)));
+        feeAtClaim = uint256(vm.load(address(target), bytes32(base + 2)));
+        requestBlock = uint256(vm.load(address(target), bytes32(base + 3)));
+    }
+
+    /// @notice Writes a claimer directly into a claim slot, to set up ordering fixtures
+    function _seedClaim(
+        PegInContract target,
+        bytes32 pegInId,
+        address claimerAddr
+    ) internal {
+        vm.store(
+            address(target),
+            bytes32(_claimSlot(pegInId)),
+            bytes32(uint256(uint160(claimerAddr)))
+        );
+    }
+
+    // ---- call helpers ----
+
+    function _emptyBranch() internal pure returns (bytes32[] memory) {
+        return new bytes32[](0);
+    }
+
+    function _requestPegIn(
+        address caller,
+        address rskAddr,
+        uint256 amount,
+        bytes32 btcTxHash,
+        uint256 value
+    ) internal returns (bytes32) {
+        vm.prank(caller);
+        return
+            pegInContract.requestPegIn{value: value}(
+                rskAddr,
+                amount,
+                btcTxHash,
+                "",
+                bytes32(0),
+                0,
+                _emptyBranch()
+            );
+    }
+
+    function _expectedFee(uint256 amount) internal pure returns (uint256) {
+        return
+            DEFAULT_FIXED_FEE +
+            (amount * DEFAULT_PERCENTAGE_FEE) /
+            BASIS_POINTS;
+    }
+}


### PR DESCRIPTION
## What

Adds a Foundry suite for `requestPegIn` under `test/pegin/`, including ordered reverts, duplicate-claim ordering, fronting delivery, claim-record fields, fee snapshots and boundaries, reentrancy, atomicity, and hard-pause coverage.

## Why

The commit-first peg-in claim path moves funds and must prove first-wins processing, exact failure surfaces, fee-at-claim accounting, and atomic delivery before the implementation can merge.

## Type of Change

- [x] Tests
- [ ] Production contract behavior
- [ ] Public API or ABI
- [ ] Deployment or release configuration

## Affected part

`liquidity-bridge-contract`: `test/pegin/` plus one test-only receiver under `src/test-contracts/`. No production `src/` contract is modified.

## Related Issues

- [FLY-2481](https://rsklabs.atlassian.net/browse/FLY-2481)
- Stacked implementation: [FLY-2480](https://rsklabs.atlassian.net/browse/FLY-2480)

## How to test

```bash
npm ci
npm ls @openzeppelin/contracts @openzeppelin/contracts-upgradeable
forge inspect PegInContract storageLayout
forge test --match-path 'test/pegin/RequestPegIn*.t.sol'
forge test --match-path 'test/pegin/*.t.sol'
npm test
```

Verified results: requestPegIn 21/21, complete PegIn 96/96, CI-scoped suite 578/578. PR checks pass.

## Reviewer Guidelines

- Confirm the storage pins match OpenZeppelin 5.5.0 (`_pegInAddressRegistry` slot 8 and `_pegInClaims` slot 10).
- Check exact custom-error arguments and first-check ordering for duplicate claims.
- Check that the malicious receiver re-enters with a different `btcTxHash`, proving the reentrancy guard rather than duplicate detection.
- Confirm the diff contains no production contract change.

## Additional Notes

This PR remains stacked on `fly-2480`; retarget to `3.0.0` after FLY-2480 merges. No generated artifacts, release action, or downstream SDK/LPS update is required.