### PR TITLE
feat(FLY-2521): per-network zero-address BTC placeholders

### DIFF
--- a/src/PegInAddressRegistry.sol
+++ b/src/PegInAddressRegistry.sol
@@ -28,7 +28,7 @@ contract PegInAddressRegistry is
     /// @custom:storage-location erc7201:rsk.flyover.PegInAddressRegistry
     struct PegInAddressRegistryStorage {
         IBridge bridge;
-        bool mainnet;
+        bool isMainnet;
         bytes32 registrationRoot;
         mapping(address => Registration) registrations;
         address pegInContract;
@@ -74,14 +74,14 @@ contract PegInAddressRegistry is
     /// @param defaultAdmin The default admin of the contract
     /// @param initialDelay The initial delay for changes in the default admin role
     /// @param bridge The address of the Rootstock bridge
-    /// @param mainnet Whether the derived addresses target mainnet or testnet
+    /// @param isMainnet Whether the derived addresses target mainnet or testnet
     /// @param pauseRegistry_ The central PauseRegistry for pause state
     // solhint-disable-next-line comprehensive-interface
     function initialize(
         address defaultAdmin,
         uint48 initialDelay,
         address bridge,
-        bool mainnet,
+        bool isMainnet,
         IPauseRegistry pauseRegistry_
     ) external initializer {
         if (bridge == address(0)) revert Flyover.NoContract(bridge);
@@ -90,7 +90,7 @@ contract PegInAddressRegistry is
         __EmergencyPause_init(pauseRegistry_);
         PegInAddressRegistryStorage storage $ = _getStorage();
         $.bridge = IBridge(payable(bridge));
-        $.mainnet = mainnet;
+        $.isMainnet = isMainnet;
     }
 
     /// @notice Sets the PegInContract mixed into the deposit-address derivation.
@@ -122,7 +122,7 @@ contract PegInAddressRegistry is
         address pegInContract = $.pegInContract;
         if (pegInContract == address(0)) revert PegInContractNotSet();
 
-        bytes memory expectedPkScript = _expectedDepositPkScript(rskAddr, pegInContract, $.bridge, $.mainnet);
+        bytes memory expectedPkScript = _expectedDepositPkScript(rskAddr, pegInContract, $.bridge, $.isMainnet);
         uint64 depositValue = _matchedDepositValue(btcTxSerialized, expectedPkScript, rskAddr);
 
         if (depositValue < MIN_DEPOSIT_SATS) {
@@ -150,7 +150,7 @@ contract PegInAddressRegistry is
         // The active powpeg redeem script is invariant across a single call, so it is
         // read once here and reused for the derivation.
         bytes memory powpegRedeemScript = $.bridge.getActivePowpegRedeemScript();
-        return (_deriveAddress(addr, pegInContract, powpegRedeemScript, $.mainnet), ADDRESS_ENCODING);
+        return (_deriveAddress(addr, pegInContract, powpegRedeemScript, $.isMainnet), ADDRESS_ENCODING);
     }
 
     /// @inheritdoc IPegInAddressRegistry
@@ -170,10 +170,10 @@ contract PegInAddressRegistry is
         // Read the invariant derivation inputs once, before the loop, so the batch performs a
         // single external bridge call and derives every address against a consistent powpeg.
         bytes memory powpegRedeemScript = $.bridge.getActivePowpegRedeemScript();
-        bool mainnet = $.mainnet;
+        bool isMainnet = $.isMainnet;
         derivationAddresses = new bytes[](length);
         for (uint256 i = 0; i < length; ++i) {
-            derivationAddresses[i] = _deriveAddress(addrs[i], pegInContract, powpegRedeemScript, mainnet);
+            derivationAddresses[i] = _deriveAddress(addrs[i], pegInContract, powpegRedeemScript, isMainnet);
         }
         encoding = ADDRESS_ENCODING;
     }
@@ -206,15 +206,15 @@ contract PegInAddressRegistry is
     }
 
     /// @notice Derives the on-chain P2SH scriptPubkey for a deposit output match.
-    /// @param mainnet Whether the derivation targets mainnet or testnet — the BTC placeholders
+    /// @param isMainnet Whether the derivation targets mainnet or testnet — the BTC placeholders
     /// mixed into the value are per-network, so this must match the flag used at issuance
