### PR TITLE
fix: add PegInAddressRegistry to DeployFlyover script

### DIFF
--- a/script/HelperConfig.s.sol
+++ b/script/HelperConfig.s.sol
@@ -408,7 +408,7 @@ contract HelperConfig is Script {
 
     function getOptions() public pure returns (Options memory) {
         Options memory opts;
-        opts.unsafeAllow = "external-library-linking";
+        opts.unsafeAllow = "external-library-linking,constructor";
         return opts;
     }
 }

--- a/script/deployment/DeployFlyover.s.sol
+++ b/script/deployment/DeployFlyover.s.sol
@@ -12,8 +12,10 @@ import {ProxyReader} from "../helpers/ProxyReader.sol";
 import {CollateralManagementContract} from "../../src/CollateralManagement.sol";
 import {FlyoverDiscovery} from "../../src/FlyoverDiscovery.sol";
 import {PauseRegistry} from "../../src/PauseRegistry.sol";
+import {PegInAddressRegistry} from "../../src/PegInAddressRegistry.sol";
 import {PegInContract} from "../../src/PegInContract.sol";
 import {PegOutContract} from "../../src/PegOutContract.sol";
+import {IPauseRegistry} from "../../src/interfaces/IPauseRegistry.sol";
 
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
@@ -36,6 +38,9 @@ contract DeployFlyover is Script {
         address pegOutImpl;
         address pegOutProxy;
         address pegOutProxyAdmin;
+        address pegInAddressRegistryImpl;
+        address pegInAddressRegistryProxy;
+        address pegInAddressRegistryProxyAdmin;
     }
 
     function run() external returns (FlyoverDeployment memory) {
@@ -210,6 +215,34 @@ contract DeployFlyover is Script {
         d.pegOutProxy = pegOutProxy;
         d.pegOutImpl = ProxyReader.readImplementation(vm, pegOutProxy);
         d.pegOutProxyAdmin = ProxyReader.readAdmin(vm, pegOutProxy);
+
+        // 5) PegInAddressRegistry
+        address pegInAddressRegistryProxy = Upgrades.deployTransparentProxy(
+            "PegInAddressRegistry.sol",
+            defaultAdmin,
+            abi.encodeCall(
+                PegInAddressRegistry.initialize,
+                (
+                    defaultAdmin,
+                    cfg.adminDelay,
+                    cfg.bridge,
+                    cfg.mainnet,
+                    IPauseRegistry(pauseRegistryProxy)
+                )
+            ),
+            opts
+        );
+        d.pegInAddressRegistryProxy = pegInAddressRegistryProxy;
+        d.pegInAddressRegistryImpl = ProxyReader.readImplementation(
+            vm,
+            pegInAddressRegistryProxy
+        );
+        d.pegInAddressRegistryProxyAdmin = ProxyReader.readAdmin(
+            vm,
+            pegInAddressRegistryProxy
+        );
+        PegInAddressRegistry(payable(pegInAddressRegistryProxy))
+            .setPegInContract(d.pegInProxy);
     }
 
     function _setupRoles(FlyoverDeployment memory d) private {
@@ -246,5 +279,11 @@ contract DeployFlyover is Script {
         console.log("PegOutContract impl:", d.pegOutImpl);
         console.log("PegOutContract proxy:", d.pegOutProxy);
         console.log("PegOutContract ProxyAdmin:", d.pegOutProxyAdmin);
+        console.log("PegInAddressRegistry impl:", d.pegInAddressRegistryImpl);
+        console.log("PegInAddressRegistry proxy:", d.pegInAddressRegistryProxy);
+        console.log(
+            "PegInAddressRegistry ProxyAdmin:",
+            d.pegInAddressRegistryProxyAdmin
+        );
     }
 }


### PR DESCRIPTION
## What

Adds the `PegInAddressRegistry` deployment step to `DeployFlyover.s.sol`. The contract itself already
lives in `src/PegInAddressRegistry.sol`, but the deployment script never deployed it, so no environment
could get a registry instance from the official deploy flow — blocking end-to-end pegin V2 testing on
regtest environments.

## Changes

### `script/deployment/DeployFlyover.s.sol`

- Deploys `PegInAddressRegistry` behind a `TransparentUpgradeableProxy` via
  `Upgrades.deployTransparentProxy`, following the same pattern as the other contracts, initialized with
  `(defaultAdmin, cfg.adminDelay, cfg.bridge, cfg.mainnet, IPauseRegistry(pauseRegistryProxy))`.
- The step runs last, which satisfies its two ordering constraints: `initialize` reverts if the
  PauseRegistry proxy has no code, and the wiring below needs the PegInContract proxy address.
- Calls `setPegInContract(pegInProxy)` right after the proxy deploy, inside the same broadcast.
  Without this, `getPegInAddress` reverts with `PegInContractNotSet` and the registry is unusable.
  This assumes the deployer is the `defaultAdmin` (true for this script, which uses the deployer as
  admin), so the `DEFAULT_ADMIN_ROLE` check on `setPegInContract` passes.
- Extends the `FlyoverDeployment` struct and the summary log with the registry implementation, proxy
  and ProxyAdmin addresses. The new `PegInAddressRegistry proxy: 0x...` line follows the same format
  as the existing entries, which downstream tooling parses to extract deployment addresses. All
  pre-existing log lines are unchanged.

### `script/HelperConfig.s.sol`

- Extends `getOptions()` `unsafeAllow` from `external-library-linking` to
  `external-library-linking,constructor`.

**Why this is needed:** the upgrades plugin validator rejects proxied implementations whose
inheritance chain contains a constructor. Our own constructors (`_disableInitializers()`) are already
exempted via `@custom:oz-upgrades-unsafe-allow constructor` annotations, but the flagged constructor
is the one inherited from the non-upgradeable OpenZeppelin `ReentrancyGuard` (v5.5), which we cannot
annotate. This affects not only the new registry: `PegInContract`, `PegOutContract` and
`CollateralManagement` also inherit `ReentrancyGuard` and fail the same validation since the switch
away from `ReentrancyGuardUpgradeable`, so the flag is required for the deploy script to run at all.

**Why it is safe:** implementation constructor state never reaches the proxy. The v5 `ReentrancyGuard`
treats an uninitialized (zero) guard slot as "not entered", so behavior behind the proxy is unchanged,
and `_disableInitializers()` in constructors is a recommended hardening pattern.

**Scope note for reviewers:** `getOptions()` is shared by every deploy/upgrade script, so this
disables the constructor check globally. The validator will no longer flag a future contract that
mistakenly performs real initialization in its constructor; the per-contract NatSpec annotations
remain as documentation of intent.

## Testing

- Verified end to end on regtest using the standard flow (`DeployLibraries` first, then `DeployFlyover`
  with `--libraries`, `--legacy`, `--slow`): the registry proxy is deployed with code at the logged
  address, `getPegInAddress(addr)` returns a derived address (no `PegInContractNotSet` revert), and
  `isRegistered(addr)` returns `false` for a fresh address. A watchtower regtest run consumed a
  registry deployed with this script.
- Existing deployment tests pass; `deployForTesting` reuses `_deployAll`, so tests going through it
  also exercise the new step.