### PR TITLE
Feat/fly 2460

### DIFF
--- a/test/configurations/AdminGating.t.sol
+++ b/test/configurations/AdminGating.t.sol
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {ConfigurationsTestBase} from "./ConfigurationsTestBase.sol";
+import {FlyoverConfigurations} from "../../src/FlyoverConfigurations.sol";
+import {IFlyoverConfigurations} from "../../src/interfaces/IFlyoverConfigurations.sol";
+import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
+
+/// @title AdminGatingTest
+/// @notice Access control on the admin path and every configuration-validation revert reachable
+/// through queueChange. Bounds guard even a compromised role (2·D).
+contract AdminGatingTest is ConfigurationsTestBase {
+    function setUp() public {
+        _deploy();
+    }
+
+    function _unauthorized(address account) private view returns (bytes memory) {
+        return abi.encodeWithSelector(
+            IAccessControl.AccessControlUnauthorizedAccount.selector, account, config.DEFAULT_ADMIN_ROLE()
+        );
+    }
+
+    // ------------------------------------------------------------------ role gating
+
+    function test_queueChange_nonAdminReverts() public {
+        IFlyoverConfigurations.PegConfiguration memory c = _altConfig();
+        // Precompute the expected error before pranking: reading DEFAULT_ADMIN_ROLE() is itself
+        // a call that would otherwise consume the prank.
+        bytes memory err = _unauthorized(stranger);
+        vm.prank(stranger);
+        vm.expectRevert(err);
+        config.queueChange(c);
+    }
+
+    function test_applyChange_nonAdminReverts() public {
+        _queueAlt();
+        vm.warp(block.timestamp + TIMELOCK_DELAY);
+        bytes memory err = _unauthorized(stranger);
+        vm.prank(stranger);
+        vm.expectRevert(err);
+        config.applyChange();
+    }
+
+    function test_admin_canQueueAndApply() public {
+        _queueAlt();
+        vm.warp(block.timestamp + TIMELOCK_DELAY);
+        vm.prank(owner);
+        config.applyChange();
+        assertEq(config.getPegInConfiguration().fixedFee, _altConfig().fixedFee);
+    }
+
+    // ------------------------------------------------------------------ tier validation
+
+    function test_queueChange_emptyTiersReverts() public {
+        IFlyoverConfigurations.PegConfiguration memory c = _altConfig();
+        c.confirmationTiers = new IFlyoverConfigurations.ConfirmationTier[](0);
+        vm.prank(owner);
+        vm.expectRevert(FlyoverConfigurations.EmptyTiers.selector);
+        config.queueChange(c);
+    }
+
+    function test_queueChange_nonAscendingTiersReverts() public {
+        IFlyoverConfigurations.PegConfiguration memory c = _altConfig();
+        c.confirmationTiers = new IFlyoverConfigurations.ConfirmationTier[](2);
+        c.confirmationTiers[0] = IFlyoverConfigurations.ConfirmationTier({maxAmount: 10 ether, confirmations: 3});
+        c.confirmationTiers[1] = IFlyoverConfigurations.ConfirmationTier({maxAmount: 1 ether, confirmations: 1});
+        vm.prank(owner);
+        vm.expectRevert(FlyoverConfigurations.TiersNotAscending.selector);
+        config.queueChange(c);
+    }
+
+    function test_queueChange_equalAdjacentTiersReverts() public {
+        // Strictly ascending: equal adjacent maxAmounts are rejected too.
+        IFlyoverConfigurations.PegConfiguration memory c = _altConfig();
+        c.confirmationTiers = new IFlyoverConfigurations.ConfirmationTier[](2);
+        c.confirmationTiers[0] = IFlyoverConfigurations.ConfirmationTier({maxAmount: 1 ether, confirmations: 1});
+        c.confirmationTiers[1] = IFlyoverConfigurations.ConfirmationTier({maxAmount: 1 ether, confirmations: 2});
+        vm.prank(owner);
+        vm.expectRevert(FlyoverConfigurations.TiersNotAscending.selector);
+        config.queueChange(c);
+    }
+
+    // ------------------------------------------------------------------ bounds validation
+
+    /// @notice The fixed-fee floor (2·D) cannot be undercut even by the admin role.
+    function test_queueChange_fixedFeeBelowFloorReverts() public {
+        IFlyoverConfigurations.PegConfiguration memory c = _altConfig();
+        c.fixedFee = BOUND_MIN_FIXED_FEE - 1;
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FlyoverConfigurations.ConfigValueOutOfBounds.selector,
+                FlyoverConfigurations.Field.FixedFee,
+                BOUND_MIN_FIXED_FEE - 1,
+                BOUND_MIN_FIXED_FEE,
+                BOUND_MAX_FIXED_FEE
+            )
+        );
+        config.queueChange(c);
+    }
+
+    function test_queueChange_fixedFeeAboveMaxReverts() public {
+        IFlyoverConfigurations.PegConfiguration memory c = _altConfig();
+        c.fixedFee = BOUND_MAX_FIXED_FEE + 1;
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FlyoverConfigurations.ConfigValueOutOfBounds.selector,
+                FlyoverConfigurations.Field.FixedFee,
+                BOUND_MAX_FIXED_FEE + 1,
+                BOUND_MIN_FIXED_FEE,
+                BOUND_MAX_FIXED_FEE
+            )
+        );
+        config.queueChange(c);
+    }
+
+    function test_queueChange_percentageFeeOutOfBoundsReverts() public {
+        IFlyoverConfigurations.PegConfiguration memory c = _altConfig();
+        c.percentageFee = BOUND_MAX_PCT + 1;
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FlyoverConfigurations.ConfigValueOutOfBounds.selector,
+                FlyoverConfigurations.Field.PercentageFee,
+                BOUND_MAX_PCT + 1,
+                BOUND_MIN_PCT,
+                BOUND_MAX_PCT
+            )
+        );
+        config.queueChange(c);
+    }
+
+    function test_queueChange_minAmountOutOfBoundsReverts() public {
+        IFlyoverConfigurations.PegConfiguration memory c = _altConfig();
+        c.minAmount = BOUND_MAX_MIN_AMOUNT + 1;
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FlyoverConfigurations.ConfigValueOutOfBounds.selector,
+                FlyoverConfigurations.Field.MinAmount,
+                BOUND_MAX_MIN_AMOUNT + 1,
+                BOUND_MIN_MIN_AMOUNT,
+                BOUND_MAX_MIN_AMOUNT
+            )
+        );
+        config.queueChange(c);
+    }
+
+    function test_queueChange_maxAmountOutOfBoundsReverts() public {
+        IFlyoverConfigurations.PegConfiguration memory c = _altConfig();
+        c.maxAmount = BOUND_MAX_MAX_AMOUNT + 1;
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FlyoverConfigurations.ConfigValueOutOfBounds.selector,
+                FlyoverConfigurations.Field.MaxAmount,
+                BOUND_MAX_MAX_AMOUNT + 1,
+                BOUND_MIN_MAX_AMOUNT,
+                BOUND_MAX_MAX_AMOUNT
+            )
+        );
+        config.queueChange(c);
+    }
+
+    // ------------------------------------------------------------------ structural invariants
+
+    /// @notice percentageFee within bounds but above the 100% denominator is rejected.
+    function test_queueChange_invalidPercentageFeeReverts() public {
+        uint256 badPct = PCT_DENOMINATOR + 5000; // 15000: within [0, 20000] bound, but > 100%
+        IFlyoverConfigurations.PegConfiguration memory c = _altConfig();
+        c.percentageFee = badPct;
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(FlyoverConfigurations.InvalidPercentageFee.selector, badPct));
+        config.queueChange(c);
+    }
+
+    /// @notice minAmount greater than maxAmount is rejected, even when both are within bounds.
+    function test_queueChange_invalidAmountLimitsReverts() public {
+        IFlyoverConfigurations.PegConfiguration memory c = _altConfig();
+        c.minAmount = 1 ether; // within [0, 1 ether]
+        c.maxAmount = 0.5 ether; // within [0, 10000 ether] but < minAmount
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(FlyoverConfigurations.InvalidAmountLimits.selector, 1 ether, 0.5 ether)
+        );
+        config.queueChange(c);
+    }
+}

--- a/test/configurations/AdminGating.t.sol
+++ b/test/configurations/AdminGating.t.sol
@@ -14,10 +14,15 @@ contract AdminGatingTest is ConfigurationsTestBase {
         _deploy();
     }
 