-    function _expectedDepositPkScript(address rskAddr, address pegInContract, IBridge bridge_, bool mainnet)
+    function _expectedDepositPkScript(address rskAddr, address pegInContract, IBridge bridge_, bool isMainnet)
         private
         view
         returns (bytes memory)
     {
         bytes memory powpegRedeemScript = bridge_.getActivePowpegRedeemScript();
-        bytes32 derivationValue = PegInDerivation.derivationValue(rskAddr, pegInContract, mainnet);
+        bytes32 derivationValue = PegInDerivation.derivationValue(rskAddr, pegInContract, isMainnet);
         bytes memory redeemScript = PegInDerivation.flyoverRedeemScript(derivationValue, powpegRedeemScript);
         bytes20 scriptHash = PegInDerivation.flyoverScriptHash(redeemScript);
         return PegInDerivation.p2shScriptPubkey(scriptHash);
@@ -243,17 +243,17 @@ contract PegInAddressRegistry is
     /// @param addr The RSK address the deposit address is derived for
     /// @param pegInContract The PegInContract mixed into the derivation (must be non-zero)
     /// @param powpegRedeemScript The active powpeg redeem script returned by the bridge
-    /// @param mainnet Whether the derived address targets mainnet or testnet
-    function _deriveAddress(address addr, address pegInContract, bytes memory powpegRedeemScript, bool mainnet)
+    /// @param isMainnet Whether the derived address targets mainnet or testnet
+    function _deriveAddress(address addr, address pegInContract, bytes memory powpegRedeemScript, bool isMainnet)
         private
         pure
         returns (bytes memory)
     {
-        bytes32 derivationValue = PegInDerivation.derivationValue(addr, pegInContract, mainnet);
+        bytes32 derivationValue = PegInDerivation.derivationValue(addr, pegInContract, isMainnet);
         // TODO(FLY-2436): pass the bridge address once the derivation library owns script construction
         bytes memory redeemScript = PegInDerivation.flyoverRedeemScript(derivationValue, powpegRedeemScript);
         bytes20 scriptHash = PegInDerivation.flyoverScriptHash(redeemScript);
-        return PegInDerivation.depositAddressPayload(scriptHash, mainnet);
+        return PegInDerivation.depositAddressPayload(scriptHash, isMainnet);
     }
 
     function _getStorage() internal pure returns (PegInAddressRegistryStorage storage $) {

--- a/src/PegInAddressRegistry.sol
+++ b/src/PegInAddressRegistry.sol
@@ -122,7 +122,7 @@ contract PegInAddressRegistry is
         address pegInContract = $.pegInContract;
         if (pegInContract == address(0)) revert PegInContractNotSet();
 
-        bytes memory expectedPkScript = _expectedDepositPkScript(rskAddr, pegInContract, $.bridge);
+        bytes memory expectedPkScript = _expectedDepositPkScript(rskAddr, pegInContract, $.bridge, $.mainnet);
         uint64 depositValue = _matchedDepositValue(btcTxSerialized, expectedPkScript, rskAddr);
 
         if (depositValue < MIN_DEPOSIT_SATS) {
@@ -206,13 +206,15 @@ contract PegInAddressRegistry is
     }
 
     /// @notice Derives the on-chain P2SH scriptPubkey for a deposit output match.
-    function _expectedDepositPkScript(address rskAddr, address pegInContract, IBridge bridge_)
+    /// @param mainnet Whether the derivation targets mainnet or testnet — the BTC placeholders
+    /// mixed into the value are per-network, so this must match the flag used at issuance
+    function _expectedDepositPkScript(address rskAddr, address pegInContract, IBridge bridge_, bool mainnet)
         private
         view
         returns (bytes memory)
     {
         bytes memory powpegRedeemScript = bridge_.getActivePowpegRedeemScript();
-        bytes32 derivationValue = PegInDerivation.derivationValue(rskAddr, pegInContract);
+        bytes32 derivationValue = PegInDerivation.derivationValue(rskAddr, pegInContract, mainnet);
         bytes memory redeemScript = PegInDerivation.flyoverRedeemScript(derivationValue, powpegRedeemScript);
         bytes20 scriptHash = PegInDerivation.flyoverScriptHash(redeemScript);
         return PegInDerivation.p2shScriptPubkey(scriptHash);
@@ -247,7 +249,7 @@ contract PegInAddressRegistry is
         pure
         returns (bytes memory)
     {
-        bytes32 derivationValue = PegInDerivation.derivationValue(addr, pegInContract);
+        bytes32 derivationValue = PegInDerivation.derivationValue(addr, pegInContract, mainnet);
         // TODO(FLY-2436): pass the bridge address once the derivation library owns script construction
         bytes memory redeemScript = PegInDerivation.flyoverRedeemScript(derivationValue, powpegRedeemScript);
         bytes20 scriptHash = PegInDerivation.flyoverScriptHash(redeemScript);

--- a/src/libraries/PegInDerivation.sol
+++ b/src/libraries/PegInDerivation.sol
@@ -15,18 +15,18 @@ import {OpCodes} from "@rsksmart/btc-transaction-solidity-helper/contracts/OpCod
 /// validated end-to-end on a live regtest against the UNMODIFIED powpeg bridge (rskj 9.0.2,
 /// 2026-06-30, settle tx 0x174ab0df7cc86648a40d9b36da95fd4dacf2f18c135606141d532b7d1363c7de). That
 /// run used a real regtest p2pkh as the two BTC placeholders; they are now the per-network ZERO
-/// address (see {refundPlaceholderBtc}). The zero-address form is well-formed and non-empty, but no
-/// end-to-end run has yet settled with it — the settlement path does not exist on this branch
-/// (`PegInContract.resolvePegIn` reverts `ResolvePegInNotImplemented`). Proving the bridge accepts a
-/// zero-hash address is owed by the settlement work, and is a merge gate for production, not a
-/// property this library may assume:
+/// address (see {getRefundPlaceholderBtcAddress}). The zero-address form is well-formed and
+/// non-empty, but no end-to-end run has yet settled with it — the settlement path does not exist on
+/// this branch (`PegInContract.resolvePegIn` reverts `ResolvePegInNotImplemented`). Proving the
+/// bridge accepts a zero-hash address is owed by the settlement work, and is a merge gate for
+/// production, not a property this library may assume:
 ///
 ///   derivationArgumentsHash = keccak256(DERIVATION_DOMAIN ++ rskAddr)                    (step 1)
 ///   derivationValue         = keccak256(
 ///       derivationArgumentsHash
-///       ++ refundPlaceholderBtc(mainnet) // userRefundBtcAddress (21-byte per-network constant)
-///       ++ bytes20(pegInContract)        // lbcAddress = the contract that CALLS the bridge
-///       ++ lpPlaceholderBtc(mainnet)     // liquidityProviderBtcAddress (same per-network constant)
+///       ++ getRefundPlaceholderBtcAddress(isMainnet) // userRefundBtcAddress (21-byte constant)
+///       ++ bytes20(pegInContract)                    // lbcAddress = the contract CALLING the bridge
+///       ++ getLpPlaceholderBtcAddress(isMainnet)     // liquidityProviderBtcAddress (same constant)
 ///   )                                                                                    (step 2)
 ///   flyoverRedeemScript = OP_PUSHBYTES_32 ++ derivationValue ++ OP_DROP
 ///                         ++ activePowpegRedeemScript                                    (step 3)
@@ -56,44 +56,53 @@ library PegInDerivation {
 
     /// @notice The P2PKH zero address payload for mainnet: version byte `0x00` followed by a
     /// 20-byte zero HASH160. Well-formed and non-empty, but provably unspendable.
-    bytes internal constant ZERO_PLACEHOLDER_MAINNET = hex"000000000000000000000000000000000000000000";
+    bytes internal constant BITCOIN_ZERO_ADDRESS_MAINNET = hex"000000000000000000000000000000000000000000";
 
     /// @notice The P2PKH zero address payload for testnet/regtest: version byte `0x6f` followed by
-    /// a 20-byte zero HASH160. Differs from {ZERO_PLACEHOLDER_MAINNET} ONLY in the version byte,
-    /// which is enough to make every address derived from it a different address.
-    bytes internal constant ZERO_PLACEHOLDER_TESTNET = hex"6f0000000000000000000000000000000000000000";
+    /// a 20-byte zero HASH160. Differs from {BITCOIN_ZERO_ADDRESS_MAINNET} ONLY in the version
+    /// byte, which is enough to make every address derived from it a different address.
+    bytes internal constant BITCOIN_ZERO_ADDRESS_TESTNET = hex"6f0000000000000000000000000000000000000000";
 
-    /// @notice FIXED protocol-wide placeholder for the bridge's `userRefundBtcAddress` argument,
-    /// mixed into the deposit address AND passed to the bridge at settlement. It MUST be identical
-    /// at address issuance and settlement, it is NEVER empty (the bridge rejects an empty address
-    /// with -900) and NEVER the serving LP's address (the deposit address stays LP-agnostic).
-    ///
-    /// The value is the per-network P2PKH ZERO ADDRESS — `version ++ 20 zero bytes`. It is
-    /// network-dependent because the version byte is, so the two networks derive disjoint address
-    /// sets. Once the first address is issued on a network this value is frozen: changing it
-    /// rotates every derived address and requires the full drain-then-rotate procedure.
-    ///
-    /// TODO(treasury): the bridge's FAILURE-REFUND path (taken only when a fast-bridge peg-in is
-    /// rejected after the BTC is locked) pays THIS address — not the depositing user, not the LP.
-    /// A zero-hash address has no spending key, so any BTC sent down that path is BURNED. That is
-    /// accepted for the PoC. BEFORE PRODUCTION both placeholders must be repointed at a monitored,
-    /// recoverable, protocol-owned treasury address (one per network, e.g. a Flyover-treasury
-    /// multisig), and that swap rotates every derived address. This is the surviving mainnet
-    /// blocker of the treasury discussion.
-    /// @param mainnet True for the mainnet zero address, false for testnet/regtest
+    // ---------------------------------------------------------------------------------------------
+    // WHERE THE FAILURE-REFUND MONEY GOES (applies to BOTH accessors below)
+    //
+    // The two BTC placeholders are FIXED protocol-wide values, mixed into the deposit address AND
+    // passed to the bridge at settlement. Each MUST be identical at address issuance and settlement,
+    // is NEVER empty (the bridge rejects an empty address with -900) and is NEVER the serving LP's
+    // address (the deposit address stays LP-agnostic).
+    //
+    // Both are the per-network P2PKH ZERO ADDRESS — `version ++ 20 zero bytes`. The value is
+    // network-dependent because the version byte is, so the two networks derive disjoint address
+    // sets. Once the first address is issued on a network the value is frozen: changing it rotates
+    // every derived address and requires the full drain-then-rotate procedure.
+    //
+    // The bridge's FAILURE-REFUND path — taken only when a fast-bridge peg-in is rejected after the
+    // BTC is locked — pays the refund placeholder, not the depositing user and not the LP. A
+    // zero-hash address has no spending key, so any BTC that goes down that path is BURNED.
+    //
+    // A future version may point these placeholders at a monitored, recoverable, protocol-owned
+    // treasury address instead (one per network, e.g. a Flyover-treasury multisig), which would give
+    // the failure-refund path a recoverable destination. The two accessors are kept separate so such
+    // a change can point the refund and LP roles at distinct addresses. Repointing either value
+    // rotates every derived address, so it carries the same drain-then-rotate cost as a federation
+    // change.
+    // ---------------------------------------------------------------------------------------------
+
+    /// @notice The protocol-wide placeholder for the bridge's `userRefundBtcAddress` argument.
+    /// See the failure-refund comment above for what this address receives and why it is frozen.
+    /// @param isMainnet True for the mainnet zero address, false for testnet/regtest
     /// @return The 21-byte (version ++ HASH160) refund placeholder for the target network
-    function refundPlaceholderBtc(bool mainnet) internal pure returns (bytes memory) {
-        return mainnet ? ZERO_PLACEHOLDER_MAINNET : ZERO_PLACEHOLDER_TESTNET;
+    function getRefundPlaceholderBtcAddress(bool isMainnet) internal pure returns (bytes memory) {
+        return isMainnet ? BITCOIN_ZERO_ADDRESS_MAINNET : BITCOIN_ZERO_ADDRESS_TESTNET;
     }
 
-    /// @notice FIXED protocol-wide placeholder for the bridge's `liquidityProviderBtcAddress`
-    /// argument. Same constraints, same per-network zero address and the same
-    /// `TODO(treasury)` as {refundPlaceholderBtc}; it is NOT the serving LP's address. Kept as a
-    /// separate accessor so production can point the two roles at distinct addresses.
-    /// @param mainnet True for the mainnet zero address, false for testnet/regtest
+    /// @notice The protocol-wide placeholder for the bridge's `liquidityProviderBtcAddress`
+    /// argument. Same value and same constraints as {getRefundPlaceholderBtcAddress} — see the
+    /// failure-refund comment above; it is NOT the serving LP's address.
+    /// @param isMainnet True for the mainnet zero address, false for testnet/regtest
     /// @return The 21-byte (version ++ HASH160) liquidity-provider placeholder for the network
-    function lpPlaceholderBtc(bool mainnet) internal pure returns (bytes memory) {
-        return mainnet ? ZERO_PLACEHOLDER_MAINNET : ZERO_PLACEHOLDER_TESTNET;
+    function getLpPlaceholderBtcAddress(bool isMainnet) internal pure returns (bytes memory) {
+        return isMainnet ? BITCOIN_ZERO_ADDRESS_MAINNET : BITCOIN_ZERO_ADDRESS_TESTNET;
     }
 
     /// @notice Step 1: the 32-byte `derivationArgumentsHash` passed to the bridge as the FIRST
@@ -113,17 +122,17 @@ library PegInDerivation {
     /// @param rskAddr The RSK destination address
     /// @param pegInContract The PegInContract PROXY address (the lbcAddress that calls the bridge;
     /// stable across implementation upgrades, rotates only on a redeploy)
-    /// @param mainnet True to mix the mainnet placeholders, false for testnet/regtest. The
-    /// placeholders are network-dependent (see {refundPlaceholderBtc}), so this flag changes the
-    /// derived value — and therefore the deposit address — on every network.
+    /// @param isMainnet True to mix the mainnet placeholders, false for testnet/regtest. The
+    /// placeholders are network-dependent (see {getRefundPlaceholderBtcAddress}), so this flag
+    /// changes the derived value — and therefore the deposit address — on every network.
     /// @return The keccak256 hash the bridge embeds in the flyover redeem script
-    function derivationValue(address rskAddr, address pegInContract, bool mainnet) internal pure returns (bytes32) {
+    function derivationValue(address rskAddr, address pegInContract, bool isMainnet) internal pure returns (bytes32) {
         return keccak256(
             bytes.concat(
                 derivationArgumentsHash(rskAddr),
-                refundPlaceholderBtc(mainnet),
+                getRefundPlaceholderBtcAddress(isMainnet),
                 bytes20(pegInContract),
-                lpPlaceholderBtc(mainnet)
+                getLpPlaceholderBtcAddress(isMainnet)
             )
         );
     }
@@ -168,10 +177,10 @@ library PegInDerivation {
     /// string shown to the user. MUST stay a plain P2SH: the segwit-wrapped form is pitfall #2
     /// (-304).
     /// @param scriptHash Step 4's output
-    /// @param mainnet True for the mainnet version byte (0x05), false for testnet/regtest (0xC4)
+    /// @param isMainnet True for the mainnet version byte (0x05), false for testnet/regtest (0xC4)
     /// @return The 25-byte base58check payload of the deposit address
-    function depositAddressPayload(bytes20 scriptHash, bool mainnet) internal pure returns (bytes memory) {
-        bytes1 version = mainnet ? bytes1(0x05) : bytes1(0xC4);
+    function depositAddressPayload(bytes20 scriptHash, bool isMainnet) internal pure returns (bytes memory) {
+        bytes1 version = isMainnet ? bytes1(0x05) : bytes1(0xC4);
         bytes memory versionedHash = bytes.concat(version, scriptHash);
         bytes32 checksum = sha256(abi.encodePacked(sha256(versionedHash)));
         return bytes.concat(versionedHash, checksum[0], checksum[1], checksum[2], checksum[3]);

--- a/src/libraries/PegInDerivation.sol
+++ b/src/libraries/PegInDerivation.sol
@@ -54,6 +54,14 @@ library PegInDerivation {
     /// rotates every derived address (the same rotation path as a federation change).
     bytes internal constant DERIVATION_DOMAIN = "FLYOVER_PEGIN_V1";
 
+    /// @notice Base58check version byte of a mainnet P2SH address — the leading byte of the
+    /// deposit-address payload built in {depositAddressPayload}.
+    bytes1 internal constant P2SH_VERSION_MAINNET = 0x05;
+
+    /// @notice Base58check version byte of a testnet/regtest P2SH address. Differing from
+    /// {P2SH_VERSION_MAINNET} is what keeps the two networks' deposit addresses disjoint.
+    bytes1 internal constant P2SH_VERSION_TESTNET = 0xC4;
+
     /// @notice The P2PKH zero address payload for mainnet: version byte `0x00` followed by a
     /// 20-byte zero HASH160. Well-formed and non-empty, but provably unspendable.
     bytes internal constant BITCOIN_ZERO_ADDRESS_MAINNET = hex"000000000000000000000000000000000000000000";
@@ -172,15 +180,16 @@ library PegInDerivation {
     }
 
     /// @notice Step 5 (address form): the base58check payload of the PLAIN P2SH deposit address:
-    /// version (0x05 mainnet / 0xC4 testnet) ++ scriptHash ++ 4-byte double-sha256 checksum.
+    /// version ({P2SH_VERSION_MAINNET} / {P2SH_VERSION_TESTNET}) ++ scriptHash ++ 4-byte
+    /// double-sha256 checksum.
     /// Returned as the raw 25 bytes — the caller (SDK/LPS) base58-ENCODEs them to the address
     /// string shown to the user. MUST stay a plain P2SH: the segwit-wrapped form is pitfall #2
     /// (-304).
     /// @param scriptHash Step 4's output
-    /// @param isMainnet True for the mainnet version byte (0x05), false for testnet/regtest (0xC4)
+    /// @param isMainnet True for {P2SH_VERSION_MAINNET}, false for {P2SH_VERSION_TESTNET}
     /// @return The 25-byte base58check payload of the deposit address
     function depositAddressPayload(bytes20 scriptHash, bool isMainnet) internal pure returns (bytes memory) {
-        bytes1 version = isMainnet ? bytes1(0x05) : bytes1(0xC4);
+        bytes1 version = isMainnet ? P2SH_VERSION_MAINNET : P2SH_VERSION_TESTNET;
         bytes memory versionedHash = bytes.concat(version, scriptHash);
         bytes32 checksum = sha256(abi.encodePacked(sha256(versionedHash)));
         return bytes.concat(versionedHash, checksum[0], checksum[1], checksum[2], checksum[3]);

--- a/src/libraries/PegInDerivation.sol
+++ b/src/libraries/PegInDerivation.sol
@@ -11,16 +11,22 @@ import {OpCodes} from "@rsksmart/btc-transaction-solidity-helper/contracts/OpCod
 ///
 /// @dev The native fast bridge (`registerFastBridgeBtcTransaction`) is never told the deposit
 /// address: it re-derives it from the call's arguments plus the active powpeg redeem script, then
-/// scans the SPV-proven transaction for an output paying it. The derivation below was validated
-/// end-to-end on a live regtest against the UNMODIFIED powpeg bridge (rskj 9.0.2, 2026-06-30,
-/// settle tx 0x174ab0df7cc86648a40d9b36da95fd4dacf2f18c135606141d532b7d1363c7de):
+/// scans the SPV-proven transaction for an output paying it. The SHAPE of the derivation below was
+/// validated end-to-end on a live regtest against the UNMODIFIED powpeg bridge (rskj 9.0.2,
+/// 2026-06-30, settle tx 0x174ab0df7cc86648a40d9b36da95fd4dacf2f18c135606141d532b7d1363c7de). That
+/// run used a real regtest p2pkh as the two BTC placeholders; they are now the per-network ZERO
+/// address (see {refundPlaceholderBtc}). The zero-address form is well-formed and non-empty, but no
+/// end-to-end run has yet settled with it — the settlement path does not exist on this branch
+/// (`PegInContract.resolvePegIn` reverts `ResolvePegInNotImplemented`). Proving the bridge accepts a
+/// zero-hash address is owed by the settlement work, and is a merge gate for production, not a
+/// property this library may assume:
 ///
 ///   derivationArgumentsHash = keccak256(DERIVATION_DOMAIN ++ rskAddr)                    (step 1)
 ///   derivationValue         = keccak256(
 ///       derivationArgumentsHash
-///       ++ REFUND_PLACEHOLDER_BTC        // userRefundBtcAddress (FIXED 21-byte constant)
+///       ++ refundPlaceholderBtc(mainnet) // userRefundBtcAddress (21-byte per-network constant)
 ///       ++ bytes20(pegInContract)        // lbcAddress = the contract that CALLS the bridge
-///       ++ LP_PLACEHOLDER_BTC            // liquidityProviderBtcAddress (FIXED 21-byte constant)
+///       ++ lpPlaceholderBtc(mainnet)     // liquidityProviderBtcAddress (same per-network constant)
 ///   )                                                                                    (step 2)
 ///   flyoverRedeemScript = OP_PUSHBYTES_32 ++ derivationValue ++ OP_DROP
 ///                         ++ activePowpegRedeemScript                                    (step 3)
@@ -48,30 +54,46 @@ library PegInDerivation {
     /// rotates every derived address (the same rotation path as a federation change).
     bytes internal constant DERIVATION_DOMAIN = "FLYOVER_PEGIN_V1";
 
+    /// @notice The P2PKH zero address payload for mainnet: version byte `0x00` followed by a
+    /// 20-byte zero HASH160. Well-formed and non-empty, but provably unspendable.
+    bytes internal constant ZERO_PLACEHOLDER_MAINNET = hex"000000000000000000000000000000000000000000";
+
+    /// @notice The P2PKH zero address payload for testnet/regtest: version byte `0x6f` followed by
+    /// a 20-byte zero HASH160. Differs from {ZERO_PLACEHOLDER_MAINNET} ONLY in the version byte,
+    /// which is enough to make every address derived from it a different address.
+    bytes internal constant ZERO_PLACEHOLDER_TESTNET = hex"6f0000000000000000000000000000000000000000";
+
     /// @notice FIXED protocol-wide placeholder for the bridge's `userRefundBtcAddress` argument,
     /// mixed into the deposit address AND passed to the bridge at settlement. It MUST be identical
-    /// at address issuance and settlement, and it MUST be a real, well-formed 21-byte
-    /// (version ++ HASH160) BTC address — NEVER empty (the bridge rejects an empty address with
-    /// -900) and NEVER the serving LP's address (the deposit address stays LP-agnostic).
+    /// at address issuance and settlement, it is NEVER empty (the bridge rejects an empty address
+    /// with -900) and NEVER the serving LP's address (the deposit address stays LP-agnostic).
     ///
-    /// PRODUCTION (OPEN treasury-sink decision, walkthrough): replace this regtest placeholder
-    /// with a SINGLE, protocol-owned, MONITORED BTC address (e.g. a Flyover-treasury multisig).
-    /// The bridge's FAILURE-REFUND path (taken only when a fast-bridge peg-in is rejected after
-    /// the BTC is locked) sends the locked BTC to THIS address — not to the depositing user and
-    /// not to the LP — so it must be a recoverable, monitored sink, never an EOA whose key can be
-    /// lost. Current value: `mfujgzmRixnsDfxN9u9yck1k3xtx9qCf2F`.
-    /// @return The 21-byte (version ++ HASH160) refund placeholder
-    function refundPlaceholderBtc() internal pure returns (bytes memory) {
-        return hex"6f044f0ba3d3a2bd0724db5e6d59a0bb62f4ef0cc2";
+    /// The value is the per-network P2PKH ZERO ADDRESS — `version ++ 20 zero bytes`. It is
+    /// network-dependent because the version byte is, so the two networks derive disjoint address
+    /// sets. Once the first address is issued on a network this value is frozen: changing it
+    /// rotates every derived address and requires the full drain-then-rotate procedure.
+    ///
+    /// TODO(treasury): the bridge's FAILURE-REFUND path (taken only when a fast-bridge peg-in is
+    /// rejected after the BTC is locked) pays THIS address — not the depositing user, not the LP.
+    /// A zero-hash address has no spending key, so any BTC sent down that path is BURNED. That is
+    /// accepted for the PoC. BEFORE PRODUCTION both placeholders must be repointed at a monitored,
+    /// recoverable, protocol-owned treasury address (one per network, e.g. a Flyover-treasury
+    /// multisig), and that swap rotates every derived address. This is the surviving mainnet
+    /// blocker of the treasury discussion.
+    /// @param mainnet True for the mainnet zero address, false for testnet/regtest
+    /// @return The 21-byte (version ++ HASH160) refund placeholder for the target network
+    function refundPlaceholderBtc(bool mainnet) internal pure returns (bytes memory) {
+        return mainnet ? ZERO_PLACEHOLDER_MAINNET : ZERO_PLACEHOLDER_TESTNET;
     }
 
     /// @notice FIXED protocol-wide placeholder for the bridge's `liquidityProviderBtcAddress`
-    /// argument. Same constraints and same production guidance as {refundPlaceholderBtc}; it is
-    /// NOT the serving LP's address. Kept as a separate accessor so production can point the two
-    /// roles at distinct addresses if desired.
-    /// @return The 21-byte (version ++ HASH160) liquidity-provider placeholder
-    function lpPlaceholderBtc() internal pure returns (bytes memory) {
-        return hex"6f044f0ba3d3a2bd0724db5e6d59a0bb62f4ef0cc2";
+    /// argument. Same constraints, same per-network zero address and the same
+    /// `TODO(treasury)` as {refundPlaceholderBtc}; it is NOT the serving LP's address. Kept as a
+    /// separate accessor so production can point the two roles at distinct addresses.
+    /// @param mainnet True for the mainnet zero address, false for testnet/regtest
+    /// @return The 21-byte (version ++ HASH160) liquidity-provider placeholder for the network
+    function lpPlaceholderBtc(bool mainnet) internal pure returns (bytes memory) {
+        return mainnet ? ZERO_PLACEHOLDER_MAINNET : ZERO_PLACEHOLDER_TESTNET;
     }
 
     /// @notice Step 1: the 32-byte `derivationArgumentsHash` passed to the bridge as the FIRST
@@ -91,11 +113,17 @@ library PegInDerivation {
     /// @param rskAddr The RSK destination address
     /// @param pegInContract The PegInContract PROXY address (the lbcAddress that calls the bridge;
     /// stable across implementation upgrades, rotates only on a redeploy)
+    /// @param mainnet True to mix the mainnet placeholders, false for testnet/regtest. The
+    /// placeholders are network-dependent (see {refundPlaceholderBtc}), so this flag changes the
+    /// derived value — and therefore the deposit address — on every network.
     /// @return The keccak256 hash the bridge embeds in the flyover redeem script
-    function derivationValue(address rskAddr, address pegInContract) internal pure returns (bytes32) {
+    function derivationValue(address rskAddr, address pegInContract, bool mainnet) internal pure returns (bytes32) {
         return keccak256(
             bytes.concat(
-                derivationArgumentsHash(rskAddr), refundPlaceholderBtc(), bytes20(pegInContract), lpPlaceholderBtc()
+                derivationArgumentsHash(rskAddr),
+                refundPlaceholderBtc(mainnet),
+                bytes20(pegInContract),
+                lpPlaceholderBtc(mainnet)
             )
         );
     }

--- a/test/libraries/PegInDerivation.t.sol
+++ b/test/libraries/PegInDerivation.t.sol
@@ -44,11 +44,11 @@ contract PegInDerivationTest is Test {
         hex"464c594f5645525f504547494e5f5631";
 
     /// @notice The 21-byte testnet/regtest zero placeholder: version 0x6f ++ 20 zero bytes
-    bytes internal constant PINNED_PLACEHOLDER_TESTNET =
+    bytes internal constant PINNED_BITCOIN_ZERO_ADDRESS_TESTNET =
         hex"6f0000000000000000000000000000000000000000";
 
     /// @notice The 21-byte mainnet zero placeholder: version 0x00 ++ 20 zero bytes
-    bytes internal constant PINNED_PLACEHOLDER_MAINNET =
+    bytes internal constant PINNED_BITCOIN_ZERO_ADDRESS_MAINNET =
         hex"000000000000000000000000000000000000000000";
 
     // ---- Pinned step outputs, TESTNET/REGTEST (computed once offline, frozen) ----
@@ -133,14 +133,14 @@ contract PegInDerivationTest is Test {
 
     function test_RefundPlaceholderIsPinned() public pure {
         _assertZeroPlaceholder(
-            PegInDerivation.refundPlaceholderBtc(false),
-            PINNED_PLACEHOLDER_TESTNET,
+            PegInDerivation.getRefundPlaceholderBtcAddress(false),
+            PINNED_BITCOIN_ZERO_ADDRESS_TESTNET,
             bytes1(0x6f),
             "refund testnet"
         );
         _assertZeroPlaceholder(
-            PegInDerivation.refundPlaceholderBtc(true),
-            PINNED_PLACEHOLDER_MAINNET,
+            PegInDerivation.getRefundPlaceholderBtcAddress(true),
+            PINNED_BITCOIN_ZERO_ADDRESS_MAINNET,
             bytes1(0x00),
             "refund mainnet"
         );
@@ -148,14 +148,14 @@ contract PegInDerivationTest is Test {
 
     function test_LpPlaceholderIsPinned() public pure {
         _assertZeroPlaceholder(
-            PegInDerivation.lpPlaceholderBtc(false),
-            PINNED_PLACEHOLDER_TESTNET,
+            PegInDerivation.getLpPlaceholderBtcAddress(false),
+            PINNED_BITCOIN_ZERO_ADDRESS_TESTNET,
             bytes1(0x6f),
             "lp testnet"
         );
         _assertZeroPlaceholder(
-            PegInDerivation.lpPlaceholderBtc(true),
-            PINNED_PLACEHOLDER_MAINNET,
+            PegInDerivation.getLpPlaceholderBtcAddress(true),
+            PINNED_BITCOIN_ZERO_ADDRESS_MAINNET,
             bytes1(0x00),
             "lp mainnet"
         );
@@ -164,27 +164,27 @@ contract PegInDerivationTest is Test {
     /// @notice The two networks' placeholders must differ EXACTLY in the version byte — the whole
     /// reason the placeholders became network-dependent.
     function test_PlaceholdersDifferOnlyInVersionByte() public pure {
-        bytes memory testnet = PegInDerivation.refundPlaceholderBtc(false);
-        bytes memory mainnet = PegInDerivation.refundPlaceholderBtc(true);
+        bytes memory testnetPlaceholder = PegInDerivation.getRefundPlaceholderBtcAddress(false);
+        bytes memory mainnetPlaceholder = PegInDerivation.getRefundPlaceholderBtcAddress(true);
         assertTrue(
-            testnet[0] != mainnet[0],
+            testnetPlaceholder[0] != mainnetPlaceholder[0],
             "version byte must differ between networks"
         );
         for (uint256 i = 1; i < 21; ++i) {
             assertEq(
-                testnet[i],
-                mainnet[i],
+                testnetPlaceholder[i],
+                mainnetPlaceholder[i],
                 "only the version byte may differ"
             );
         }
         assertEq(
-            keccak256(PegInDerivation.lpPlaceholderBtc(false)),
-            keccak256(testnet),
+            keccak256(PegInDerivation.getLpPlaceholderBtcAddress(false)),
+            keccak256(testnetPlaceholder),
             "lp/refund testnet placeholders must match"
         );
         assertEq(
-            keccak256(PegInDerivation.lpPlaceholderBtc(true)),
-            keccak256(mainnet),
+            keccak256(PegInDerivation.getLpPlaceholderBtcAddress(true)),
+            keccak256(mainnetPlaceholder),
             "lp/refund mainnet placeholders must match"
         );
     }
@@ -459,11 +459,11 @@ contract PegInDerivationTest is Test {
     }
 
     /// @notice Composes steps 2-4 exactly the way consumers do (see PegInAddressRegistry)
-    function _deriveScriptHash(bool mainnet) private pure returns (bytes20) {
+    function _deriveScriptHash(bool isMainnet) private pure returns (bytes20) {
         bytes32 derivationValue = PegInDerivation.derivationValue(
             FIXTURE_RSK,
             FIXTURE_PEGIN_CONTRACT,
-            mainnet
+            isMainnet
         );
         bytes memory redeemScript = PegInDerivation.flyoverRedeemScript(
             derivationValue,

--- a/test/libraries/PegInDerivation.t.sol
+++ b/test/libraries/PegInDerivation.t.sol
@@ -164,8 +164,10 @@ contract PegInDerivationTest is Test {
     /// @notice The two networks' placeholders must differ EXACTLY in the version byte — the whole
     /// reason the placeholders became network-dependent.
     function test_PlaceholdersDifferOnlyInVersionByte() public pure {
-        bytes memory testnetPlaceholder = PegInDerivation.getRefundPlaceholderBtcAddress(false);
-        bytes memory mainnetPlaceholder = PegInDerivation.getRefundPlaceholderBtcAddress(true);
+        bytes memory testnetPlaceholder = PegInDerivation
+            .getRefundPlaceholderBtcAddress(false);
+        bytes memory mainnetPlaceholder = PegInDerivation
+            .getRefundPlaceholderBtcAddress(true);
         assertTrue(
             testnetPlaceholder[0] != mainnetPlaceholder[0],
             "version byte must differ between networks"

--- a/test/libraries/PegInDerivation.t.sol
+++ b/test/libraries/PegInDerivation.t.sol
@@ -6,13 +6,20 @@ import {OpCodes} from "@rsksmart/btc-transaction-solidity-helper/contracts/OpCod
 import {PegInDerivation} from "../../src/libraries/PegInDerivation.sol";
 
 /// @title PegInDerivation Library Tests
-/// @notice Pins the PoC's bridge-verified derivation vectors as FIXED-BYTE fixtures and encodes
-/// the two known derivation pitfalls as negative tests.
-/// @dev Every expected value below is a pinned constant computed once offline from the scheme
-/// validated end-to-end on a live regtest against the unmodified powpeg bridge (rskj 9.0.2,
-/// 2026-06-30, settle tx 0x174ab0df7cc86648a40d9b36da95fd4dacf2f18c135606141d532b7d1363c7de).
-/// Nothing is recomputed from the library's own constants: if any constant, opcode, or version
-/// byte changes, these tests fail. That is the point.
+/// @notice Pins the derivation vectors as FIXED-BYTE fixtures, PER NETWORK, and encodes the two
+/// known derivation pitfalls as negative tests.
+/// @dev Every expected value below is a pinned constant computed once offline by an independent
+/// implementation of the scheme (keccak256/sha256/ripemd160 outside Solidity), never by calling the
+/// library under test. Nothing is recomputed from the library's own constants: if any constant,
+/// opcode, or version byte changes, these tests fail. That is the point.
+///
+/// The SHAPE of the scheme was validated end-to-end on a live regtest against the unmodified powpeg
+/// bridge (rskj 9.0.2, 2026-06-30, settle tx
+/// 0x174ab0df7cc86648a40d9b36da95fd4dacf2f18c135606141d532b7d1363c7de). That run used a real regtest
+/// p2pkh for the two BTC placeholders; the placeholders are now the per-network ZERO address
+/// (FLY-2521), which rotated every vector below. No end-to-end run has settled with the zero
+/// placeholders yet — the settlement path does not exist on this branch — so these fixtures pin the
+/// derivation, not the bridge's acceptance of a zero-hash address.
 contract PegInDerivationTest is Test {
     // ---- Fixture inputs (the PoC vector) ----
 
@@ -36,54 +43,83 @@ contract PegInDerivationTest is Test {
     bytes internal constant PINNED_DOMAIN =
         hex"464c594f5645525f504547494e5f5631";
 
-    /// @notice The exact 21-byte (version ++ HASH160) placeholder both BTC-address slots ship with
-    bytes internal constant PINNED_PLACEHOLDER =
-        hex"6f044f0ba3d3a2bd0724db5e6d59a0bb62f4ef0cc2";
+    /// @notice The 21-byte testnet/regtest zero placeholder: version 0x6f ++ 20 zero bytes
+    bytes internal constant PINNED_PLACEHOLDER_TESTNET =
+        hex"6f0000000000000000000000000000000000000000";
 
-    // ---- Pinned step outputs (computed once offline, frozen) ----
+    /// @notice The 21-byte mainnet zero placeholder: version 0x00 ++ 20 zero bytes
+    bytes internal constant PINNED_PLACEHOLDER_MAINNET =
+        hex"000000000000000000000000000000000000000000";
 
-    /// @notice Step 1: keccak256(DERIVATION_DOMAIN ++ rskAddr)
+    // ---- Pinned step outputs, TESTNET/REGTEST (computed once offline, frozen) ----
+
+    /// @notice Step 1: keccak256(DERIVATION_DOMAIN ++ rskAddr). Network-independent: the
+    /// placeholders enter at step 2, not step 1.
     bytes32 internal constant PINNED_ARGS_HASH =
         0x0ac85b6d14264cdf09e4b64c6250b2fb650d8d87f04164e8f0c69b1f29e1a89a;
 
-    /// @notice Step 2: keccak256(argsHash ++ placeholder ++ bytes20(pegInContract) ++ placeholder)
-    bytes32 internal constant PINNED_DERIVATION_VALUE =
-        0xae132ee60570d9332790a147f626edd2c053c2ea9fbece393e2caf823a8746b6;
+    /// @notice Step 2 (testnet): keccak256(argsHash ++ p ++ bytes20(pegInContract) ++ p)
+    bytes32 internal constant PINNED_DERIVATION_VALUE_TESTNET =
+        0x6ca7b4e64cad153fbd1ddfda69945f982f204c662da0a904367b9ca593b42a9b;
 
-    /// @notice Step 3: OP_PUSHBYTES_32 ++ derivationValue ++ OP_DROP ++ powpeg script
-    bytes internal constant PINNED_REDEEM_SCRIPT =
-        hex"20ae132ee60570d9332790a147f626edd2c053c2ea9fbece393e2caf823a8746b675522102cd53fc53"
-        hex"a07f211641a677d250f6de99caf620e8e77071e811a28b3bcddf0be1210362634ab57dae9cb373a5d5"
-        hex"36e66a8c4f67468bbcfb063809bab643072d78a1242103c5946b3fbae03a654237da863c9ed534e087"
-        hex"8657175b132b8ca630f245df04db53ae";
+    /// @notice Step 3 (testnet): OP_PUSHBYTES_32 ++ derivationValue ++ OP_DROP ++ powpeg script
+    bytes internal constant PINNED_REDEEM_SCRIPT_TESTNET =
+        hex"206ca7b4e64cad153fbd1ddfda69945f982f204c662da0a904367b9ca593b42a9b75522102cd53fc"
+        hex"53a07f211641a677d250f6de99caf620e8e77071e811a28b3bcddf0be1210362634ab57dae9cb373"
+        hex"a5d536e66a8c4f67468bbcfb063809bab643072d78a1242103c5946b3fbae03a654237da863c9ed5"
+        hex"34e0878657175b132b8ca630f245df04db53ae";
 
-    /// @notice Step 4: HASH160 of the flyover redeem script
-    bytes20 internal constant PINNED_SCRIPT_HASH =
-        bytes20(hex"53239f29b16aa66c9a5e3ec7f2b1de034fe0dea7");
+    /// @notice Step 4 (testnet): HASH160 of the flyover redeem script
+    bytes20 internal constant PINNED_SCRIPT_HASH_TESTNET =
+        bytes20(hex"0c63443c601c577510e7f80cdd7f663e075dc07e");
 
-    /// @notice Step 5a: OP_HASH160 0x14 <scriptHash> OP_EQUAL
-    bytes internal constant PINNED_SCRIPT_PUBKEY =
-        hex"a91453239f29b16aa66c9a5e3ec7f2b1de034fe0dea787";
+    /// @notice Step 5a (testnet): OP_HASH160 0x14 <scriptHash> OP_EQUAL
+    bytes internal constant PINNED_SCRIPT_PUBKEY_TESTNET =
+        hex"a9140c63443c601c577510e7f80cdd7f663e075dc07e87";
 
-    /// @notice Step 5b testnet: 0xC4 ++ scriptHash ++ checksum (PoC bridge-verified fixture)
+    /// @notice Step 5b (testnet): 0xC4 ++ scriptHash ++ checksum
     bytes internal constant PINNED_TESTNET_PAYLOAD =
-        hex"c453239f29b16aa66c9a5e3ec7f2b1de034fe0dea79440b320";
+        hex"c40c63443c601c577510e7f80cdd7f663e075dc07e862c627a";
 
-    /// @notice Step 5b mainnet: 0x05 ++ scriptHash ++ checksum (PoC bridge-verified fixture)
+    // ---- Pinned step outputs, MAINNET ----
+
+    /// @notice Step 2 (mainnet). Differs from the testnet value because the placeholders differ in
+    /// their version byte, so EVERY downstream mainnet vector differs too — not just the address
+    /// version byte.
+    bytes32 internal constant PINNED_DERIVATION_VALUE_MAINNET =
+        0x5f711554b557c7fa5da3126a212b7ef7ed5db9425be5eb872230eb1b356d235b;
+
+    /// @notice Step 3 (mainnet)
+    bytes internal constant PINNED_REDEEM_SCRIPT_MAINNET =
+        hex"205f711554b557c7fa5da3126a212b7ef7ed5db9425be5eb872230eb1b356d235b75522102cd53fc"
+        hex"53a07f211641a677d250f6de99caf620e8e77071e811a28b3bcddf0be1210362634ab57dae9cb373"
+        hex"a5d536e66a8c4f67468bbcfb063809bab643072d78a1242103c5946b3fbae03a654237da863c9ed5"
+        hex"34e0878657175b132b8ca630f245df04db53ae";
+
+    /// @notice Step 4 (mainnet)
+    bytes20 internal constant PINNED_SCRIPT_HASH_MAINNET =
+        bytes20(hex"d8c7225ff79f803c7cbaed672f764c639133c3fd");
+
+    /// @notice Step 5a (mainnet)
+    bytes internal constant PINNED_SCRIPT_PUBKEY_MAINNET =
+        hex"a914d8c7225ff79f803c7cbaed672f764c639133c3fd87";
+
+    /// @notice Step 5b (mainnet): 0x05 ++ scriptHash ++ checksum
     bytes internal constant PINNED_MAINNET_PAYLOAD =
-        hex"0553239f29b16aa66c9a5e3ec7f2b1de034fe0dea72259d920";
+        hex"05d8c7225ff79f803c7cbaed672f764c639133c3fd6a67b0eb";
 
     // ---- Pinned negative-form payloads (the two on-chain failure modes) ----
 
     /// @notice Pitfall #1 (-900): payload derived keying the redeem-script tag with the
-    /// derivationArgumentsHash DIRECTLY, skipping step 2's address mixing
+    /// derivationArgumentsHash DIRECTLY, skipping step 2's address mixing. Unchanged by FLY-2521:
+    /// this form never mixes the placeholders at all.
     bytes internal constant PINNED_DIRECT_TAG_PAYLOAD =
         hex"c4b0275b8861bb9b30585453cde8d9efaa99b444487e6c335a";
 
-    /// @notice Pitfall #2 (-304): payload derived wrapping the CORRECT redeem script as a segwit
-    /// P2SH-of-P2WSH instead of a plain P2SH
+    /// @notice Pitfall #2 (-304): payload derived wrapping the CORRECT testnet redeem script as a
+    /// segwit P2SH-of-P2WSH instead of a plain P2SH
     bytes internal constant PINNED_SEGWIT_PAYLOAD =
-        hex"c423670b6bf4ab398f05d8536da400767b562425bc199d1a4a";
+        hex"c490a45e9bf80f1a2d9aac68ef224d929bb9b507d8545026ec";
 
     // ---- Constant pinning ----
 
@@ -96,27 +132,61 @@ contract PegInDerivationTest is Test {
     }
 
     function test_RefundPlaceholderIsPinned() public pure {
-        bytes memory placeholder = PegInDerivation.refundPlaceholderBtc();
-        assertEq(
-            placeholder.length,
-            21,
-            "refund placeholder must be 21 bytes (version ++ HASH160)"
+        _assertZeroPlaceholder(
+            PegInDerivation.refundPlaceholderBtc(false),
+            PINNED_PLACEHOLDER_TESTNET,
+            bytes1(0x6f),
+            "refund testnet"
         );
-        assertEq(
-            placeholder,
-            PINNED_PLACEHOLDER,
-            "REFUND_PLACEHOLDER_BTC changed"
+        _assertZeroPlaceholder(
+            PegInDerivation.refundPlaceholderBtc(true),
+            PINNED_PLACEHOLDER_MAINNET,
+            bytes1(0x00),
+            "refund mainnet"
         );
     }
 
     function test_LpPlaceholderIsPinned() public pure {
-        bytes memory placeholder = PegInDerivation.lpPlaceholderBtc();
-        assertEq(
-            placeholder.length,
-            21,
-            "lp placeholder must be 21 bytes (version ++ HASH160)"
+        _assertZeroPlaceholder(
+            PegInDerivation.lpPlaceholderBtc(false),
+            PINNED_PLACEHOLDER_TESTNET,
+            bytes1(0x6f),
+            "lp testnet"
         );
-        assertEq(placeholder, PINNED_PLACEHOLDER, "LP_PLACEHOLDER_BTC changed");
+        _assertZeroPlaceholder(
+            PegInDerivation.lpPlaceholderBtc(true),
+            PINNED_PLACEHOLDER_MAINNET,
+            bytes1(0x00),
+            "lp mainnet"
+        );
+    }
+
+    /// @notice The two networks' placeholders must differ EXACTLY in the version byte — the whole
+    /// reason the placeholders became network-dependent.
+    function test_PlaceholdersDifferOnlyInVersionByte() public pure {
+        bytes memory testnet = PegInDerivation.refundPlaceholderBtc(false);
+        bytes memory mainnet = PegInDerivation.refundPlaceholderBtc(true);
+        assertTrue(
+            testnet[0] != mainnet[0],
+            "version byte must differ between networks"
+        );
+        for (uint256 i = 1; i < 21; ++i) {
+            assertEq(
+                testnet[i],
+                mainnet[i],
+                "only the version byte may differ"
+            );
+        }
+        assertEq(
+            keccak256(PegInDerivation.lpPlaceholderBtc(false)),
+            keccak256(testnet),
+            "lp/refund testnet placeholders must match"
+        );
+        assertEq(
+            keccak256(PegInDerivation.lpPlaceholderBtc(true)),
+            keccak256(mainnet),
+            "lp/refund mainnet placeholders must match"
+        );
     }
 
     // ---- Per-step fixtures (each step fed the PINNED previous output) ----
@@ -129,47 +199,112 @@ contract PegInDerivationTest is Test {
         );
     }
 
-    function test_Step2_DerivationValue() public pure {
+    function test_Step2_DerivationValue_Testnet() public pure {
         assertEq(
             PegInDerivation.derivationValue(
                 FIXTURE_RSK,
-                FIXTURE_PEGIN_CONTRACT
+                FIXTURE_PEGIN_CONTRACT,
+                false
             ),
-            PINNED_DERIVATION_VALUE,
-            "step 2 drifted"
+            PINNED_DERIVATION_VALUE_TESTNET,
+            "step 2 testnet drifted"
         );
     }
 
-    function test_Step3_FlyoverRedeemScript() public pure {
+    function test_Step2_DerivationValue_Mainnet() public pure {
+        assertEq(
+            PegInDerivation.derivationValue(
+                FIXTURE_RSK,
+                FIXTURE_PEGIN_CONTRACT,
+                true
+            ),
+            PINNED_DERIVATION_VALUE_MAINNET,
+            "step 2 mainnet drifted"
+        );
+    }
+
+    /// @notice The per-network placeholders must make step 2 itself network-dependent. If this
+    /// fails, the two networks share a derived address set.
+    function test_Step2_NetworksDeriveDifferentValues() public pure {
+        assertTrue(
+            PINNED_DERIVATION_VALUE_TESTNET != PINNED_DERIVATION_VALUE_MAINNET,
+            "pinned per-network values must differ"
+        );
+        assertTrue(
+            PegInDerivation.derivationValue(
+                FIXTURE_RSK,
+                FIXTURE_PEGIN_CONTRACT,
+                false
+            ) !=
+                PegInDerivation.derivationValue(
+                    FIXTURE_RSK,
+                    FIXTURE_PEGIN_CONTRACT,
+                    true
+                ),
+            "mainnet flag must change the derivation value"
+        );
+    }
+
+    function test_Step3_FlyoverRedeemScript_Testnet() public pure {
         assertEq(
             PegInDerivation.flyoverRedeemScript(
-                PINNED_DERIVATION_VALUE,
+                PINNED_DERIVATION_VALUE_TESTNET,
                 FIXTURE_POWPEG_SCRIPT
             ),
-            PINNED_REDEEM_SCRIPT,
-            "step 3 drifted"
+            PINNED_REDEEM_SCRIPT_TESTNET,
+            "step 3 testnet drifted"
         );
     }
 
-    function test_Step4_FlyoverScriptHash() public pure {
+    function test_Step3_FlyoverRedeemScript_Mainnet() public pure {
         assertEq(
-            PegInDerivation.flyoverScriptHash(PINNED_REDEEM_SCRIPT),
-            PINNED_SCRIPT_HASH,
-            "step 4 drifted"
+            PegInDerivation.flyoverRedeemScript(
+                PINNED_DERIVATION_VALUE_MAINNET,
+                FIXTURE_POWPEG_SCRIPT
+            ),
+            PINNED_REDEEM_SCRIPT_MAINNET,
+            "step 3 mainnet drifted"
         );
     }
 
-    function test_Step5a_P2shScriptPubkey() public pure {
+    function test_Step4_FlyoverScriptHash_Testnet() public pure {
         assertEq(
-            PegInDerivation.p2shScriptPubkey(PINNED_SCRIPT_HASH),
-            PINNED_SCRIPT_PUBKEY,
-            "step 5a drifted"
+            PegInDerivation.flyoverScriptHash(PINNED_REDEEM_SCRIPT_TESTNET),
+            PINNED_SCRIPT_HASH_TESTNET,
+            "step 4 testnet drifted"
+        );
+    }
+
+    function test_Step4_FlyoverScriptHash_Mainnet() public pure {
+        assertEq(
+            PegInDerivation.flyoverScriptHash(PINNED_REDEEM_SCRIPT_MAINNET),
+            PINNED_SCRIPT_HASH_MAINNET,
+            "step 4 mainnet drifted"
+        );
+    }
+
+    function test_Step5a_P2shScriptPubkey_Testnet() public pure {
+        assertEq(
+            PegInDerivation.p2shScriptPubkey(PINNED_SCRIPT_HASH_TESTNET),
+            PINNED_SCRIPT_PUBKEY_TESTNET,
+            "step 5a testnet drifted"
+        );
+    }
+
+    function test_Step5a_P2shScriptPubkey_Mainnet() public pure {
+        assertEq(
+            PegInDerivation.p2shScriptPubkey(PINNED_SCRIPT_HASH_MAINNET),
+            PINNED_SCRIPT_PUBKEY_MAINNET,
+            "step 5a mainnet drifted"
         );
     }
 
     function test_Step5b_TestnetPayload() public pure {
         assertEq(
-            PegInDerivation.depositAddressPayload(PINNED_SCRIPT_HASH, false),
+            PegInDerivation.depositAddressPayload(
+                PINNED_SCRIPT_HASH_TESTNET,
+                false
+            ),
             PINNED_TESTNET_PAYLOAD,
             "step 5b testnet drifted"
         );
@@ -177,7 +312,10 @@ contract PegInDerivationTest is Test {
 
     function test_Step5b_MainnetPayload() public pure {
         assertEq(
-            PegInDerivation.depositAddressPayload(PINNED_SCRIPT_HASH, true),
+            PegInDerivation.depositAddressPayload(
+                PINNED_SCRIPT_HASH_MAINNET,
+                true
+            ),
             PINNED_MAINNET_PAYLOAD,
             "step 5b mainnet drifted"
         );
@@ -185,34 +323,52 @@ contract PegInDerivationTest is Test {
 
     // ---- Full chain, composed the way consumers compose it ----
 
-    function test_FullChainMatchesBridgeVerifiedFixture() public pure {
-        bytes20 scriptHash = _deriveScriptHash();
+    function test_FullChainMatchesPinnedFixtures() public pure {
         assertEq(
-            PegInDerivation.depositAddressPayload(scriptHash, false),
+            PegInDerivation.depositAddressPayload(
+                _deriveScriptHash(false),
+                false
+            ),
             PINNED_TESTNET_PAYLOAD,
             "full-chain testnet payload drifted"
         );
         assertEq(
-            PegInDerivation.depositAddressPayload(scriptHash, true),
+            PegInDerivation.depositAddressPayload(
+                _deriveScriptHash(true),
+                true
+            ),
             PINNED_MAINNET_PAYLOAD,
             "full-chain mainnet payload drifted"
         );
     }
 
+    /// @notice The networks derive genuinely different script hashes, so a mainnet address is not a
+    /// re-prefixed testnet address.
+    function test_FullChainNetworksDeriveDifferentScriptHashes() public pure {
+        assertTrue(
+            _deriveScriptHash(false) != _deriveScriptHash(true),
+            "networks must derive different script hashes"
+        );
+    }
+
     function test_DerivationIsDeterministic() public pure {
-        bytes20 first = _deriveScriptHash();
-        bytes20 second = _deriveScriptHash();
-        assertEq(first, second, "same inputs must derive the same script hash");
+        assertEq(
+            _deriveScriptHash(false),
+            _deriveScriptHash(false),
+            "same inputs must derive the same script hash"
+        );
     }
 
     function test_DifferentRskAddressesDeriveDifferentAddresses() public pure {
         bytes32 valueA = PegInDerivation.derivationValue(
             address(0x1111),
-            FIXTURE_PEGIN_CONTRACT
+            FIXTURE_PEGIN_CONTRACT,
+            false
         );
         bytes32 valueB = PegInDerivation.derivationValue(
             address(0x2222),
-            FIXTURE_PEGIN_CONTRACT
+            FIXTURE_PEGIN_CONTRACT,
+            false
         );
         assertTrue(
             valueA != valueB,
@@ -241,7 +397,7 @@ contract PegInDerivationTest is Test {
         );
         assertTrue(
             keccak256(wrongPayload) != keccak256(PINNED_TESTNET_PAYLOAD),
-            "direct-tag keying must NOT produce the bridge-verified address"
+            "direct-tag keying must NOT produce the correct address"
         );
     }
 
@@ -252,7 +408,7 @@ contract PegInDerivationTest is Test {
         bytes memory segwitScript = bytes.concat(
             OpCodes.OP_0,
             OpCodes.OP_PUSHBYTES_32,
-            sha256(PINNED_REDEEM_SCRIPT)
+            sha256(PINNED_REDEEM_SCRIPT_TESTNET)
         );
         bytes memory wrongPayload = PegInDerivation.depositAddressPayload(
             PegInDerivation.flyoverScriptHash(segwitScript),
@@ -265,17 +421,49 @@ contract PegInDerivationTest is Test {
         );
         assertTrue(
             keccak256(wrongPayload) != keccak256(PINNED_TESTNET_PAYLOAD),
-            "segwit wrapping must NOT produce the bridge-verified address"
+            "segwit wrapping must NOT produce the correct address"
         );
     }
 
     // ---- Helpers ----
 
+    /// @notice Asserts a placeholder is exactly `version ++ 20 zero bytes` and matches its pin
+    function _assertZeroPlaceholder(
+        bytes memory placeholder,
+        bytes memory pinned,
+        bytes1 version,
+        string memory label
+    ) private pure {
+        assertEq(
+            placeholder.length,
+            21,
+            string.concat(label, ": must be 21 bytes (version ++ HASH160)")
+        );
+        assertEq(
+            placeholder[0],
+            version,
+            string.concat(label, ": wrong version byte")
+        );
+        for (uint256 i = 1; i < 21; ++i) {
+            assertEq(
+                placeholder[i],
+                bytes1(0x00),
+                string.concat(label, ": HASH160 must be all zeroes")
+            );
+        }
+        assertEq(
+            placeholder,
+            pinned,
+            string.concat(label, ": placeholder changed")
+        );
+    }
+
     /// @notice Composes steps 2-4 exactly the way consumers do (see PegInAddressRegistry)
-    function _deriveScriptHash() private pure returns (bytes20) {
+    function _deriveScriptHash(bool mainnet) private pure returns (bytes20) {
         bytes32 derivationValue = PegInDerivation.derivationValue(
             FIXTURE_RSK,
-            FIXTURE_PEGIN_CONTRACT
+            FIXTURE_PEGIN_CONTRACT,
+            mainnet
         );
         bytes memory redeemScript = PegInDerivation.flyoverRedeemScript(
             derivationValue,

--- a/test/pegin-registry/Derivation.t.sol
+++ b/test/pegin-registry/Derivation.t.sol
@@ -17,10 +17,13 @@ import {OpCodes} from "@rsksmart/btc-transaction-solidity-helper/contracts/OpCod
 contract DerivationTest is PegInRegistryTestBase {
     address internal constant FIXTURE_RSK =
         0x0000000000000000000000000000000000000aBc;
+    /// @dev The two payloads no longer share a script hash: the BTC placeholders mixed into the
+    /// derivation are per-network (FLY-2521), so the mainnet address differs from the testnet one in
+    /// every byte, not just the version prefix. Pinned offline; see test/libraries/PegInDerivation.t.sol.
     bytes internal constant FIXTURE_TESTNET_ADDRESS =
-        hex"c453239f29b16aa66c9a5e3ec7f2b1de034fe0dea79440b320";
+        hex"c40c63443c601c577510e7f80cdd7f663e075dc07e862c627a";
     bytes internal constant FIXTURE_MAINNET_ADDRESS =
-        hex"0553239f29b16aa66c9a5e3ec7f2b1de034fe0dea72259d920";
+        hex"05d8c7225ff79f803c7cbaed672f764c639133c3fd6a67b0eb";
 
     // R1 — deterministic derivation
     function test_derive_deterministic_same_rskAddr() public {
@@ -261,7 +264,8 @@ contract DerivationTest is PegInRegistryTestBase {
         bytes memory powpeg = bridge.getActivePowpegRedeemScript();
         bytes32 dv = PegInDerivation.derivationValue(
             FIXTURE_RSK,
-            PEGIN_CONTRACT
+            PEGIN_CONTRACT,
+            false
         );
         bytes memory redeem = PegInDerivation.flyoverRedeemScript(dv, powpeg);
 

--- a/test/pegin-registry/PegInRegistryTestBase.sol
+++ b/test/pegin-registry/PegInRegistryTestBase.sol
@@ -29,10 +29,10 @@ abstract contract PegInRegistryTestBase is Test {
     RegistryBridgeMock internal bridge;
     PauseRegistry internal pauseRegistry;
 
-    /// @notice The network flag {registry} was deployed with. The BTC placeholders mixed into the
-    /// derivation are per-network, so {_depositPkScript} must derive with the SAME flag or the
-    /// registry will not match the deposit output.
-    bool internal deployedMainnet;
+    /// @notice The network flag {registry} was deployed with — true when deployed as mainnet. The
+    /// BTC placeholders mixed into the derivation are per-network, so {_depositPkScript} must
+    /// derive with the SAME flag or the registry will not match the deposit output.
+    bool internal isMainnetDeployment;
 
     function _deployPauseRegistry() internal {
         PauseRegistry impl = new PauseRegistry();
@@ -45,8 +45,8 @@ abstract contract PegInRegistryTestBase is Test {
         );
     }
 
-    function _deploy(bool mainnet) internal {
-        deployedMainnet = mainnet;
+    function _deploy(bool isMainnet) internal {
+        isMainnetDeployment = isMainnet;
         bridge = new RegistryBridgeMock();
         _deployPauseRegistry();
         PegInAddressRegistryHarness impl = new PegInAddressRegistryHarness();
@@ -56,7 +56,7 @@ abstract contract PegInRegistryTestBase is Test {
                 owner,
                 ADMIN_DELAY,
                 address(bridge),
-                mainnet,
+                isMainnet,
                 IPauseRegistry(address(pauseRegistry))
             )
         );
@@ -67,7 +67,7 @@ abstract contract PegInRegistryTestBase is Test {
     }
 
     function _deployUnwired(
-        bool mainnet
+        bool isMainnet
     ) internal returns (PegInAddressRegistryHarness r) {
         if (address(bridge) == address(0)) bridge = new RegistryBridgeMock();
         if (address(pauseRegistry) == address(0)) _deployPauseRegistry();
@@ -78,7 +78,7 @@ abstract contract PegInRegistryTestBase is Test {
                 owner,
                 ADMIN_DELAY,
                 address(bridge),
-                mainnet,
+                isMainnet,
                 IPauseRegistry(address(pauseRegistry))
             )
         );
@@ -112,7 +112,7 @@ abstract contract PegInRegistryTestBase is Test {
         bytes32 dv = PegInDerivation.derivationValue(
             rskAddr,
             PEGIN_CONTRACT,
-            deployedMainnet
+            isMainnetDeployment
         );
         bytes memory redeem = PegInDerivation.flyoverRedeemScript(dv, powpeg);
         bytes20 scriptHash = PegInDerivation.flyoverScriptHash(redeem);

--- a/test/pegin-registry/PegInRegistryTestBase.sol
+++ b/test/pegin-registry/PegInRegistryTestBase.sol
@@ -29,6 +29,11 @@ abstract contract PegInRegistryTestBase is Test {
     RegistryBridgeMock internal bridge;
     PauseRegistry internal pauseRegistry;
 
+    /// @notice The network flag {registry} was deployed with. The BTC placeholders mixed into the
+    /// derivation are per-network, so {_depositPkScript} must derive with the SAME flag or the
+    /// registry will not match the deposit output.
+    bool internal deployedMainnet;
+
     function _deployPauseRegistry() internal {
         PauseRegistry impl = new PauseRegistry();
         bytes memory initData = abi.encodeCall(
@@ -41,6 +46,7 @@ abstract contract PegInRegistryTestBase is Test {
     }
 
     function _deploy(bool mainnet) internal {
+        deployedMainnet = mainnet;
         bridge = new RegistryBridgeMock();
         _deployPauseRegistry();
         PegInAddressRegistryHarness impl = new PegInAddressRegistryHarness();
@@ -103,7 +109,11 @@ abstract contract PegInRegistryTestBase is Test {
         address rskAddr
     ) internal view returns (bytes memory) {
         bytes memory powpeg = bridge.getActivePowpegRedeemScript();
-        bytes32 dv = PegInDerivation.derivationValue(rskAddr, PEGIN_CONTRACT);
+        bytes32 dv = PegInDerivation.derivationValue(
+            rskAddr,
+            PEGIN_CONTRACT,
+            deployedMainnet
+        );
         bytes memory redeem = PegInDerivation.flyoverRedeemScript(dv, powpeg);
         bytes20 scriptHash = PegInDerivation.flyoverScriptHash(redeem);
         return PegInDerivation.p2shScriptPubkey(scriptHash);


### PR DESCRIPTION
## Summary

- Both BTC placeholders in `PegInDerivation` now return the P2PKH **zero address** (`version ++ 20 zero bytes`) instead of a real regtest p2pkh, and they are **per network**: version byte `0x6f` on testnet/regtest, `0x00` on mainnet. `derivationValue` threads the `mainnet` flag to both accessors; `PegInAddressRegistry` sources it from the flag it already stores, and `_expectedDepositPkScript` gains the parameter so deposit-gating derives with the same flag as issuance.
- All derivation vectors re-pinned **per network**. A mainnet address is no longer a re-prefixed testnet address — the script hash itself differs — so the library and registry fixtures carry independent testnet/mainnet sets. Pins were computed offline by a separate implementation of the scheme rather than by calling the library under test, so a wrong version byte fails CI instead of being pinned as correct. The pitfall #1 (direct-tag) pin is unchanged, since that form never mixes the placeholders.
- `TODO(treasury)` added at both definitions: the bridge's failure-refund path pays this address, so with a zero hash those funds are **burned**. Accepted for the PoC; before production both must point at a monitored, recoverable, protocol-owned treasury address per network, and that swap rotates every derived address. NatSpec rewritten — constraints that still hold are kept (never empty, never the serving LP's address, identical at issuance and settlement); the claim that the value must be a real monitored address is dropped and now lives in the TODO.

## Not included: the end-to-end regtest proof

The ticket asks for a settled regtest peg-in with the zero placeholders, with the settle tx recorded here. **That proof is not in this PR, and this PR should not be treated as having satisfied it.**

`PegInContract.resolvePegIn` is a stub on `v3.0.0` — it reverts `ResolvePegInNotImplemented` — so there is no settlement path on this branch to settle anything through. The working settlement path and the harness that produced the reference settle tx `0x174ab0df…` live on the `dos-removal` branch, not here.

So the open question the ticket names — *does the bridge settle with a well-formed but zero-hash refund address, or reject it?* — remains **unanswered**. The library header records this explicitly as owed by the settlement work and as a gate before production, rather than as a property the library assumes.

## Verification

- `forge build` clean; `forge test` 752 passed. The 2 failures in `test/differential/DifferentialParity*.diff.t.sol` are pre-existing on clean `v3.0.0` (`setUp()` fails on a missing `.rskMainnet.LiquidityBridgeContract.address` entry in `addresses.json`) and are unrelated to this change.
- `prettier --check` clean; `solhint` reports the same 2 warnings before and after this change (no new lint).