-    function _unauthorized(address account) private view returns (bytes memory) {
-        return abi.encodeWithSelector(
-            IAccessControl.AccessControlUnauthorizedAccount.selector, account, config.DEFAULT_ADMIN_ROLE()
-        );
+    function _unauthorized(
+        address account
+    ) private view returns (bytes memory) {
+        return
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                account,
+                config.DEFAULT_ADMIN_ROLE()
+            );
     }
 
     // ------------------------------------------------------------------ role gating
@@ -46,7 +51,10 @@ contract AdminGatingTest is ConfigurationsTestBase {
         vm.warp(block.timestamp + TIMELOCK_DELAY);
         vm.prank(owner);
         config.applyChange();
-        assertEq(config.getPegInConfiguration().fixedFee, _altConfig().fixedFee);
+        assertEq(
+            config.getPegInConfiguration().fixedFee,
+            _altConfig().fixedFee
+        );
     }
 
     // ------------------------------------------------------------------ tier validation
@@ -62,8 +70,14 @@ contract AdminGatingTest is ConfigurationsTestBase {
     function test_queueChange_nonAscendingTiersReverts() public {
         IFlyoverConfigurations.PegConfiguration memory c = _altConfig();
         c.confirmationTiers = new IFlyoverConfigurations.ConfirmationTier[](2);
-        c.confirmationTiers[0] = IFlyoverConfigurations.ConfirmationTier({maxAmount: 10 ether, confirmations: 3});
-        c.confirmationTiers[1] = IFlyoverConfigurations.ConfirmationTier({maxAmount: 1 ether, confirmations: 1});
+        c.confirmationTiers[0] = IFlyoverConfigurations.ConfirmationTier({
+            maxAmount: 10 ether,
+            confirmations: 3
+        });
+        c.confirmationTiers[1] = IFlyoverConfigurations.ConfirmationTier({
+            maxAmount: 1 ether,
+            confirmations: 1
+        });
         vm.prank(owner);
         vm.expectRevert(FlyoverConfigurations.TiersNotAscending.selector);
         config.queueChange(c);
@@ -73,8 +87,14 @@ contract AdminGatingTest is ConfigurationsTestBase {
         // Strictly ascending: equal adjacent maxAmounts are rejected too.
         IFlyoverConfigurations.PegConfiguration memory c = _altConfig();
         c.confirmationTiers = new IFlyoverConfigurations.ConfirmationTier[](2);
-        c.confirmationTiers[0] = IFlyoverConfigurations.ConfirmationTier({maxAmount: 1 ether, confirmations: 1});
-        c.confirmationTiers[1] = IFlyoverConfigurations.ConfirmationTier({maxAmount: 1 ether, confirmations: 2});
+        c.confirmationTiers[0] = IFlyoverConfigurations.ConfirmationTier({
+            maxAmount: 1 ether,
+            confirmations: 1
+        });
+        c.confirmationTiers[1] = IFlyoverConfigurations.ConfirmationTier({
+            maxAmount: 1 ether,
+            confirmations: 2
+        });
         vm.prank(owner);
         vm.expectRevert(FlyoverConfigurations.TiersNotAscending.selector);
         config.queueChange(c);
@@ -171,7 +191,12 @@ contract AdminGatingTest is ConfigurationsTestBase {
         IFlyoverConfigurations.PegConfiguration memory c = _altConfig();
         c.percentageFee = badPct;
         vm.prank(owner);
-        vm.expectRevert(abi.encodeWithSelector(FlyoverConfigurations.InvalidPercentageFee.selector, badPct));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FlyoverConfigurations.InvalidPercentageFee.selector,
+                badPct
+            )
+        );
         config.queueChange(c);
     }
 
@@ -182,7 +207,11 @@ contract AdminGatingTest is ConfigurationsTestBase {
         c.maxAmount = 0.5 ether; // within [0, 10000 ether] but < minAmount
         vm.prank(owner);
         vm.expectRevert(
-            abi.encodeWithSelector(FlyoverConfigurations.InvalidAmountLimits.selector, 1 ether, 0.5 ether)
+            abi.encodeWithSelector(
+                FlyoverConfigurations.InvalidAmountLimits.selector,
+                1 ether,
+                0.5 ether
+            )
         );
         config.queueChange(c);
     }

--- a/test/configurations/ConfigurationsTestBase.sol
+++ b/test/configurations/ConfigurationsTestBase.sol
@@ -54,14 +54,25 @@ abstract contract ConfigurationsTestBase is Test {
         FlyoverConfigurations impl = new FlyoverConfigurations();
         bytes memory initData = abi.encodeCall(
             FlyoverConfigurations.initialize,
-            (owner, ADMIN_DELAY, TIMELOCK_DELAY, _seedConfig(), _boundsMin(), _boundsMax())
+            (
+                owner,
+                ADMIN_DELAY,
+                TIMELOCK_DELAY,
+                _seedConfig(),
+                _boundsMin(),
+                _boundsMax()
+            )
         );
         ERC1967Proxy proxy = new ERC1967Proxy(address(impl), initData);
         config = FlyoverConfigurations(payable(address(proxy)));
     }
 
     /// @notice The seed peg-in configuration written at initialize time.
-    function _seedConfig() internal pure returns (IFlyoverConfigurations.PegConfiguration memory c) {
+    function _seedConfig()
+        internal
+        pure
+        returns (IFlyoverConfigurations.PegConfiguration memory c)
+    {
         c.fixedFee = SEED_FIXED_FEE;
         c.percentageFee = SEED_PCT;
         c.minAmount = SEED_MIN_AMOUNT;
@@ -70,14 +81,31 @@ abstract contract ConfigurationsTestBase is Test {
     }
 
     /// @notice Seed tiers: (1e18,1) (10e18,3) (100e18,6), strictly ascending.
-    function _seedTiers() internal pure returns (IFlyoverConfigurations.ConfirmationTier[] memory tiers) {
+    function _seedTiers()
+        internal
+        pure
+        returns (IFlyoverConfigurations.ConfirmationTier[] memory tiers)
+    {
         tiers = new IFlyoverConfigurations.ConfirmationTier[](3);
-        tiers[0] = IFlyoverConfigurations.ConfirmationTier({maxAmount: 1 ether, confirmations: 1});
-        tiers[1] = IFlyoverConfigurations.ConfirmationTier({maxAmount: 10 ether, confirmations: 3});
-        tiers[2] = IFlyoverConfigurations.ConfirmationTier({maxAmount: 100 ether, confirmations: 6});
+        tiers[0] = IFlyoverConfigurations.ConfirmationTier({
+            maxAmount: 1 ether,
+            confirmations: 1
+        });
+        tiers[1] = IFlyoverConfigurations.ConfirmationTier({
+            maxAmount: 10 ether,
+            confirmations: 3
+        });
+        tiers[2] = IFlyoverConfigurations.ConfirmationTier({
+            maxAmount: 100 ether,
+            confirmations: 6
+        });
     }
 
-    function _boundsMin() internal pure returns (IFlyoverConfigurations.PegConfiguration memory c) {
+    function _boundsMin()
+        internal
+        pure
+        returns (IFlyoverConfigurations.PegConfiguration memory c)
+    {
         c.fixedFee = BOUND_MIN_FIXED_FEE;
         c.percentageFee = BOUND_MIN_PCT;
         c.minAmount = BOUND_MIN_MIN_AMOUNT;
@@ -86,7 +114,11 @@ abstract contract ConfigurationsTestBase is Test {
         c.confirmationTiers = new IFlyoverConfigurations.ConfirmationTier[](0);
     }
 
-    function _boundsMax() internal pure returns (IFlyoverConfigurations.PegConfiguration memory c) {
+    function _boundsMax()
+        internal
+        pure
+        returns (IFlyoverConfigurations.PegConfiguration memory c)
+    {
         c.fixedFee = BOUND_MAX_FIXED_FEE;
         c.percentageFee = BOUND_MAX_PCT;
         c.minAmount = BOUND_MAX_MIN_AMOUNT;
@@ -96,18 +128,31 @@ abstract contract ConfigurationsTestBase is Test {
 
     /// @notice A valid config distinct from the seed, for queue/apply tests so the applied change
     /// is observable. All scalars sit within the deployment bounds.
-    function _altConfig() internal pure returns (IFlyoverConfigurations.PegConfiguration memory c) {
+    function _altConfig()
+        internal
+        pure
+        returns (IFlyoverConfigurations.PegConfiguration memory c)
+    {
         c.fixedFee = 2000 * SAT;
         c.percentageFee = 20; // 0.20%
         c.minAmount = 0.002 ether;
         c.maxAmount = 200 ether;
         c.confirmationTiers = new IFlyoverConfigurations.ConfirmationTier[](2);
-        c.confirmationTiers[0] = IFlyoverConfigurations.ConfirmationTier({maxAmount: 2 ether, confirmations: 2});
-        c.confirmationTiers[1] = IFlyoverConfigurations.ConfirmationTier({maxAmount: 20 ether, confirmations: 5});
+        c.confirmationTiers[0] = IFlyoverConfigurations.ConfirmationTier({
+            maxAmount: 2 ether,
+            confirmations: 2
+        });
+        c.confirmationTiers[1] = IFlyoverConfigurations.ConfirmationTier({
+            maxAmount: 20 ether,
+            confirmations: 5
+        });
     }
 
     /// @notice Convenience: queue `_altConfig()` as the admin and return it.
-    function _queueAlt() internal returns (IFlyoverConfigurations.PegConfiguration memory c) {
+    function _queueAlt()
+        internal
+        returns (IFlyoverConfigurations.PegConfiguration memory c)
+    {
         c = _altConfig();
         vm.prank(owner);
         config.queueChange(c);

--- a/test/configurations/ConfigurationsTestBase.sol
+++ b/test/configurations/ConfigurationsTestBase.sol
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {FlyoverConfigurations} from "../../src/FlyoverConfigurations.sol";
+import {IFlyoverConfigurations} from "../../src/interfaces/IFlyoverConfigurations.sol";
+
+/// @title ConfigurationsTestBase
+/// @notice Shared setup for the FlyoverConfigurations suite (tests the S2.1 / FLY-2459 contract
+/// against the S0-frozen peg-in-only interface). Deploys the contract behind an ERC1967 proxy
+/// with a known seed config, explicit deployment bounds, and a non-zero time-lock delay.
+/// @dev ERC1967 (not Transparent) is used so `owner` can call admin functions directly; a
+/// TransparentUpgradeableProxy would route the admin's calls to the proxy admin, not the impl.
+abstract contract ConfigurationsTestBase is Test {
+    // --- deployment params ---
+    uint48 internal constant ADMIN_DELAY = 0;
+    uint256 internal constant TIMELOCK_DELAY = 1 days;
+
+    /// @notice 1 satoshi in wei; fees round down to this boundary.
+    uint256 internal constant SAT = 10 ** 10;
+    /// @notice Percentage fee denominator: 10_000 == 100%.
+    uint256 internal constant PCT_DENOMINATOR = 10_000;
+
+    // --- seed configuration (the active config right after initialize) ---
+    uint256 internal constant SEED_FIXED_FEE = 1000 * SAT; // 1e13 wei, satoshi-aligned
+    uint256 internal constant SEED_PCT = 10; // 0.10%
+    uint256 internal constant SEED_MIN_AMOUNT = 0.001 ether;
+    uint256 internal constant SEED_MAX_AMOUNT = 100 ether;
+
+    // --- immutable deployment bounds ---
+    // fixedFee lower bound IS the 2·D security floor; no queued change may drop below it.
+    uint256 internal constant BOUND_MIN_FIXED_FEE = 100 * SAT;
+    uint256 internal constant BOUND_MAX_FIXED_FEE = 1 ether;
+    uint256 internal constant BOUND_MIN_PCT = 0;
+    // Intentionally above the 100% denominator so the InvalidPercentageFee guard is reachable
+    // and provably independent of the bound check.
+    uint256 internal constant BOUND_MAX_PCT = 20_000;
+    uint256 internal constant BOUND_MIN_MIN_AMOUNT = 0;
+    uint256 internal constant BOUND_MAX_MIN_AMOUNT = 1 ether;
+    uint256 internal constant BOUND_MIN_MAX_AMOUNT = 0;
+    uint256 internal constant BOUND_MAX_MAX_AMOUNT = 10_000 ether;
+
+    // ERC-7201 base slot of the mutable namespace `rsk.flyover.FlyoverConfigurations`.
+    bytes32 internal constant STORAGE_SLOT =
+        0x13aa2a37a5354fe7c5dcced2a6c33933ec66091f98f22792660cd2862f158700;
+
+    address internal owner = makeAddr("owner");
+    address internal stranger = makeAddr("stranger");
+
+    FlyoverConfigurations internal config;
+
+    function _deploy() internal {
+        FlyoverConfigurations impl = new FlyoverConfigurations();
+        bytes memory initData = abi.encodeCall(
+            FlyoverConfigurations.initialize,
+            (owner, ADMIN_DELAY, TIMELOCK_DELAY, _seedConfig(), _boundsMin(), _boundsMax())
+        );
+        ERC1967Proxy proxy = new ERC1967Proxy(address(impl), initData);
+        config = FlyoverConfigurations(payable(address(proxy)));
+    }
+
+    /// @notice The seed peg-in configuration written at initialize time.
+    function _seedConfig() internal pure returns (IFlyoverConfigurations.PegConfiguration memory c) {
+        c.fixedFee = SEED_FIXED_FEE;
+        c.percentageFee = SEED_PCT;
+        c.minAmount = SEED_MIN_AMOUNT;
+        c.maxAmount = SEED_MAX_AMOUNT;
+        c.confirmationTiers = _seedTiers();
+    }
+
+    /// @notice Seed tiers: (1e18,1) (10e18,3) (100e18,6), strictly ascending.
+    function _seedTiers() internal pure returns (IFlyoverConfigurations.ConfirmationTier[] memory tiers) {
+        tiers = new IFlyoverConfigurations.ConfirmationTier[](3);
+        tiers[0] = IFlyoverConfigurations.ConfirmationTier({maxAmount: 1 ether, confirmations: 1});
+        tiers[1] = IFlyoverConfigurations.ConfirmationTier({maxAmount: 10 ether, confirmations: 3});
+        tiers[2] = IFlyoverConfigurations.ConfirmationTier({maxAmount: 100 ether, confirmations: 6});
+    }
+
+    function _boundsMin() internal pure returns (IFlyoverConfigurations.PegConfiguration memory c) {
+        c.fixedFee = BOUND_MIN_FIXED_FEE;
+        c.percentageFee = BOUND_MIN_PCT;
+        c.minAmount = BOUND_MIN_MIN_AMOUNT;
+        c.maxAmount = BOUND_MIN_MAX_AMOUNT;
+        // Tier array is ordering/non-emptiness checked, never min/max bounded; left empty.
+        c.confirmationTiers = new IFlyoverConfigurations.ConfirmationTier[](0);
+    }
+
+    function _boundsMax() internal pure returns (IFlyoverConfigurations.PegConfiguration memory c) {
+        c.fixedFee = BOUND_MAX_FIXED_FEE;
+        c.percentageFee = BOUND_MAX_PCT;
+        c.minAmount = BOUND_MAX_MIN_AMOUNT;
+        c.maxAmount = BOUND_MAX_MAX_AMOUNT;
+        c.confirmationTiers = new IFlyoverConfigurations.ConfirmationTier[](0);
+    }
+
+    /// @notice A valid config distinct from the seed, for queue/apply tests so the applied change
+    /// is observable. All scalars sit within the deployment bounds.
+    function _altConfig() internal pure returns (IFlyoverConfigurations.PegConfiguration memory c) {
+        c.fixedFee = 2000 * SAT;
+        c.percentageFee = 20; // 0.20%
+        c.minAmount = 0.002 ether;
+        c.maxAmount = 200 ether;
+        c.confirmationTiers = new IFlyoverConfigurations.ConfirmationTier[](2);
+        c.confirmationTiers[0] = IFlyoverConfigurations.ConfirmationTier({maxAmount: 2 ether, confirmations: 2});
+        c.confirmationTiers[1] = IFlyoverConfigurations.ConfirmationTier({maxAmount: 20 ether, confirmations: 5});
+    }
+
+    /// @notice Convenience: queue `_altConfig()` as the admin and return it.
+    function _queueAlt() internal returns (IFlyoverConfigurations.PegConfiguration memory c) {
+        c = _altConfig();
+        vm.prank(owner);
+        config.queueChange(c);
+    }
+}

--- a/test/configurations/Fee.t.sol
+++ b/test/configurations/Fee.t.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {ConfigurationsTestBase} from "./ConfigurationsTestBase.sol";
+import {Quotes} from "../../src/libraries/Quotes.sol";
+
+/// @title FeeTest
+/// @notice calculatePegInFee: floor behavior, satoshi rounding, and hand-computed values.
+/// @dev Walkthrough anchors: step 2, decision block 2·D (the fixed fee is a security floor).
+contract FeeTest is ConfigurationsTestBase {
+    function setUp() public {
+        _deploy();
+    }
+
+    /// @dev Independent mirror of the contract formula + rounding, to assert against.
+    function _expectedFee(uint256 fixedFee, uint256 pct, uint256 amount) private pure returns (uint256) {
+        uint256 fee = fixedFee + (amount * pct) / PCT_DENOMINATOR;
+        if (fee > SAT && (fee % SAT) != 0) {
+            fee -= (fee % SAT);
+        }
+        return fee;
+    }
+
+    /// @notice The SAT constant used by the suite equals the on-chain conversion constant.
+    function test_satConstant_matchesQuotesLibrary() public view {
+        assertEq(SAT, Quotes.SAT_TO_WEI_CONVERSION);
+        assertEq(SAT, config.SAT_TO_WEI_CONVERSION());
+    }
+
+    /// @notice At zero amount the fee is exactly the fixed floor (2·D).
+    function test_zeroAmount_returnsFixedFloor() public view {
+        assertEq(config.calculatePegInFee(0), SEED_FIXED_FEE);
+    }
+
+    /// @notice At the minimum peg-in amount the fee is floor + percentage of that amount.
+    /// Hand-computed: 1000*SAT + 0.001e18 * 10 / 10000 = 1e13 + 1e12 = 11 * 1e12.
+    function test_floorAtMinAmount_handComputed() public view {
+        uint256 amount = SEED_MIN_AMOUNT; // 0.001 ether = 1e15 wei
+        uint256 expected = 1e13 + (1e15 * 10) / 10_000; // 1e13 + 1e12
+        assertEq(expected, 11 * 1e12); // sanity on the hand math
+        assertEq(config.calculatePegInFee(amount), expected);
+    }
+
+    /// @notice A mid-range amount: floor + percentage, asserted against the hand formula.
+    /// 5 ether * 10 / 10000 = 5e15; plus 1e13 floor = 5_010_000_000_000_000 wei.
+    function test_midAmount_handComputed() public view {
+        uint256 amount = 5 ether;
+        uint256 expected = SEED_FIXED_FEE + (amount * SEED_PCT) / PCT_DENOMINATOR;
+        assertEq(expected, 5_010_000_000_000_000);
+        assertEq(config.calculatePegInFee(amount), expected);
+    }
+
+    /// @notice The fee is rounded DOWN to a satoshi boundary, exactly like
+    /// Quotes.checkAgreedAmount, for an amount whose percentage term is not satoshi-aligned.
+    function test_roundingMatchesCheckAgreedAmount() public view {
+        // percentage term = amount * 10 / 10000 = amount / 1000; choose a non-SAT-aligned result.
+        uint256 amount = 123_456_789_012_345;
+        uint256 rawFee = SEED_FIXED_FEE + (amount * SEED_PCT) / PCT_DENOMINATOR;
+        assertTrue(rawFee % SAT != 0, "test setup: pick an amount with a sub-satoshi remainder");
+
+        uint256 got = config.calculatePegInFee(amount);
+        assertEq(got, rawFee - (rawFee % SAT));
+        assertEq(got % SAT, 0, "result must be satoshi-aligned");
+        assertEq(got, _expectedFee(SEED_FIXED_FEE, SEED_PCT, amount));
+    }
+
+    /// @notice A large amount does not overflow and matches the hand formula.
+    function test_largeAmount_noOverflow() public view {
+        uint256 amount = type(uint128).max;
+        uint256 fee = config.calculatePegInFee(amount);
+        assertEq(fee, _expectedFee(SEED_FIXED_FEE, SEED_PCT, amount));
+        assertGt(fee, 0);
+    }
+}

--- a/test/configurations/Fee.t.sol
+++ b/test/configurations/Fee.t.sol
@@ -31,6 +31,12 @@ contract FeeTest is ConfigurationsTestBase {
         assertEq(SAT, config.SAT_TO_WEI_CONVERSION());
     }
 
+    /// @notice The public fee-percentage denominator getter pins 10_000 (== 100%).
+    function test_feePercentageDenominator_matchesConstant() public view {
+        assertEq(config.FEE_PERCENTAGE_DENOMINATOR(), PCT_DENOMINATOR);
+        assertEq(config.FEE_PERCENTAGE_DENOMINATOR(), 10_000);
+    }
+
     /// @notice At zero amount the fee is exactly the fixed floor (2·D).
     function test_zeroAmount_returnsFixedFloor() public view {
         assertEq(config.calculatePegInFee(0), SEED_FIXED_FEE);

--- a/test/configurations/Fee.t.sol
+++ b/test/configurations/Fee.t.sol
@@ -13,7 +13,11 @@ contract FeeTest is ConfigurationsTestBase {
     }
 
     /// @dev Independent mirror of the contract formula + rounding, to assert against.
-    function _expectedFee(uint256 fixedFee, uint256 pct, uint256 amount) private pure returns (uint256) {
+    function _expectedFee(
+        uint256 fixedFee,
+        uint256 pct,
+        uint256 amount
+    ) private pure returns (uint256) {
         uint256 fee = fixedFee + (amount * pct) / PCT_DENOMINATOR;
         if (fee > SAT && (fee % SAT) != 0) {
             fee -= (fee % SAT);
@@ -45,7 +49,9 @@ contract FeeTest is ConfigurationsTestBase {
     /// 5 ether * 10 / 10000 = 5e15; plus 1e13 floor = 5_010_000_000_000_000 wei.
     function test_midAmount_handComputed() public view {
         uint256 amount = 5 ether;
-        uint256 expected = SEED_FIXED_FEE + (amount * SEED_PCT) / PCT_DENOMINATOR;
+        uint256 expected = SEED_FIXED_FEE +
+            (amount * SEED_PCT) /
+            PCT_DENOMINATOR;
         assertEq(expected, 5_010_000_000_000_000);
         assertEq(config.calculatePegInFee(amount), expected);
     }
@@ -56,7 +62,10 @@ contract FeeTest is ConfigurationsTestBase {
         // percentage term = amount * 10 / 10000 = amount / 1000; choose a non-SAT-aligned result.
         uint256 amount = 123_456_789_012_345;
         uint256 rawFee = SEED_FIXED_FEE + (amount * SEED_PCT) / PCT_DENOMINATOR;
-        assertTrue(rawFee % SAT != 0, "test setup: pick an amount with a sub-satoshi remainder");
+        assertTrue(
+            rawFee % SAT != 0,
+            "test setup: pick an amount with a sub-satoshi remainder"
+        );
 
         uint256 got = config.calculatePegInFee(amount);
         assertEq(got, rawFee - (rawFee % SAT));

--- a/test/configurations/Getters.t.sol
+++ b/test/configurations/Getters.t.sol
@@ -13,7 +13,8 @@ contract GettersTest is ConfigurationsTestBase {
     }
 
     function test_getPegInConfiguration_roundTripsSeed() public view {
-        IFlyoverConfigurations.PegConfiguration memory c = config.getPegInConfiguration();
+        IFlyoverConfigurations.PegConfiguration memory c = config
+            .getPegInConfiguration();
         assertEq(c.fixedFee, SEED_FIXED_FEE);
         assertEq(c.percentageFee, SEED_PCT);
         assertEq(c.minAmount, SEED_MIN_AMOUNT);
@@ -26,13 +27,17 @@ contract GettersTest is ConfigurationsTestBase {
     }
 
     function test_limits_readableFromConfiguration() public view {
-        IFlyoverConfigurations.PegConfiguration memory c = config.getPegInConfiguration();
+        IFlyoverConfigurations.PegConfiguration memory c = config
+            .getPegInConfiguration();
         assertEq(c.minAmount, SEED_MIN_AMOUNT);
         assertEq(c.maxAmount, SEED_MAX_AMOUNT);
         assertLe(c.minAmount, c.maxAmount);
     }
 
-    function test_getPegInConfigurationBounds_returnsDeploymentBounds() public view {
+    function test_getPegInConfigurationBounds_returnsDeploymentBounds()
+        public
+        view
+    {
         (
             IFlyoverConfigurations.PegConfiguration memory min,
             IFlyoverConfigurations.PegConfiguration memory max
@@ -54,7 +59,10 @@ contract GettersTest is ConfigurationsTestBase {
     }
 
     function test_getPendingChange_zeroedWhenNothingQueued() public view {
-        (IFlyoverConfigurations.PegConfiguration memory pending, uint256 eta) = config.getPendingChange();
+        (
+            IFlyoverConfigurations.PegConfiguration memory pending,
+            uint256 eta
+        ) = config.getPendingChange();
         assertEq(eta, 0);
         assertEq(pending.fixedFee, 0);
         assertEq(pending.percentageFee, 0);
@@ -67,13 +75,19 @@ contract GettersTest is ConfigurationsTestBase {
         uint256 expectedEta = block.timestamp + TIMELOCK_DELAY;
         IFlyoverConfigurations.PegConfiguration memory queued = _queueAlt();
 
-        (IFlyoverConfigurations.PegConfiguration memory pending, uint256 eta) = config.getPendingChange();
+        (
+            IFlyoverConfigurations.PegConfiguration memory pending,
+            uint256 eta
+        ) = config.getPendingChange();
         assertEq(eta, expectedEta);
         assertEq(pending.fixedFee, queued.fixedFee);
         assertEq(pending.percentageFee, queued.percentageFee);
         assertEq(pending.minAmount, queued.minAmount);
         assertEq(pending.maxAmount, queued.maxAmount);
-        assertEq(pending.confirmationTiers.length, queued.confirmationTiers.length);
+        assertEq(
+            pending.confirmationTiers.length,
+            queued.confirmationTiers.length
+        );
     }
 
     function test_getPendingChange_clearedAfterApply() public {
@@ -82,7 +96,10 @@ contract GettersTest is ConfigurationsTestBase {
         vm.prank(owner);
         config.applyChange();
 
-        (IFlyoverConfigurations.PegConfiguration memory pending, uint256 eta) = config.getPendingChange();
+        (
+            IFlyoverConfigurations.PegConfiguration memory pending,
+            uint256 eta
+        ) = config.getPendingChange();
         assertEq(eta, 0);
         assertEq(pending.fixedFee, 0);
         assertEq(pending.confirmationTiers.length, 0);

--- a/test/configurations/Getters.t.sol
+++ b/test/configurations/Getters.t.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {ConfigurationsTestBase} from "./ConfigurationsTestBase.sol";
+import {IFlyoverConfigurations} from "../../src/interfaces/IFlyoverConfigurations.sol";
+
+/// @title GettersTest
+/// @notice Every read surface: the active configuration (incl. limits), the immutable bounds,
+/// the pending change, and the time-lock delay.
+contract GettersTest is ConfigurationsTestBase {
+    function setUp() public {
+        _deploy();
+    }
+
+    function test_getPegInConfiguration_roundTripsSeed() public view {
+        IFlyoverConfigurations.PegConfiguration memory c = config.getPegInConfiguration();
+        assertEq(c.fixedFee, SEED_FIXED_FEE);
+        assertEq(c.percentageFee, SEED_PCT);
+        assertEq(c.minAmount, SEED_MIN_AMOUNT);
+        assertEq(c.maxAmount, SEED_MAX_AMOUNT);
+        assertEq(c.confirmationTiers.length, 3);
+        assertEq(c.confirmationTiers[0].maxAmount, 1 ether);
+        assertEq(c.confirmationTiers[0].confirmations, 1);
+        assertEq(c.confirmationTiers[2].maxAmount, 100 ether);
+        assertEq(c.confirmationTiers[2].confirmations, 6);
+    }
+
+    function test_limits_readableFromConfiguration() public view {
+        IFlyoverConfigurations.PegConfiguration memory c = config.getPegInConfiguration();
+        assertEq(c.minAmount, SEED_MIN_AMOUNT);
+        assertEq(c.maxAmount, SEED_MAX_AMOUNT);
+        assertLe(c.minAmount, c.maxAmount);
+    }
+
+    function test_getPegInConfigurationBounds_returnsDeploymentBounds() public view {
+        (
+            IFlyoverConfigurations.PegConfiguration memory min,
+            IFlyoverConfigurations.PegConfiguration memory max
+        ) = config.getPegInConfigurationBounds();
+
+        assertEq(min.fixedFee, BOUND_MIN_FIXED_FEE);
+        assertEq(min.percentageFee, BOUND_MIN_PCT);
+        assertEq(min.minAmount, BOUND_MIN_MIN_AMOUNT);
+        assertEq(min.maxAmount, BOUND_MIN_MAX_AMOUNT);
+
+        assertEq(max.fixedFee, BOUND_MAX_FIXED_FEE);
+        assertEq(max.percentageFee, BOUND_MAX_PCT);
+        assertEq(max.minAmount, BOUND_MAX_MIN_AMOUNT);
+        assertEq(max.maxAmount, BOUND_MAX_MAX_AMOUNT);
+    }
+
+    function test_getTimelockDelay_returnsConfiguredDelay() public view {
+        assertEq(config.getTimelockDelay(), TIMELOCK_DELAY);
+    }
+
+    function test_getPendingChange_zeroedWhenNothingQueued() public view {
+        (IFlyoverConfigurations.PegConfiguration memory pending, uint256 eta) = config.getPendingChange();
+        assertEq(eta, 0);
+        assertEq(pending.fixedFee, 0);
+        assertEq(pending.percentageFee, 0);
+        assertEq(pending.minAmount, 0);
+        assertEq(pending.maxAmount, 0);
+        assertEq(pending.confirmationTiers.length, 0);
+    }
+
+    function test_getPendingChange_reflectsQueuedChange() public {
+        uint256 expectedEta = block.timestamp + TIMELOCK_DELAY;
+        IFlyoverConfigurations.PegConfiguration memory queued = _queueAlt();
+
+        (IFlyoverConfigurations.PegConfiguration memory pending, uint256 eta) = config.getPendingChange();
+        assertEq(eta, expectedEta);
+        assertEq(pending.fixedFee, queued.fixedFee);
+        assertEq(pending.percentageFee, queued.percentageFee);
+        assertEq(pending.minAmount, queued.minAmount);
+        assertEq(pending.maxAmount, queued.maxAmount);
+        assertEq(pending.confirmationTiers.length, queued.confirmationTiers.length);
+    }
+
+    function test_getPendingChange_clearedAfterApply() public {
+        _queueAlt();
+        vm.warp(block.timestamp + TIMELOCK_DELAY);
+        vm.prank(owner);
+        config.applyChange();
+
+        (IFlyoverConfigurations.PegConfiguration memory pending, uint256 eta) = config.getPendingChange();
+        assertEq(eta, 0);
+        assertEq(pending.fixedFee, 0);
+        assertEq(pending.confirmationTiers.length, 0);
+    }
+
+    function test_version_isSet() public view {
+        assertEq(config.VERSION(), "1.0.0");
+    }
+}

--- a/test/configurations/Getters.t.sol
+++ b/test/configurations/Getters.t.sol
@@ -22,6 +22,8 @@ contract GettersTest is ConfigurationsTestBase {
         assertEq(c.confirmationTiers.length, 3);
         assertEq(c.confirmationTiers[0].maxAmount, 1 ether);
         assertEq(c.confirmationTiers[0].confirmations, 1);
+        assertEq(c.confirmationTiers[1].maxAmount, 10 ether);
+        assertEq(c.confirmationTiers[1].confirmations, 3);
         assertEq(c.confirmationTiers[2].maxAmount, 100 ether);
         assertEq(c.confirmationTiers[2].confirmations, 6);
     }
@@ -88,6 +90,17 @@ contract GettersTest is ConfigurationsTestBase {
             pending.confirmationTiers.length,
             queued.confirmationTiers.length
         );
+        // Every nested tier field must survive the queue (incl. the second tier).
+        for (uint256 i = 0; i < queued.confirmationTiers.length; ++i) {
+            assertEq(
+                pending.confirmationTiers[i].maxAmount,
+                queued.confirmationTiers[i].maxAmount
+            );
+            assertEq(
+                pending.confirmationTiers[i].confirmations,
+                queued.confirmationTiers[i].confirmations
+            );
+        }
     }
 
     function test_getPendingChange_clearedAfterApply() public {

--- a/test/configurations/Scaffolding.t.sol
+++ b/test/configurations/Scaffolding.t.sol
@@ -17,7 +17,14 @@ contract ScaffoldingTest is ConfigurationsTestBase {
 
     function test_initializeOnce_reverts() public {
         vm.expectRevert(); // Initializable: InvalidInitialization
-        config.initialize(owner, ADMIN_DELAY, TIMELOCK_DELAY, _seedConfig(), _boundsMin(), _boundsMax());
+        config.initialize(
+            owner,
+            ADMIN_DELAY,
+            TIMELOCK_DELAY,
+            _seedConfig(),
+            _boundsMin(),
+            _boundsMax()
+        );
     }
 
     function test_adminRoleAssigned() public view {
@@ -37,7 +44,14 @@ contract ScaffoldingTest is ConfigurationsTestBase {
 
         bytes memory initData = abi.encodeCall(
             FlyoverConfigurations.initialize,
-            (owner, ADMIN_DELAY, TIMELOCK_DELAY, badSeed, _boundsMin(), _boundsMax())
+            (
+                owner,
+                ADMIN_DELAY,
+                TIMELOCK_DELAY,
+                badSeed,
+                _boundsMin(),
+                _boundsMax()
+            )
         );
 
         vm.expectRevert(

--- a/test/configurations/Scaffolding.t.sol
+++ b/test/configurations/Scaffolding.t.sol
@@ -16,7 +16,7 @@ contract ScaffoldingTest is ConfigurationsTestBase {
     }
 
     function test_initializeOnce_reverts() public {
-        vm.expectRevert(); // Initializable: InvalidInitialization
+        vm.expectRevert(abi.encodeWithSignature("InvalidInitialization()"));
         config.initialize(
             owner,
             ADMIN_DELAY,

--- a/test/configurations/Scaffolding.t.sol
+++ b/test/configurations/Scaffolding.t.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {ConfigurationsTestBase} from "./ConfigurationsTestBase.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {FlyoverConfigurations} from "../../src/FlyoverConfigurations.sol";
+import {IFlyoverConfigurations} from "../../src/interfaces/IFlyoverConfigurations.sol";
+import {Flyover} from "../../src/libraries/Flyover.sol";
+
+/// @title ScaffoldingTest
+/// @notice Proxy/initialize wiring: init-once, admin role assignment, seed validation at init,
+/// value rejection, and ERC-7201 storage namespace placement.
+contract ScaffoldingTest is ConfigurationsTestBase {
+    function setUp() public {
+        _deploy();
+    }
+
+    function test_initializeOnce_reverts() public {
+        vm.expectRevert(); // Initializable: InvalidInitialization
+        config.initialize(owner, ADMIN_DELAY, TIMELOCK_DELAY, _seedConfig(), _boundsMin(), _boundsMax());
+    }
+
+    function test_adminRoleAssigned() public view {
+        assertTrue(config.hasRole(config.DEFAULT_ADMIN_ROLE(), owner));
+        assertEq(config.defaultAdmin(), owner);
+    }
+
+    function test_strangerHasNoAdminRole() public view {
+        assertFalse(config.hasRole(config.DEFAULT_ADMIN_ROLE(), stranger));
+    }
+
+    /// @notice The seed configuration must itself respect the deployment bounds.
+    function test_initialize_seedOutOfBounds_reverts() public {
+        FlyoverConfigurations impl = new FlyoverConfigurations();
+        IFlyoverConfigurations.PegConfiguration memory badSeed = _seedConfig();
+        badSeed.fixedFee = BOUND_MIN_FIXED_FEE - 1; // below the 2·D floor
+
+        bytes memory initData = abi.encodeCall(
+            FlyoverConfigurations.initialize,
+            (owner, ADMIN_DELAY, TIMELOCK_DELAY, badSeed, _boundsMin(), _boundsMax())
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FlyoverConfigurations.ConfigValueOutOfBounds.selector,
+                FlyoverConfigurations.Field.FixedFee,
+                BOUND_MIN_FIXED_FEE - 1,
+                BOUND_MIN_FIXED_FEE,
+                BOUND_MAX_FIXED_FEE
+            )
+        );
+        new ERC1967Proxy(address(impl), initData);
+    }
+
+    /// @notice The contract does not accept plain value transfers.
+    function test_receive_rejectsValue() public {
+        vm.deal(stranger, 1 ether);
+        vm.prank(stranger);
+        (bool ok, bytes memory ret) = address(config).call{value: 1}("");
+        assertFalse(ok);
+        assertEq(bytes4(ret), Flyover.PaymentNotAllowed.selector);
+        assertEq(address(config).balance, 0);
+    }
+
+    /// @notice The first scalar of the mutable namespace (activePegIn.fixedFee) lives at the
+    /// declared ERC-7201 base slot, proving namespace placement is correct.
+    function test_storageSlot_matchesNamespace() public view {
+        bytes32 raw = vm.load(address(config), STORAGE_SLOT);
+        assertEq(uint256(raw), SEED_FIXED_FEE);
+    }
+}

--- a/test/configurations/Tiers.t.sol
+++ b/test/configurations/Tiers.t.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {ConfigurationsTestBase} from "./ConfigurationsTestBase.sol";
+import {IFlyoverConfigurations} from "../../src/interfaces/IFlyoverConfigurations.sol";
+
+/// @title TiersTest
+/// @notice getRequiredPegInBtcConfirmations: per-tier lookup, exact boundaries, above the last
+/// tier, and a single-tier configuration.
+/// @dev Seed tiers: (1e18,1) (10e18,3) (100e18,6). Walkthrough anchor: step 2.
+contract TiersTest is ConfigurationsTestBase {
+    function setUp() public {
+        _deploy();
+    }
+
+    function test_perTier_lookup() public view {
+        assertEq(config.getRequiredPegInBtcConfirmations(0.5 ether), 1);
+        assertEq(config.getRequiredPegInBtcConfirmations(5 ether), 3);
+        assertEq(config.getRequiredPegInBtcConfirmations(50 ether), 6);
+    }
+
+    /// @notice An amount exactly equal to a tier's maxAmount falls into that tier (inclusive).
+    function test_exactBoundary_inclusive() public view {
+        assertEq(config.getRequiredPegInBtcConfirmations(1 ether), 1);
+        assertEq(config.getRequiredPegInBtcConfirmations(10 ether), 3);
+        assertEq(config.getRequiredPegInBtcConfirmations(100 ether), 6);
+    }
+
+    /// @notice One wei above a boundary rolls into the next tier.
+    function test_justAboveBoundary_nextTier() public view {
+        assertEq(config.getRequiredPegInBtcConfirmations(1 ether + 1), 3);
+        assertEq(config.getRequiredPegInBtcConfirmations(10 ether + 1), 6);
+    }
+
+    /// @notice Above the last tier's maxAmount the highest (last) tier's confirmations apply.
+    function test_aboveLastTier_returnsHighest() public view {
+        assertEq(config.getRequiredPegInBtcConfirmations(1000 ether), 6);
+        assertEq(config.getRequiredPegInBtcConfirmations(type(uint256).max), 6);
+    }
+
+    /// @notice A single-tier configuration answers with that tier's confirmations for every
+    /// amount, both within and above the tier's maxAmount.
+    function test_singleTierConfig_answersEverything() public {
+        IFlyoverConfigurations.PegConfiguration memory c = _altConfig();
+        c.confirmationTiers = new IFlyoverConfigurations.ConfirmationTier[](1);
+        c.confirmationTiers[0] = IFlyoverConfigurations.ConfirmationTier({maxAmount: 2 ether, confirmations: 9});
+
+        vm.prank(owner);
+        config.queueChange(c);
+        vm.warp(block.timestamp + TIMELOCK_DELAY);
+        vm.prank(owner);
+        config.applyChange();
+
+        assertEq(config.getRequiredPegInBtcConfirmations(1 ether), 9); // within the tier
+        assertEq(config.getRequiredPegInBtcConfirmations(2 ether), 9); // exact boundary
+        assertEq(config.getRequiredPegInBtcConfirmations(100 ether), 9); // above the only tier
+        assertEq(config.getRequiredPegInBtcConfirmations(0), 9); // zero amount
+    }
+}

--- a/test/configurations/Tiers.t.sol
+++ b/test/configurations/Tiers.t.sol
@@ -43,7 +43,10 @@ contract TiersTest is ConfigurationsTestBase {
     function test_singleTierConfig_answersEverything() public {
         IFlyoverConfigurations.PegConfiguration memory c = _altConfig();
         c.confirmationTiers = new IFlyoverConfigurations.ConfirmationTier[](1);
-        c.confirmationTiers[0] = IFlyoverConfigurations.ConfirmationTier({maxAmount: 2 ether, confirmations: 9});
+        c.confirmationTiers[0] = IFlyoverConfigurations.ConfirmationTier({
+            maxAmount: 2 ether,
+            confirmations: 9
+        });
 
         vm.prank(owner);
         config.queueChange(c);

--- a/test/configurations/Timelock.t.sol
+++ b/test/configurations/Timelock.t.sol
@@ -41,9 +41,21 @@ contract TimelockTest is ConfigurationsTestBase {
         assertEq(active.minAmount, c.minAmount);
         assertEq(active.maxAmount, c.maxAmount);
         assertEq(active.confirmationTiers.length, c.confirmationTiers.length);
+        // Every nested tier field must survive queue+apply (incl. the second tier).
+        for (uint256 i = 0; i < c.confirmationTiers.length; ++i) {
+            assertEq(
+                active.confirmationTiers[i].maxAmount,
+                c.confirmationTiers[i].maxAmount
+            );
+            assertEq(
+                active.confirmationTiers[i].confirmations,
+                c.confirmationTiers[i].confirmations
+            );
+        }
         // fee/confirmation reads now reflect the applied config.
         assertEq(config.calculatePegInFee(0), c.fixedFee);
         assertEq(config.getRequiredPegInBtcConfirmations(1 ether), 2);
+        assertEq(config.getRequiredPegInBtcConfirmations(10 ether), 5);
     }
 
     function test_applyAtExactEta_succeeds() public {

--- a/test/configurations/Timelock.t.sol
+++ b/test/configurations/Timelock.t.sol
@@ -15,7 +15,8 @@ import {IFlyoverConfigurations} from "../../src/interfaces/IFlyoverConfiguration
 contract TimelockTest is ConfigurationsTestBase {
     /// @dev pending.fixedFee lives at the mutable namespace base + 5 (activePegIn occupies the
     /// first 5 slots: fixedFee, percentageFee, minAmount, maxAmount, confirmationTiers-length).
-    bytes32 private constant _PENDING_FIXED_FEE_SLOT = bytes32(uint256(STORAGE_SLOT) + 5);
+    bytes32 private constant _PENDING_FIXED_FEE_SLOT =
+        bytes32(uint256(STORAGE_SLOT) + 5);
 
     function setUp() public {
         _deploy();
@@ -33,7 +34,8 @@ contract TimelockTest is ConfigurationsTestBase {
         vm.prank(owner);
         config.applyChange();
 
-        IFlyoverConfigurations.PegConfiguration memory active = config.getPegInConfiguration();
+        IFlyoverConfigurations.PegConfiguration memory active = config
+            .getPegInConfiguration();
         assertEq(active.fixedFee, c.fixedFee);
         assertEq(active.percentageFee, c.percentageFee);
         assertEq(active.minAmount, c.minAmount);
@@ -50,7 +52,10 @@ contract TimelockTest is ConfigurationsTestBase {
         vm.warp(eta); // block.timestamp == eta is allowed (>=)
         vm.prank(owner);
         config.applyChange();
-        assertEq(config.getPegInConfiguration().fixedFee, _altConfig().fixedFee);
+        assertEq(
+            config.getPegInConfiguration().fixedFee,
+            _altConfig().fixedFee
+        );
     }
 
     // ------------------------------------------------------ case 2: apply before delay reverts
@@ -62,7 +67,11 @@ contract TimelockTest is ConfigurationsTestBase {
         vm.warp(eta - 1);
         vm.prank(owner);
         vm.expectRevert(
-            abi.encodeWithSelector(FlyoverConfigurations.TimelockNotElapsed.selector, eta, eta - 1)
+            abi.encodeWithSelector(
+                FlyoverConfigurations.TimelockNotElapsed.selector,
+                eta,
+                eta - 1
+            )
         );
         config.applyChange();
 
@@ -102,9 +111,14 @@ contract TimelockTest is ConfigurationsTestBase {
         (, uint256 eta) = config.getPendingChange();
 
         // Corrupt pending.fixedFee to just above the max bound, bypassing queueChange.
-        vm.store(address(config), _PENDING_FIXED_FEE_SLOT, bytes32(BOUND_MAX_FIXED_FEE + 1));
+        vm.store(
+            address(config),
+            _PENDING_FIXED_FEE_SLOT,
+            bytes32(BOUND_MAX_FIXED_FEE + 1)
+        );
         // Sanity: the poke landed on the pending value.
-        (IFlyoverConfigurations.PegConfiguration memory pending,) = config.getPendingChange();
+        (IFlyoverConfigurations.PegConfiguration memory pending, ) = config
+            .getPendingChange();
         assertEq(pending.fixedFee, BOUND_MAX_FIXED_FEE + 1);
 
         vm.warp(eta);
@@ -143,8 +157,15 @@ contract TimelockTest is ConfigurationsTestBase {
         vm.prank(owner);
         config.queueChange(second);
 
-        (IFlyoverConfigurations.PegConfiguration memory pending, uint256 eta) = config.getPendingChange();
-        assertEq(pending.fixedFee, 3000 * SAT, "pending must be the second change");
+        (
+            IFlyoverConfigurations.PegConfiguration memory pending,
+            uint256 eta
+        ) = config.getPendingChange();
+        assertEq(
+            pending.fixedFee,
+            3000 * SAT,
+            "pending must be the second change"
+        );
         assertEq(eta, expectedEta, "eta must be refreshed by the second queue");
 
         // Applying activates the second change, never the replaced first.

--- a/test/configurations/Timelock.t.sol
+++ b/test/configurations/Timelock.t.sol
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {ConfigurationsTestBase} from "./ConfigurationsTestBase.sol";
+import {FlyoverConfigurations} from "../../src/FlyoverConfigurations.sol";
+import {IFlyoverConfigurations} from "../../src/interfaces/IFlyoverConfigurations.sol";
+
+/// @title TimelockTest
+/// @notice The two-step time-locked admin path, all four spec cases:
+/// (1) queue-then-apply after the delay succeeds;
+/// (2) apply before the delay reverts;
+/// (3) out-of-bounds values revert at both queue and apply time;
+/// (4) a second queue replaces the pending change.
+/// Plus exact-eta success, applying with nothing queued, and event emission.
+contract TimelockTest is ConfigurationsTestBase {
+    /// @dev pending.fixedFee lives at the mutable namespace base + 5 (activePegIn occupies the
+    /// first 5 slots: fixedFee, percentageFee, minAmount, maxAmount, confirmationTiers-length).
+    bytes32 private constant _PENDING_FIXED_FEE_SLOT = bytes32(uint256(STORAGE_SLOT) + 5);
+
+    function setUp() public {
+        _deploy();
+    }
+
+    // ------------------------------------------------------ case 1: queue then apply succeeds
+
+    function test_case1_queueThenApplyAfterDelay_succeeds() public {
+        IFlyoverConfigurations.PegConfiguration memory c = _queueAlt();
+
+        // Not applied yet: active config is still the seed.
+        assertEq(config.getPegInConfiguration().fixedFee, SEED_FIXED_FEE);
+
+        vm.warp(block.timestamp + TIMELOCK_DELAY);
+        vm.prank(owner);
+        config.applyChange();
+
+        IFlyoverConfigurations.PegConfiguration memory active = config.getPegInConfiguration();
+        assertEq(active.fixedFee, c.fixedFee);
+        assertEq(active.percentageFee, c.percentageFee);
+        assertEq(active.minAmount, c.minAmount);
+        assertEq(active.maxAmount, c.maxAmount);
+        assertEq(active.confirmationTiers.length, c.confirmationTiers.length);
+        // fee/confirmation reads now reflect the applied config.
+        assertEq(config.calculatePegInFee(0), c.fixedFee);
+        assertEq(config.getRequiredPegInBtcConfirmations(1 ether), 2);
+    }
+
+    function test_applyAtExactEta_succeeds() public {
+        _queueAlt();
+        (, uint256 eta) = config.getPendingChange();
+        vm.warp(eta); // block.timestamp == eta is allowed (>=)
+        vm.prank(owner);
+        config.applyChange();
+        assertEq(config.getPegInConfiguration().fixedFee, _altConfig().fixedFee);
+    }
+
+    // ------------------------------------------------------ case 2: apply before delay reverts
+
+    function test_case2_applyBeforeDelay_reverts() public {
+        _queueAlt();
+        (, uint256 eta) = config.getPendingChange();
+
+        vm.warp(eta - 1);
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(FlyoverConfigurations.TimelockNotElapsed.selector, eta, eta - 1)
+        );
+        config.applyChange();
+
+        // The active config is untouched.
+        assertEq(config.getPegInConfiguration().fixedFee, SEED_FIXED_FEE);
+    }
+
+    function test_applyWithoutQueue_reverts() public {
+        vm.prank(owner);
+        vm.expectRevert(FlyoverConfigurations.NoQueuedChange.selector);
+        config.applyChange();
+    }
+
+    // ------------------------------------------------------ case 3: out-of-bounds at both steps
+
+    function test_case3_outOfBounds_revertsAtQueueTime() public {
+        IFlyoverConfigurations.PegConfiguration memory c = _altConfig();
+        c.fixedFee = BOUND_MAX_FIXED_FEE + 1;
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FlyoverConfigurations.ConfigValueOutOfBounds.selector,
+                FlyoverConfigurations.Field.FixedFee,
+                BOUND_MAX_FIXED_FEE + 1,
+                BOUND_MIN_FIXED_FEE,
+                BOUND_MAX_FIXED_FEE
+            )
+        );
+        config.queueChange(c);
+    }
+
+    /// @notice applyChange re-validates against the immutable bounds. Since queueChange blocks
+    /// out-of-bounds values, we prove the apply-time guard by queuing a valid change and then
+    /// corrupting the stored pending value directly before applying.
+    function test_case3_outOfBounds_revertsAtApplyTime() public {
+        _queueAlt();
+        (, uint256 eta) = config.getPendingChange();
+
+        // Corrupt pending.fixedFee to just above the max bound, bypassing queueChange.
+        vm.store(address(config), _PENDING_FIXED_FEE_SLOT, bytes32(BOUND_MAX_FIXED_FEE + 1));
+        // Sanity: the poke landed on the pending value.
+        (IFlyoverConfigurations.PegConfiguration memory pending,) = config.getPendingChange();
+        assertEq(pending.fixedFee, BOUND_MAX_FIXED_FEE + 1);
+
+        vm.warp(eta);
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FlyoverConfigurations.ConfigValueOutOfBounds.selector,
+                FlyoverConfigurations.Field.FixedFee,
+                BOUND_MAX_FIXED_FEE + 1,
+                BOUND_MIN_FIXED_FEE,
+                BOUND_MAX_FIXED_FEE
+            )
+        );
+        config.applyChange();
+
+        // The active config remains the seed; the corrupted change never took effect.
+        assertEq(config.getPegInConfiguration().fixedFee, SEED_FIXED_FEE);
+    }
+
+    // ------------------------------------------------------ case 4: second queue replaces pending
+
+    function test_case4_secondQueueReplacesPending() public {
+        // First queued change.
+        IFlyoverConfigurations.PegConfiguration memory first = _altConfig();
+        first.fixedFee = 2000 * SAT;
+        vm.prank(owner);
+        config.queueChange(first);
+
+        // Advance time so the second queue gets a distinct eta.
+        vm.warp(block.timestamp + 1 hours);
+        uint256 expectedEta = block.timestamp + TIMELOCK_DELAY;
+
+        // Second queued change replaces the first.
+        IFlyoverConfigurations.PegConfiguration memory second = _altConfig();
+        second.fixedFee = 3000 * SAT;
+        vm.prank(owner);
+        config.queueChange(second);
+
+        (IFlyoverConfigurations.PegConfiguration memory pending, uint256 eta) = config.getPendingChange();
+        assertEq(pending.fixedFee, 3000 * SAT, "pending must be the second change");
+        assertEq(eta, expectedEta, "eta must be refreshed by the second queue");
+
+        // Applying activates the second change, never the replaced first.
+        vm.warp(eta);
+        vm.prank(owner);
+        config.applyChange();
+        assertEq(config.getPegInConfiguration().fixedFee, 3000 * SAT);
+    }
+
+    // ------------------------------------------------------ events
+
+    function test_queueChange_emitsChangeQueued() public {
+        IFlyoverConfigurations.PegConfiguration memory c = _altConfig();
+        uint256 expectedEta = block.timestamp + TIMELOCK_DELAY;
+
+        vm.expectEmit(true, true, true, true, address(config));
+        emit FlyoverConfigurations.ChangeQueued(c, expectedEta);
+        vm.prank(owner);
+        config.queueChange(c);
+    }
+
+    function test_applyChange_emitsChangeApplied() public {
+        IFlyoverConfigurations.PegConfiguration memory c = _queueAlt();
+        vm.warp(block.timestamp + TIMELOCK_DELAY);
+
+        vm.expectEmit(true, true, true, true, address(config));
+        emit FlyoverConfigurations.ChangeApplied(c);
+        vm.prank(owner);
+        config.applyChange();
+    }
+}


### PR DESCRIPTION
## What

Adds the Foundry unit-test suite for `FlyoverConfigurations` under
`test/configurations/**`, pinning every number the protocol will read from the
contract: fee math, confirmation-tier lookups, amount limits, all getters, the
admin authorization path, and the two-step time-locked change flow. Contract
under test ships in a separate PR (S2.1 / FLY-2459); this is the sibling test
suite (S2.2 / FLY-2460).

New files (own `*TestBase.sol` per repo convention):
- `test/configurations/ConfigurationsTestBase.sol` — ERC1967-proxy deploy, seed
  config, explicit deployment bounds, tier/config helpers.
- `Fee.t.sol` — floor, satoshi rounding, hand-computed values.
- `Tiers.t.sol` — boundaries, above-last-tier, single-tier config.
- `Getters.t.sol` — configuration, bounds, pending change, delay, version.
- `AdminGating.t.sol` — role gating + every config-validation revert.
- `Timelock.t.sol` — all four timelock cases + exact-eta, no-queue, events.
- `Scaffolding.t.sol` — init-once, admin role, seed-validated-at-init,
  `receive()` rejection, ERC-7201 slot placement.

## Why

The commit-first redesign removes the off-chain quote, so the fee, confirmation
tiers, and limits become on-chain values every party (SDK, LPS, settlement)
trusts equally. Before any consumer reads them, each value and each revert path
must be pinned by a test — especially the fixed-fee floor, a security parameter
(decision 2·D), and the immutable bounds that guard even a compromised admin
role.

## Type of Change

- [x] Tests only

## Affected Areas

- [x] PegIn flow (config values consumed by the peg-in flow; no production code changed)
- [x] CI workflows (`ci`, `fuzz`, `formal`, `slither`, `codeql`) — suite runs under `make test-unit`

## Risk & Security Review

- [x] Access control and authorization paths reviewed (queue/apply gated by `DEFAULT_ADMIN_ROLE`; non-admin reverts covered)
- [x] Reentrancy and external call paths reviewed (config is read-mostly; `receive()` rejection covered)
- [x] Storage layout / upgrade safety reviewed (ERC-7201 base-slot placement asserted via `vm.load`)
- [x] Time/block/confirmation assumptions reviewed (delay, exact-eta, before-delay all covered)
- [ ] BTC tx output/index assumptions reviewed — N/A
- [x] No secrets or sensitive values added

## Test Plan

- [ ] `npm run lint:sol` — N/A (globs `src/**` only; test files are not linted)
- [ ] `npm run lint:ts`
- [x] `npm test` / `make test-unit` — 604 passed, 0 failed (includes the 47 new configuration tests)


Case coverage (Spec):
- Fee math: zero-amount floor, floor at min amount, mid amount, large-amount
  no-overflow, satoshi-rounding parity with `Quotes.checkAgreedAmount`, all
  asserted against hand-computed values.
- Tier lookup: per-tier, exact boundary (inclusive), just-above, above the last
  tier, single-tier config.
- Limits + getters: configuration, bounds, pending (empty/queued/cleared),
  delay, version.
- Admin gating: role required on queue and apply; empty / non-ascending /
  equal-adjacent tiers; each field out-of-bounds; `InvalidPercentageFee`;
  `InvalidAmountLimits`.
- Timelock, all four cases: (1) queue→apply after delay; (2) apply-before-delay
  reverts; (3) out-of-bounds reverts at both queue and apply time (apply-time
  guard exercised via a stored-pending corruption); (4) second queue replaces
  pending. Plus exact-eta, `NoQueuedChange`, `ChangeQueued`/`ChangeApplied`.

## Deployment & Ops Impact

- [x] No deployment impact (test-only)

## Related Issues

https://rsklabs.atlassian.net/browse/FLY-2460


## Reviewer Notes

- Suite lives in `test/configurations/**`, which `make test-unit` includes
  automatically (it is not under the excluded `test/{fuzz,invariant,differential,formal}` paths).
- `ConfigurationsTestBase` uses an ERC1967 proxy (not Transparent) so `owner`
  can call admin functions directly; a TransparentUpgradeableProxy would route
  the admin's calls to the proxy admin instead of the implementation.
- Deliberate choice worth a look: the `percentageFee` upper *bound* in the test
  base is set above the 100% denominator (`20_000`) specifically so the
  `InvalidPercentageFee` guard is reachable and provably independent of the
  bound check — otherwise that revert path is shadowed by the bound.
- Case 3's apply-time bound revert is proven by queuing a valid change and then
  `vm.store`-corrupting the stored pending value before applying, since
  `queueChange` itself blocks out-of-bounds values through the normal path.
  
  
## Note

To be merged **AFTER**  https://github.com/rsksmart/liquidity-bridge-contract/pull/509

