### PR TITLE
feat(FLY-2575): derive the peg-in amount from the BTC deposit transaction

### DIFF
--- a/src/PegInAddressRegistry.sol
+++ b/src/PegInAddressRegistry.sol
@@ -206,6 +206,10 @@ contract PegInAddressRegistry is
     }
 
     /// @notice Derives the on-chain P2SH scriptPubkey for a deposit output match.
+    /// @dev Reads the live powpeg script and hands the composition to
+    /// {PegInDerivation-expectedDepositPkScript}. The registry holds no derivation of its own:
+    /// `PegInContract.requestPegIn` matches deposits against that same helper, so the script that
+    /// gates registration is the script that fixes the peg-in amount.
     /// @param isMainnet Whether the derivation targets mainnet or testnet — the BTC placeholders
     /// mixed into the value are per-network, so this must match the flag used at issuance
     function _expectedDepositPkScript(address rskAddr, address pegInContract, IBridge bridge_, bool isMainnet)
@@ -213,28 +217,24 @@ contract PegInAddressRegistry is
         view
         returns (bytes memory)
     {
-        bytes memory powpegRedeemScript = bridge_.getActivePowpegRedeemScript();
-        bytes32 derivationValue = PegInDerivation.derivationValue(rskAddr, pegInContract, isMainnet);
-        bytes memory redeemScript = PegInDerivation.flyoverRedeemScript(derivationValue, powpegRedeemScript);
-        bytes20 scriptHash = PegInDerivation.flyoverScriptHash(redeemScript);
-        return PegInDerivation.p2shScriptPubkey(scriptHash);
+        return PegInDerivation.expectedDepositPkScript(
+            rskAddr, pegInContract, bridge_.getActivePowpegRedeemScript(), isMainnet
+        );
     }
 
     /// @notice Returns the satoshi value of the output paying the derived deposit script.
+    /// @dev Thin wrapper over {PegInDerivation-matchedDepositValue} that turns the library's
+    /// found flag into the registry's own named error.
     function _matchedDepositValue(bytes calldata btcTxSerialized, bytes memory expectedPkScript, address rskAddr)
         private
         pure
         returns (uint64 depositValue)
     {
-        BtcUtils.TxRawOutput[] memory outputs = BtcUtils.getOutputs(btcTxSerialized);
-        bytes32 expectedHash = keccak256(expectedPkScript);
-        uint256 outputCount = outputs.length;
-        for (uint256 i = 0; i < outputCount; ++i) {
-            if (keccak256(outputs[i].pkScript) == expectedHash) {
-                return outputs[i].value;
-            }
+        bool found;
+        (depositValue, found) = PegInDerivation.matchedDepositValue(btcTxSerialized, expectedPkScript);
+        if (!found) {
+            revert DepositOutputNotFound(rskAddr);
         }
-        revert DepositOutputNotFound(rskAddr);
     }
 
     /// @notice Derives the BTC deposit address for an RSK address against a supplied powpeg script.

--- a/src/PegInContract.sol
+++ b/src/PegInContract.sol
@@ -17,6 +17,7 @@ import {IPegIn} from "./interfaces/IPegIn.sol";
 import {IPegInAddressRegistry} from "./interfaces/IPegInAddressRegistry.sol";
 import {IPegInCommitFirst} from "./interfaces/IPegInCommitFirst.sol";
 import {Flyover} from "./libraries/Flyover.sol";
+import {PegInDerivation} from "./libraries/PegInDerivation.sol";
 import {Quotes} from "./libraries/Quotes.sol";
 import {SignatureValidator} from "./libraries/SignatureValidator.sol";
 
@@ -327,13 +328,13 @@ contract PegInContract is
     /// @inheritdoc IPegInCommitFirst
     function requestPegIn(
         address rskAddr,
-        uint256 amount,
-        bytes32 btcTxHash,
+        bytes calldata btcTxSerialized,
         bytes calldata opReturn,
         bytes32 btcBlockHash,
         uint256 merkleBranchPath,
         bytes32[] calldata merkleBranchHashes
     ) external payable nonReentrant whenNotHardPaused override returns (bytes32 pegInId) {
+        bytes32 btcTxHash = BtcUtils.hashBtcTx(btcTxSerialized);
         pegInId = keccak256(abi.encodePacked(rskAddr, btcTxHash));
         if (_pegInClaims[pegInId].claimer != address(0)) {
             revert PegInAlreadyProcessed(pegInId);
@@ -343,6 +344,7 @@ contract PegInContract is
         if (!_pegInAddressRegistry.isRegistered(rskAddr)) {
             revert AddressNotRegistered(rskAddr);
         }
+        uint256 amount = _derivePegInAmount(rskAddr, btcTxSerialized, btcTxHash);
         _requirePegInConfirmations(amount, btcTxHash, btcBlockHash, merkleBranchPath, merkleBranchHashes);
 
         uint256 fee = _configurations.calculatePegInFee(amount);
@@ -447,6 +449,36 @@ contract PegInContract is
     function _requirePegInDepsSet() private view {
         if (address(_pegInAddressRegistry) == address(0)) revert PegInAddressRegistryNotSet();
         if (address(_configurations) == address(0)) revert FlyoverConfigurationsNotSet();
+    }
+
+    /// @notice Reads the peg-in amount out of the deposit transaction
+    /// @dev The contract derives the deposit scriptPubkey for rskAddr and takes the value of the
+    /// output paying it, through the same {PegInDerivation} helpers the registry uses at
+    /// registration. Both the derivation inputs (this proxy's address, the live powpeg script,
+    /// the network flag) and the matched output come from state or from the SPV-proven bytes, so
+    /// there is no argument a caller can move to change the answer.
+    ///
+    /// The powpeg script is read fresh from the bridge on every call, so a federation change
+    /// rotates the expected script here exactly as it rotates the issued address. In-flight
+    /// deposits to a pre-rotation address stop matching, which is the drain-then-rotate cost
+    /// PegInDerivation documents, not a new failure mode.
+    /// @param rskAddr The RSK destination address of the peg-in
+    /// @param btcTxSerialized The witness-stripped raw deposit transaction
+    /// @param btcTxHash The txid hashed from btcTxSerialized, for the revert reason
+    /// @return The gross peg-in amount in wei
+    function _derivePegInAmount(address rskAddr, bytes calldata btcTxSerialized, bytes32 btcTxHash)
+        private
+        view
+        returns (uint256)
+    {
+        bytes memory expectedPkScript = PegInDerivation.expectedDepositPkScript(
+            rskAddr, address(this), _bridge.getActivePowpegRedeemScript(), _mainnet
+        );
+        (uint64 depositSats, bool found) = PegInDerivation.matchedDepositValue(btcTxSerialized, expectedPkScript);
+        if (!found) {
+            revert DepositOutputNotFound(rskAddr, btcTxHash);
+        }
+        return uint256(depositSats) * Quotes.SAT_TO_WEI_CONVERSION;
     }
 
     /// @notice Reverts unless Bridge confirmations meet the configured tier for amount

--- a/src/interfaces/IPegInCommitFirst.sol
+++ b/src/interfaces/IPegInCommitFirst.sol
@@ -19,7 +19,8 @@ interface IPegInCommitFirst {
     /// @param pegInId The id under which the claim was recorded
     /// @param claimer The account that fronted the RBTC and holds the claim
     /// @param rskAddr The RSK destination address that received the funds
-    /// @param amount The gross peg-in amount, in wei
+    /// @param amount The gross peg-in amount, in wei — the deposit output's satoshi value
+    /// scaled by 10**10, never a caller-supplied figure
     /// @param netToUser The amount delivered to the user (amount minus fee), in wei
     /// @param callSuccess Whether the delivery call succeeded (always true this sprint)
     event PegInRequested(
@@ -60,8 +61,10 @@ interface IPegInCommitFirst {
     );
 
     /// @notice Reverts requestPegIn when the peg-in already has a claimer
-    /// @dev First check in the function, so the loser of a claim race burns minimal gas.
-    /// Walkthrough anchors: decisions D10-D11, exception A1.
+    /// @dev First check in the function, so the loser of a claim race burns minimal gas. The
+    /// deposit txid is hashed out of the raw transaction before it, because the id is keyed on
+    /// that txid; nothing else runs ahead of it. Walkthrough anchors: decisions D10-D11,
+    /// exception A1.
     /// @param pegInId The id of the already-claimed peg-in
     error PegInAlreadyProcessed(bytes32 pegInId);
 
@@ -70,9 +73,22 @@ interface IPegInCommitFirst {
     /// @param rskAddr The unregistered RSK destination address
     error AddressNotRegistered(address rskAddr);
 
+    /// @notice Reverts requestPegIn when the presented transaction has no output paying the
+    /// deposit address derived from the destination address
+    /// @dev The check that makes the peg-in amount a derived value instead of a declared one.
+    /// Without it any confirmed txid pairs with any registered destination, so a dust claim
+    /// locks the real depositor out under PegInAlreadyProcessed. Same rule the registry
+    /// enforces at registration, through the same shared helper.
+    /// Walkthrough anchors: step 11, exception A1.
+    /// @param rskAddr The destination address whose derived deposit output was not found
+    /// @param btcTxHash The hash of the presented transaction
+    error DepositOutputNotFound(address rskAddr, bytes32 btcTxHash);
+
     /// @notice Reverts requestPegIn when the deposit lacks the confirmations the
     /// configuration requires for its amount
-    /// @dev Walkthrough anchor: step 11.
+    /// @dev The amount driving the tier lookup is the one read off the deposit output, so
+    /// understating a large deposit to buy the low tier is not expressible.
+    /// Walkthrough anchor: step 11.
     /// @param have The confirmations the bridge reports
     /// @param required The confirmations the active configuration requires
     error InsufficientConfirmations(uint256 have, uint256 required);
@@ -86,25 +102,29 @@ interface IPegInCommitFirst {
 
     /// @notice Claims a confirmed BTC deposit by fronting the net amount in RBTC, which is
     /// delivered to the destination address in the same transaction
-    /// @dev Payable: msg.value must equal amount minus the fee. The claim record stores the
-    /// claimer, the fronted amount, and the fee at claim time, because the configuration can
-    /// change before settlement pays the claimer back (~17 hours later). The opReturn
+    /// @dev Takes the raw deposit transaction, not an amount and not a txid. The gross amount
+    /// is READ from the output paying the address derived for rskAddr, and the txid is hashed
+    /// from the same bytes, so the SPV proof, the peg-in id and the amount provably describe
+    /// one transaction. Nothing about the deposit's value is caller-supplied.
+    ///
+    /// Payable: msg.value must equal the derived amount minus the fee. The claim record stores
+    /// the claimer, the fronted amount, and the fee at claim time, because the configuration
+    /// can change before settlement pays the claimer back (~17 hours later). The opReturn
     /// argument is accepted and ignored this sprint (plain transfers only; contract-call
-    /// delivery lands in sprint 2). Walkthrough anchors: step 11 (the five checks), step 12,
+    /// delivery lands in sprint 2). Walkthrough anchors: step 11 (the checks), step 12,
     /// "Why record the claim at requestPegIn time?", decisions D9-D11.
     /// @param rskAddr The RSK destination address of the peg-in
-    /// @param amount The gross peg-in amount, in wei
-    /// @param btcTxHash The hash of the BTC deposit transaction
+    /// @param btcTxSerialized The witness-stripped raw BTC deposit transaction
     /// @param opReturn The OP_RETURN payload of the deposit, if any (ignored this sprint)
     /// @param btcBlockHash The hash of the Bitcoin block containing the deposit
     /// @param merkleBranchPath The path bitmap of the merkle branch proving inclusion
     /// @param merkleBranchHashes The hashes of the merkle branch proving inclusion
     /// @return pegInId The id under which the claim was recorded:
-    /// keccak256(rskAddr ++ btcTxHash), the same id resolvePegIn re-derives at settlement
+    /// keccak256(rskAddr ++ btcTxHash), with btcTxHash hashed from btcTxSerialized — the same
+    /// id resolvePegIn re-derives at settlement
     function requestPegIn(
         address rskAddr,
-        uint256 amount,
-        bytes32 btcTxHash,
+        bytes calldata btcTxSerialized,
         bytes calldata opReturn,
         bytes32 btcBlockHash,
         uint256 merkleBranchPath,

--- a/src/libraries/PegInDerivation.sol
+++ b/src/libraries/PegInDerivation.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
+import {BtcUtils} from "@rsksmart/btc-transaction-solidity-helper/contracts/BtcUtils.sol";
 import {OpCodes} from "@rsksmart/btc-transaction-solidity-helper/contracts/OpCodes.sol";
 
 /// @title PegInDerivation
@@ -35,6 +36,12 @@ import {OpCodes} from "@rsksmart/btc-transaction-solidity-helper/contracts/OpCod
 ///
 /// Each step is a separate function taking the previous step's output, so every consumer enters
 /// the pipeline at the step it needs and none re-implements any script math.
+///
+/// The pipeline does not stop at the address. Every consumer that reads a VALUE out of a deposit
+/// transaction — the registry gating registration, `PegInContract.requestPegIn` computing the
+/// peg-in amount — must match outputs against the SAME script this library derives, so
+/// {expectedDepositPkScript} and {matchedDepositValue} live here too. A caller-supplied amount is
+/// never an input to either path: the amount is a value the contract computes.
 ///
 /// Two known pitfalls, both proven on-chain and both encoded as negative tests:
 ///   1. Keying the redeem-script tag with `derivationArgumentsHash` directly (skipping step 2's
@@ -184,5 +191,58 @@ library PegInDerivation {
         bytes memory versionedHash = bytes.concat(version, scriptHash);
         bytes32 checksum = sha256(abi.encodePacked(sha256(versionedHash)));
         return bytes.concat(versionedHash, checksum[0], checksum[1], checksum[2], checksum[3]);
+    }
+
+    /// @notice Steps 2-5 composed: the on-chain P2SH scriptPubkey a deposit output must carry to
+    /// count as a deposit for `rskAddr`. The single entry point for deposit matching — the
+    /// registry and the peg-in claim path both call this rather than re-composing the steps, so
+    /// the script that gates registration and the script that fixes the peg-in amount cannot
+    /// drift apart.
+    /// @param rskAddr The RSK destination address the deposit address is derived for
+    /// @param pegInContract The PegInContract PROXY address mixed into step 2
+    /// @param activePowpegRedeemScript The live powpeg redeem script, read from the bridge at
+    /// call time — never stored
+    /// @param isMainnet True to mix the mainnet placeholders, false for testnet/regtest. Must be
+    /// the same flag the deposit address was issued under, or no output will match.
+    /// @return The 23-byte P2SH scriptPubkey of the deposit address
+    function expectedDepositPkScript(
+        address rskAddr,
+        address pegInContract,
+        bytes memory activePowpegRedeemScript,
+        bool isMainnet
+    ) internal pure returns (bytes memory) {
+        bytes32 derivationValue_ = derivationValue(rskAddr, pegInContract, isMainnet);
+        bytes memory redeemScript = flyoverRedeemScript(derivationValue_, activePowpegRedeemScript);
+        return p2shScriptPubkey(flyoverScriptHash(redeemScript));
+    }
+
+    /// @notice The satoshi value of the FIRST output of `btcTxSerialized` paying `expectedPkScript`.
+    /// @dev First match, not the sum of every matching output. A deposit split across several
+    /// outputs to the same derived address therefore counts only its first output, which
+    /// UNDERSTATES the deposit. That direction is the safe one — the claimer fronts less than the
+    /// bridge will release and settlement covers the claim — and it is the rule the registry has
+    /// always applied, so the value that gates registration and the value that fixes the peg-in
+    /// amount stay identical. Summing would have to change both call sites at once.
+    ///
+    /// Returns a found flag rather than reverting: the two call sites revert with their own named
+    /// errors, and a library revert would flatten them into one.
+    /// @param btcTxSerialized The witness-stripped raw deposit transaction
+    /// @param expectedPkScript The scriptPubkey from {expectedDepositPkScript}
+    /// @return value The matched output's value in satoshis, 0 when no output matched
+    /// @return found Whether any output paid `expectedPkScript`
+    function matchedDepositValue(bytes calldata btcTxSerialized, bytes memory expectedPkScript)
+        internal
+        pure
+        returns (uint64 value, bool found)
+    {
+        BtcUtils.TxRawOutput[] memory outputs = BtcUtils.getOutputs(btcTxSerialized);
+        bytes32 expectedHash = keccak256(expectedPkScript);
+        uint256 outputCount = outputs.length;
+        for (uint256 i = 0; i < outputCount; ++i) {
+            if (keccak256(outputs[i].pkScript) == expectedHash) {
+                return (outputs[i].value, true);
+            }
+        }
+        return (0, false);
     }
 }

--- a/src/test-contracts/RequestPegInReenterReceiver.sol
+++ b/src/test-contracts/RequestPegInReenterReceiver.sol
@@ -5,13 +5,14 @@ import {IPegInCommitFirst} from "../interfaces/IPegInCommitFirst.sol";
 
 /// @notice Malicious peg-in destination that re-enters requestPegIn on delivery.
 /// @dev Mirrors the WithdrawReceiver test-contract pattern. On receiving the fronted RBTC it
-/// calls requestPegIn again with a different btcTxHash (a fresh pegInId), so the re-entry is
-/// blocked by the nonReentrant guard rather than trivially hitting the already-processed check.
+/// calls requestPegIn again with a different deposit transaction (a different txid, so a fresh
+/// pegInId), so the re-entry is blocked by the nonReentrant guard rather than trivially hitting
+/// the already-processed check.
 /* solhint-disable comprehensive-interface */
 contract RequestPegInReenterReceiver {
     IPegInCommitFirst private _pegIn;
     bool private _attack;
-    bytes32 private _reenterBtcTxHash;
+    bytes private _reenterBtcTx;
 
     constructor(address pegInContract) {
         _pegIn = IPegInCommitFirst(pegInContract);
@@ -20,14 +21,15 @@ contract RequestPegInReenterReceiver {
     receive() external payable {
         if (_attack) {
             _attack = false;
-            _pegIn.requestPegIn(address(this), 1, _reenterBtcTxHash, "", bytes32(0), 0, new bytes32[](0));
+            _pegIn.requestPegIn(address(this), _reenterBtcTx, "", bytes32(0), 0, new bytes32[](0));
         }
     }
 
-    /// @notice Arms or disarms the re-entry, and sets the btcTxHash used for the re-entrant call
-    function setAttack(bool attack, bytes32 reenterBtcTxHash) external {
+    /// @notice Arms or disarms the re-entry, and sets the deposit transaction used for the
+    /// re-entrant call
+    function setAttack(bool attack, bytes calldata reenterBtcTx) external {
         _attack = attack;
-        _reenterBtcTxHash = reenterBtcTxHash;
+        _reenterBtcTx = reenterBtcTx;
     }
 }
 /* solhint-enable comprehensive-interface */

--- a/test/pegin/RequestPegInAtomicity.t.sol
+++ b/test/pegin/RequestPegInAtomicity.t.sol
@@ -12,7 +12,8 @@ import {Flyover} from "../../src/libraries/Flyover.sol";
 contract RequestPegInAtomicityTest is RequestPegInTestBase {
     function test_failedCheck_isAtomic_unregistered() public {
         address unregistered = makeAddr("unregisteredAtomic");
-        bytes32 pegInId = _pegInId(unregistered, DEFAULT_BTC_TX_HASH);
+        bytes memory btcTx = _depositTx(unregistered, DEFAULT_AMOUNT);
+        bytes32 pegInId = _pegInIdForTx(unregistered, btcTx);
         uint256 userBefore = unregistered.balance;
 
         vm.prank(claimer);
@@ -24,8 +25,7 @@ contract RequestPegInAtomicityTest is RequestPegInTestBase {
         );
         pegInContract.requestPegIn{value: 1 ether}(
             unregistered,
-            DEFAULT_AMOUNT,
-            DEFAULT_BTC_TX_HASH,
+            btcTx,
             "",
             bytes32(0),
             0,
@@ -40,9 +40,40 @@ contract RequestPegInAtomicityTest is RequestPegInTestBase {
         );
     }
 
+    function test_failedCheck_isAtomic_depositOutputNotFound() public {
+        bytes memory unrelated = _unrelatedTx();
+        bytes32 pegInId = _pegInIdForTx(rskUser, unrelated);
+        uint256 userBefore = rskUser.balance;
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.DepositOutputNotFound.selector,
+                rskUser,
+                this.hashTx(unrelated)
+            )
+        );
+        pegInContract.requestPegIn{value: 1 wei}(
+            rskUser,
+            unrelated,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+
+        _assertNoClaim(pegInId);
+        assertEq(
+            rskUser.balance,
+            userBefore,
+            "no delivery when no output pays the derived address"
+        );
+    }
+
     function test_failedCheck_isAtomic_insufficientConfirmations() public {
         bridgeMock.setConfirmations(int256(DEFAULT_TIER_CONFIRMATIONS) - 1);
-        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+        bytes memory btcTx = _defaultTx();
+        bytes32 pegInId = _pegInIdForTx(rskUser, btcTx);
         uint256 userBefore = rskUser.balance;
 
         vm.prank(claimer);
@@ -55,8 +86,7 @@ contract RequestPegInAtomicityTest is RequestPegInTestBase {
         );
         pegInContract.requestPegIn{value: 1 ether}(
             rskUser,
-            DEFAULT_AMOUNT,
-            DEFAULT_BTC_TX_HASH,
+            btcTx,
             "",
             bytes32(0),
             0,
@@ -74,7 +104,8 @@ contract RequestPegInAtomicityTest is RequestPegInTestBase {
     function test_failedCheck_isAtomic_incorrectFronting() public {
         uint256 amount = DEFAULT_AMOUNT;
         uint256 wrongValue = amount; // not amount - fee
-        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+        bytes memory btcTx = _defaultTx();
+        bytes32 pegInId = _pegInIdForTx(rskUser, btcTx);
         uint256 userBefore = rskUser.balance;
 
         vm.prank(claimer);
@@ -87,8 +118,7 @@ contract RequestPegInAtomicityTest is RequestPegInTestBase {
         );
         pegInContract.requestPegIn{value: wrongValue}(
             rskUser,
-            amount,
-            DEFAULT_BTC_TX_HASH,
+            btcTx,
             "",
             bytes32(0),
             0,
@@ -112,15 +142,15 @@ contract RequestPegInAtomicityTest is RequestPegInTestBase {
 
         uint256 amount = DEFAULT_AMOUNT;
         uint256 net = amount - _expectedFee(amount);
-        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+        bytes memory btcTx = _defaultTx();
+        bytes32 pegInId = _pegInIdForTx(rskUser, btcTx);
         uint256 userBefore = rskUser.balance;
 
         vm.prank(claimer);
         vm.expectRevert(Flyover.EnforcedPause.selector);
         pegInContract.requestPegIn{value: net}(
             rskUser,
-            amount,
-            DEFAULT_BTC_TX_HASH,
+            btcTx,
             "",
             bytes32(0),
             0,

--- a/test/pegin/RequestPegInFeeEdges.t.sol
+++ b/test/pegin/RequestPegInFeeEdges.t.sol
@@ -12,10 +12,11 @@ contract RequestPegInFeeEdgesTest is RequestPegInTestBase {
         uint256 amount = TEST_MIN_PEGIN;
         uint256 fee = _expectedFee(amount);
         uint256 net = amount - fee;
-        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+        bytes memory btcTx = _depositTx(rskUser, amount);
+        bytes32 pegInId = _pegInIdForTx(rskUser, btcTx);
 
         uint256 userBefore = rskUser.balance;
-        _requestPegIn(claimer, rskUser, amount, DEFAULT_BTC_TX_HASH, net);
+        _requestPegInTx(claimer, rskUser, btcTx, net);
 
         assertEq(
             rskUser.balance,
@@ -31,11 +32,12 @@ contract RequestPegInFeeEdgesTest is RequestPegInTestBase {
         uint256 amount = DEFAULT_MAX_AMOUNT;
         uint256 fee = _expectedFee(amount);
         uint256 net = amount - fee;
-        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+        bytes memory btcTx = _depositTx(rskUser, amount);
+        bytes32 pegInId = _pegInIdForTx(rskUser, btcTx);
 
         vm.deal(claimer, amount);
         uint256 userBefore = rskUser.balance;
-        _requestPegIn(claimer, rskUser, amount, DEFAULT_BTC_TX_HASH, net);
+        _requestPegInTx(claimer, rskUser, btcTx, net);
 
         assertEq(
             rskUser.balance,
@@ -52,6 +54,7 @@ contract RequestPegInFeeEdgesTest is RequestPegInTestBase {
         // Fee strictly greater than the amount: amount < fee path -> IncorrectFronting(0, msg.value).
         configurations.setFee(amount + 1, 0);
         uint256 sentValue = 1;
+        bytes memory btcTx = _depositTx(rskUser, amount);
 
         vm.prank(claimer);
         vm.expectRevert(
@@ -63,8 +66,7 @@ contract RequestPegInFeeEdgesTest is RequestPegInTestBase {
         );
         pegInContract.requestPegIn{value: sentValue}(
             rskUser,
-            amount,
-            DEFAULT_BTC_TX_HASH,
+            btcTx,
             "",
             bytes32(0),
             0,

--- a/test/pegin/RequestPegInHappyPath.t.sol
+++ b/test/pegin/RequestPegInHappyPath.t.sol
@@ -32,7 +32,8 @@ contract RequestPegInHappyPathTest is RequestPegInTestBase {
         uint256 amount = DEFAULT_AMOUNT;
         uint256 fee = _expectedFee(amount);
         uint256 expectedNet = amount - fee;
-        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+        bytes memory btcTx = _defaultTx();
+        bytes32 pegInId = _pegInIdForTx(rskUser, btcTx);
 
         uint256 claimerBefore = claimer.balance;
         uint256 userBefore = rskUser.balance;
@@ -47,11 +48,10 @@ contract RequestPegInHappyPathTest is RequestPegInTestBase {
             true
         );
 
-        bytes32 returnedId = _requestPegIn(
+        bytes32 returnedId = _requestPegInTx(
             claimer,
             rskUser,
-            amount,
-            DEFAULT_BTC_TX_HASH,
+            btcTx,
             expectedNet
         );
 
@@ -87,15 +87,10 @@ contract RequestPegInHappyPathTest is RequestPegInTestBase {
         uint256 amount = DEFAULT_AMOUNT;
         uint256 fee = _expectedFee(amount);
         uint256 expectedNet = amount - fee;
-        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+        bytes memory btcTx = _defaultTx();
+        bytes32 pegInId = _pegInIdForTx(rskUser, btcTx);
 
-        _requestPegIn(
-            claimer,
-            rskUser,
-            amount,
-            DEFAULT_BTC_TX_HASH,
-            expectedNet
-        );
+        _requestPegInTx(claimer, rskUser, btcTx, expectedNet);
 
         (, , uint256 feeAtClaimBefore, ) = _readClaim(pegInId);
         assertEq(feeAtClaimBefore, fee, "fee snapshot at claim");
@@ -116,5 +111,74 @@ contract RequestPegInHappyPathTest is RequestPegInTestBase {
             feeAtClaimBefore,
             "recorded feeAtClaim unchanged after config change"
         );
+    }
+
+    /// @notice The amount is read off the deposit output, so a caller who wants a different
+    /// amount has to present a different deposit. Two deposits of different sizes, claimed with
+    /// nothing but the transaction changing, produce two different peg-in amounts.
+    function test_amount_followsTheDepositOutput() public {
+        address second = makeAddr("rskUserSecond");
+        registry.harness_seedRegistration(second, makeAddr("registrant3"), 1);
+
+        uint256 small = 0.5 ether;
+        uint256 large = 20 ether;
+        vm.deal(claimer, 100 ether);
+
+        bytes memory smallTx = _depositTx(rskUser, small);
+        bytes memory largeTx = _depositTx(second, large);
+
+        vm.expectEmit(true, true, true, true);
+        emit IPegInCommitFirst.PegInRequested(
+            _pegInIdForTx(rskUser, smallTx),
+            claimer,
+            rskUser,
+            small,
+            small - _expectedFee(small),
+            true
+        );
+        _requestPegInTx(claimer, rskUser, smallTx, small - _expectedFee(small));
+
+        vm.expectEmit(true, true, true, true);
+        emit IPegInCommitFirst.PegInRequested(
+            _pegInIdForTx(second, largeTx),
+            claimer,
+            second,
+            large,
+            large - _expectedFee(large),
+            true
+        );
+        _requestPegInTx(claimer, second, largeTx, large - _expectedFee(large));
+    }
+
+    /// @notice Satoshi-to-wei conversion pinned to a literal fixture, so an off-by-a-power-of-ten
+    /// in the scaling cannot pass CI. 123_456_789 sats is 1.23456789 RBTC; every neighbouring
+    /// power of ten is a different number and would fail this assertion.
+    function test_satToWei_pinnedFixture() public {
+        uint64 depositSats = 123_456_789;
+        uint256 expectedAmount = 1.23456789 ether;
+        assertEq(
+            uint256(depositSats) * 10 ** 10,
+            expectedAmount,
+            "fixture self-check: 123456789 sats == 1.23456789 ether"
+        );
+
+        bytes memory btcTx = _buildTx(
+            _depositPkScript(rskUser),
+            depositSats,
+            42
+        );
+        uint256 net = expectedAmount - _expectedFee(expectedAmount);
+        vm.deal(claimer, 100 ether);
+
+        vm.expectEmit(true, true, true, true);
+        emit IPegInCommitFirst.PegInRequested(
+            _pegInIdForTx(rskUser, btcTx),
+            claimer,
+            rskUser,
+            expectedAmount,
+            net,
+            true
+        );
+        _requestPegInTx(claimer, rskUser, btcTx, net);
     }
 }

--- a/test/pegin/RequestPegInReentrancy.t.sol
+++ b/test/pegin/RequestPegInReentrancy.t.sol
@@ -7,12 +7,13 @@ import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol
 import {Flyover} from "../../src/libraries/Flyover.sol";
 
 /// @title requestPegIn reentrancy-guard test
-/// @notice A malicious destination re-enters requestPegIn on delivery with a different btcTxHash
-/// (a fresh pegInId), so the block comes from the nonReentrant guard rather than the
-/// already-processed check. The re-entry's revert bubbles through the delivery call, so the whole
-/// transaction reverts atomically and no claim is written for either pegInId.
+/// @notice A malicious destination re-enters requestPegIn on delivery with a second, genuine
+/// deposit transaction of its own (a different txid, so a fresh pegInId), so the block comes from
+/// the nonReentrant guard rather than the already-processed check or the deposit match. The
+/// re-entry's revert bubbles through the delivery call, so the whole transaction reverts
+/// atomically and no claim is written for either pegInId.
 contract RequestPegInReentrancyTest is RequestPegInTestBase {
-    bytes32 internal constant REENTER_BTC_TX_HASH = keccak256("reenter-btc-tx");
+    uint256 internal constant REENTER_TX_NONCE = 99;
 
     function test_reentrancy_maliciousRskAddr_differentPegInId() public {
         RequestPegInReenterReceiver receiver = new RequestPegInReenterReceiver(
@@ -26,10 +27,20 @@ contract RequestPegInReentrancyTest is RequestPegInTestBase {
 
         uint256 amount = DEFAULT_AMOUNT;
         uint256 net = amount - _expectedFee(amount);
-        receiver.setAttack(true, REENTER_BTC_TX_HASH);
 
-        bytes32 outerId = _pegInId(address(receiver), DEFAULT_BTC_TX_HASH);
-        bytes32 reenterId = _pegInId(address(receiver), REENTER_BTC_TX_HASH);
+        // Both transactions really pay the receiver's derived deposit address, so the re-entry
+        // is stopped by the guard and not by a failed derivation.
+        bytes memory outerTx = _depositTx(address(receiver), amount);
+        bytes memory reenterTx = _depositTx(
+            address(receiver),
+            amount,
+            REENTER_TX_NONCE
+        );
+        receiver.setAttack(true, reenterTx);
+
+        bytes32 outerId = _pegInIdForTx(address(receiver), outerTx);
+        bytes32 reenterId = _pegInIdForTx(address(receiver), reenterTx);
+        assertTrue(outerId != reenterId, "re-entry targets a fresh pegInId");
 
         // The re-entry reverts with the reentrancy guard error, which the delivery call surfaces
         // (and the implementation wraps) as PaymentFailed, reverting the whole transaction.
@@ -47,8 +58,7 @@ contract RequestPegInReentrancyTest is RequestPegInTestBase {
         );
         pegInContract.requestPegIn{value: net}(
             address(receiver),
-            amount,
-            DEFAULT_BTC_TX_HASH,
+            outerTx,
             "",
             bytes32(0),
             0,

--- a/test/pegin/RequestPegInReverts.t.sol
+++ b/test/pegin/RequestPegInReverts.t.sol
@@ -17,9 +17,10 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
     function test_revert_alreadyProcessed_secondClaimSameId() public {
         uint256 amount = DEFAULT_AMOUNT;
         uint256 net = amount - _expectedFee(amount);
-        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+        bytes memory btcTx = _defaultTx();
+        bytes32 pegInId = _pegInIdForTx(rskUser, btcTx);
 
-        _requestPegIn(claimer, rskUser, amount, DEFAULT_BTC_TX_HASH, net);
+        _requestPegInTx(claimer, rskUser, btcTx, net);
 
         vm.prank(claimer);
         vm.expectRevert(
@@ -30,8 +31,7 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
         );
         pegInContract.requestPegIn{value: net}(
             rskUser,
-            amount,
-            DEFAULT_BTC_TX_HASH,
+            btcTx,
             "",
             bytes32(0),
             0,
@@ -45,14 +45,14 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
         // Both branches of _requirePegInDepsSet on one unwired deployment: registry is checked
         // before configurations, so the errors surface in that order as each pointer is wired.
         PegInContract unwired = _deployUnwiredPegInContract();
+        bytes memory btcTx = _defaultTx();
 
         // Branch 1: nothing wired -> registry pointer nil is reported first.
         vm.prank(claimer);
         vm.expectRevert(PegInContract.PegInAddressRegistryNotSet.selector);
         unwired.requestPegIn{value: 1 ether}(
             rskUser,
-            DEFAULT_AMOUNT,
-            DEFAULT_BTC_TX_HASH,
+            btcTx,
             "",
             bytes32(0),
             0,
@@ -70,8 +70,7 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
         vm.expectRevert(PegInContract.FlyoverConfigurationsNotSet.selector);
         unwired.requestPegIn{value: 1 ether}(
             rskUser,
-            DEFAULT_AMOUNT,
-            DEFAULT_BTC_TX_HASH,
+            btcTx,
             "",
             bytes32(0),
             0,
@@ -83,6 +82,9 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
 
     function test_revert_unregisteredRskAddr() public {
         address unregistered = makeAddr("unregistered");
+        // Fixtures are built before vm.expectRevert: _depositTx reads the powpeg script from the
+        // bridge, and expectRevert would otherwise arm against that read.
+        bytes memory btcTx = _depositTx(unregistered, DEFAULT_AMOUNT);
 
         vm.prank(claimer);
         vm.expectRevert(
@@ -93,8 +95,7 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
         );
         pegInContract.requestPegIn{value: 1 ether}(
             unregistered,
-            DEFAULT_AMOUNT,
-            DEFAULT_BTC_TX_HASH,
+            btcTx,
             "",
             bytes32(0),
             0,
@@ -102,11 +103,103 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
         );
     }
 
-    // ---- Check 4: insufficient confirmations ----
+    // ---- Check 4: no output pays the derived deposit address ----
+    //
+    // This is the check that closes the dust lockout. Before it existed, any confirmed txid
+    // paired with any registered destination and a declared dust amount wrote the claim record
+    // and locked every honest LP out of the real deposit under PegInAlreadyProcessed.
+
+    function test_revert_depositOutputNotFound_unrelatedConfirmedTx() public {
+        // A confirmed transaction that pays nothing this protocol derives — the attacker's
+        // "any txid off the chain". Confirmations are satisfied; the derivation is not.
+        bytes memory unrelated = _unrelatedTx();
+        bytes32 txHash = this.hashTx(unrelated);
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.DepositOutputNotFound.selector,
+                rskUser,
+                txHash
+            )
+        );
+        pegInContract.requestPegIn{value: 1 wei}(
+            rskUser,
+            unrelated,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+    }
+
+    function test_revert_depositOutputNotFound_txPaysAnotherDestination()
+        public
+    {
+        // A real Flyover deposit, but derived for someone else. Claiming it against rskUser is
+        // the mismatched-transaction case: the output exists, it just is not rskUser's.
+        address other = makeAddr("otherDestination");
+        registry.harness_seedRegistration(other, makeAddr("registrant4"), 1);
+
+        bytes memory othersDeposit = _depositTx(other, DEFAULT_AMOUNT);
+        bytes32 txHash = this.hashTx(othersDeposit);
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.DepositOutputNotFound.selector,
+                rskUser,
+                txHash
+            )
+        );
+        pegInContract.requestPegIn{value: 1 wei}(
+            rskUser,
+            othersDeposit,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+    }
+
+    function test_dustClaim_cannotLockOutTheRealDeposit() public {
+        // End to end on the original defect: the dust claim is rejected, and the real depositor
+        // is served afterwards under the same pegInId the attacker tried to burn.
+        bytes memory realDeposit = _defaultTx();
+        bytes32 pegInId = _pegInIdForTx(rskUser, realDeposit);
+        address attacker = makeAddr("attacker");
+        vm.deal(attacker, 1 ether);
+
+        vm.prank(attacker);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.DepositOutputNotFound.selector,
+                rskUser,
+                this.hashTx(_unrelatedTx())
+            )
+        );
+        pegInContract.requestPegIn{value: 1 wei}(
+            rskUser,
+            _unrelatedTx(),
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+
+        uint256 net = DEFAULT_AMOUNT - _expectedFee(DEFAULT_AMOUNT);
+        _requestPegInTx(claimer, rskUser, realDeposit, net);
+
+        (address claimerAddr, , , ) = _readClaim(pegInId);
+        assertEq(claimerAddr, claimer, "honest LP still able to claim");
+    }
+
+    // ---- Check 5: insufficient confirmations ----
 
     function test_revert_insufficientConfirmations_tierBoundary() public {
         uint256 required = DEFAULT_TIER_CONFIRMATIONS;
         bridgeMock.setConfirmations(int256(required) - 1);
+        bytes memory btcTx = _defaultTx();
 
         vm.prank(claimer);
         vm.expectRevert(
@@ -118,8 +211,7 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
         );
         pegInContract.requestPegIn{value: 1 ether}(
             rskUser,
-            DEFAULT_AMOUNT,
-            DEFAULT_BTC_TX_HASH,
+            btcTx,
             "",
             bytes32(0),
             0,
@@ -132,6 +224,7 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
     {
         uint256 required = DEFAULT_TIER_CONFIRMATIONS;
         bridgeMock.setConfirmations(-1);
+        bytes memory btcTx = _defaultTx();
 
         vm.prank(claimer);
         vm.expectRevert(
@@ -143,12 +236,51 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
         );
         pegInContract.requestPegIn{value: 1 ether}(
             rskUser,
-            DEFAULT_AMOUNT,
-            DEFAULT_BTC_TX_HASH,
+            btcTx,
             "",
             bytes32(0),
             0,
             _emptyBranch()
+        );
+    }
+
+    /// @notice The tier is looked up with the DERIVED amount, so a large deposit presented with
+    /// only enough confirmations for a small one is rejected. Under the old signature the
+    /// claimer simply declared the small amount and bought the low tier.
+    function test_revert_largeDeposit_cannotBuyTheLowConfirmationTier() public {
+        uint256 smallAmount = 1 ether;
+        uint256 largeAmount = 50 ether;
+        uint256 lowTierConfirmations = 2;
+        uint256 highTierConfirmations = 40;
+        _applyTwoTierConfiguration(
+            smallAmount,
+            lowTierConfirmations,
+            highTierConfirmations
+        );
+
+        // Exactly the depth the small tier asks for, and no more.
+        bridgeMock.setConfirmations(int256(lowTierConfirmations));
+        vm.deal(claimer, 100 ether);
+        bytes memory largeTx = _depositTx(rskUser, largeAmount);
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.InsufficientConfirmations.selector,
+                lowTierConfirmations,
+                highTierConfirmations
+            )
+        );
+        pegInContract.requestPegIn{
+            value: largeAmount - _expectedFee(largeAmount)
+        }(rskUser, largeTx, "", bytes32(0), 0, _emptyBranch());
+
+        // The same depth serves a deposit that really is small.
+        _requestPegIn(
+            claimer,
+            rskUser,
+            smallAmount,
+            smallAmount - _expectedFee(smallAmount)
         );
     }
 
@@ -157,13 +289,7 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
         uint256 amount = DEFAULT_AMOUNT;
         uint256 net = amount - _expectedFee(amount);
 
-        bytes32 pegInId = _requestPegIn(
-            claimer,
-            rskUser,
-            amount,
-            DEFAULT_BTC_TX_HASH,
-            net
-        );
+        bytes32 pegInId = _requestPegIn(claimer, rskUser, amount, net);
         (address claimerAddr, , , ) = _readClaim(pegInId);
         assertEq(
             claimerAddr,
@@ -172,12 +298,13 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
         );
     }
 
-    // ---- Check 5: incorrect fronting ----
+    // ---- Check 6: incorrect fronting ----
 
-    function test_revert_incorrectFronting_wrongValue() public {
+    function test_revert_incorrectFronting_overstated() public {
         uint256 amount = DEFAULT_AMOUNT;
         uint256 expectedNet = amount - _expectedFee(amount);
         uint256 wrongValue = expectedNet + 1;
+        bytes memory btcTx = _defaultTx();
 
         vm.prank(claimer);
         vm.expectRevert(
@@ -189,8 +316,56 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
         );
         pegInContract.requestPegIn{value: wrongValue}(
             rskUser,
-            amount,
-            DEFAULT_BTC_TX_HASH,
+            btcTx,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+    }
+
+    function test_revert_incorrectFronting_understated() public {
+        uint256 amount = DEFAULT_AMOUNT;
+        uint256 expectedNet = amount - _expectedFee(amount);
+        uint256 wrongValue = expectedNet - 1;
+        bytes memory btcTx = _defaultTx();
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.IncorrectFronting.selector,
+                expectedNet,
+                wrongValue
+            )
+        );
+        pegInContract.requestPegIn{value: wrongValue}(
+            rskUser,
+            btcTx,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+    }
+
+    /// @notice Fronting dust against a real, large deposit. The expected value in the error is
+    /// the one derived from the deposit output, not anything the caller offered.
+    function test_revert_incorrectFronting_dustAgainstRealDeposit() public {
+        uint256 amount = DEFAULT_AMOUNT;
+        uint256 expectedNet = amount - _expectedFee(amount);
+        bytes memory btcTx = _defaultTx();
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.IncorrectFronting.selector,
+                expectedNet,
+                1 wei
+            )
+        );
+        pegInContract.requestPegIn{value: 1 wei}(
+            rskUser,
+            btcTx,
             "",
             bytes32(0),
             0,
@@ -203,9 +378,10 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
     function test_race_secondClaim_ordersBeforeFrontingCheck() public {
         uint256 amount = DEFAULT_AMOUNT;
         uint256 net = amount - _expectedFee(amount);
-        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+        bytes memory btcTx = _defaultTx();
+        bytes32 pegInId = _pegInIdForTx(rskUser, btcTx);
 
-        _requestPegIn(claimer, rskUser, amount, DEFAULT_BTC_TX_HASH, net);
+        _requestPegInTx(claimer, rskUser, btcTx, net);
 
         // Second claim with a deliberately wrong value still reverts already-processed,
         // never IncorrectFronting.
@@ -218,8 +394,7 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
         );
         pegInContract.requestPegIn{value: net + 123}(
             rskUser,
-            amount,
-            DEFAULT_BTC_TX_HASH,
+            btcTx,
             "",
             bytes32(0),
             0,
@@ -230,9 +405,10 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
     function test_race_secondClaim_ordersBeforeConfirmationsCheck() public {
         uint256 amount = DEFAULT_AMOUNT;
         uint256 net = amount - _expectedFee(amount);
-        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+        bytes memory btcTx = _defaultTx();
+        bytes32 pegInId = _pegInIdForTx(rskUser, btcTx);
 
-        _requestPegIn(claimer, rskUser, amount, DEFAULT_BTC_TX_HASH, net);
+        _requestPegInTx(claimer, rskUser, btcTx, net);
 
         // Drop confirmations below tier; already-processed still wins.
         bridgeMock.setConfirmations(0);
@@ -245,8 +421,7 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
         );
         pegInContract.requestPegIn{value: net}(
             rskUser,
-            amount,
-            DEFAULT_BTC_TX_HASH,
+            btcTx,
             "",
             bytes32(0),
             0,
@@ -258,7 +433,8 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
         // Unwired contract (deps unset) with a pre-seeded claim and an unregistered rskAddr:
         // check 1 must still win over the deps-set and registration checks.
         PegInContract unwired = _deployUnwiredPegInContract();
-        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+        bytes memory btcTx = _defaultTx();
+        bytes32 pegInId = _pegInIdForTx(rskUser, btcTx);
         _seedClaim(unwired, pegInId, claimer);
 
         vm.prank(claimer);
@@ -270,8 +446,32 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
         );
         unwired.requestPegIn{value: 1 ether}(
             rskUser,
-            DEFAULT_AMOUNT,
-            DEFAULT_BTC_TX_HASH,
+            btcTx,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+    }
+
+    /// @notice The already-processed check also wins over the derivation check: a second claim
+    /// presenting a transaction that pays nobody still reports the claim race, not the
+    /// derivation failure. Only the txid feeds the id, so the two are independent inputs.
+    function test_ordering_alreadyProcessed_beforeDepositMatch() public {
+        bytes memory unrelated = _unrelatedTx();
+        bytes32 pegInId = _pegInIdForTx(rskUser, unrelated);
+        _seedClaim(pegInContract, pegInId, claimer);
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.PegInAlreadyProcessed.selector,
+                pegInId
+            )
+        );
+        pegInContract.requestPegIn{value: 1 wei}(
+            rskUser,
+            unrelated,
             "",
             bytes32(0),
             0,

--- a/test/pegin/RequestPegInTestBase.sol
+++ b/test/pegin/RequestPegInTestBase.sol
@@ -6,7 +6,10 @@ import {FlyoverConfigurationsMock} from "./FlyoverConfigurationsMock.sol";
 import {PegInContract} from "../../src/PegInContract.sol";
 import {PegInAddressRegistryHarness} from "../pegin-registry/PegInAddressRegistryHarness.sol";
 import {IFlyoverConfigurations} from "../../src/interfaces/IFlyoverConfigurations.sol";
+import {PegInDerivation} from "../../src/libraries/PegInDerivation.sol";
+import {Quotes} from "../../src/libraries/Quotes.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {BtcUtils} from "@rsksmart/btc-transaction-solidity-helper/contracts/BtcUtils.sol";
 
 /// @title Base for commit-first requestPegIn tests
 /// @notice Deploys and wires a PegInContract against a real PegInAddressRegistry (seeded through
@@ -34,8 +37,12 @@ abstract contract RequestPegInTestBase is PegInTestBase {
     address internal claimer;
     address internal rskUser;
 
-    bytes32 internal constant DEFAULT_BTC_TX_HASH = keccak256("default-btc-tx");
     uint256 internal constant DEFAULT_AMOUNT = 5 ether;
+
+    /// @dev Varies the deposit transaction's input outpoint, and therefore its txid, without
+    /// touching the output being matched. Tests that need two distinct pegInIds for the same
+    /// destination and amount pass different nonces.
+    uint256 internal constant DEFAULT_TX_NONCE = 1;
 
     function setUp() public virtual {
         deployPegInContract();
@@ -88,6 +95,26 @@ abstract contract RequestPegInTestBase is PegInTestBase {
         configurations.setConfirmationTiers(tiers);
     }
 
+    /// @notice Replaces the single flat tier with a low tier up to `lowTierMaxAmount` and a high
+    /// tier above it, so tests can prove the tier is chosen by the DERIVED amount.
+    function _applyTwoTierConfiguration(
+        uint256 lowTierMaxAmount,
+        uint256 lowTierConfirmations,
+        uint256 highTierConfirmations
+    ) internal {
+        IFlyoverConfigurations.ConfirmationTier[]
+            memory tiers = new IFlyoverConfigurations.ConfirmationTier[](2);
+        tiers[0] = IFlyoverConfigurations.ConfirmationTier({
+            maxAmount: lowTierMaxAmount,
+            confirmations: lowTierConfirmations
+        });
+        tiers[1] = IFlyoverConfigurations.ConfirmationTier({
+            maxAmount: type(uint256).max,
+            confirmations: highTierConfirmations
+        });
+        configurations.setConfirmationTiers(tiers);
+    }
+
     /// @notice Deploys a second PegInContract with its dependencies left unset
     function _deployUnwiredPegInContract() internal returns (PegInContract) {
         return deployPegInContract(false);
@@ -100,6 +127,22 @@ abstract contract RequestPegInTestBase is PegInTestBase {
         bytes32 btcTxHash
     ) internal pure returns (bytes32) {
         return keccak256(abi.encodePacked(rskAddr, btcTxHash));
+    }
+
+    /// @notice Exposes BtcUtils.hashBtcTx to the memory-held fixtures. The library takes
+    /// calldata, so the tests reach it through an external self-call rather than
+    /// re-implementing the txid.
+    function hashTx(bytes calldata btcTx) external pure returns (bytes32) {
+        return BtcUtils.hashBtcTx(btcTx);
+    }
+
+    /// @notice The pegInId a claim of `btcTx` for `rskAddr` will be recorded under. The txid is
+    /// hashed out of the transaction, mirroring what the contract does.
+    function _pegInIdForTx(
+        address rskAddr,
+        bytes memory btcTx
+    ) internal view returns (bytes32) {
+        return _pegInId(rskAddr, this.hashTx(btcTx));
     }
 
     function _claimSlot(bytes32 pegInId) internal pure returns (uint256) {
@@ -156,29 +199,138 @@ abstract contract RequestPegInTestBase is PegInTestBase {
         );
     }
 
+    // ---- deposit-transaction fixtures ----
+    //
+    // requestPegIn no longer takes an amount or a txid: it reads both out of the raw deposit
+    // transaction. So every call site needs a transaction that really pays the address derived
+    // for its destination, built against the SAME inputs the contract derives with — this proxy's
+    // address, the bridge mock's powpeg script, and the testnet network flag the contract is
+    // deployed under. A test that wants a bad claim builds a bad transaction; it can no longer
+    // just pass a bad number.
+
+    /// @notice The P2SH scriptPubkey a deposit for `rskAddr` must pay, derived exactly as
+    /// PegInContract derives it.
+    function _depositPkScript(
+        address rskAddr
+    ) internal view returns (bytes memory) {
+        return
+            PegInDerivation.expectedDepositPkScript(
+                rskAddr,
+                address(pegInContract),
+                bridgeMock.getActivePowpegRedeemScript(),
+                false // deployPegInContract() deploys as testnet
+            );
+    }
+
+    /// @notice A one-input, one-output raw transaction paying `pkScript` `valueSats` satoshis.
+    /// @param nonce Mixed into the input outpoint so otherwise identical deposits get distinct
+    /// txids, and therefore distinct pegInIds.
+    function _buildTx(
+        bytes memory pkScript,
+        uint64 valueSats,
+        uint256 nonce
+    ) internal pure returns (bytes memory) {
+        bytes memory valueLe = new bytes(8);
+        uint64 v = valueSats;
+        for (uint256 i = 0; i < 8; ++i) {
+            valueLe[i] = bytes1(uint8(v & 0xFF));
+            v >>= 8;
+        }
+        return
+            abi.encodePacked(
+                hex"01000000", // version
+                hex"01", // input count
+                bytes32(nonce), // prevout txid
+                hex"00000000", // prevout index
+                hex"00", // empty scriptSig
+                hex"ffffffff", // sequence
+                hex"01", // output count
+                valueLe,
+                bytes1(uint8(pkScript.length)),
+                pkScript,
+                hex"00000000" // locktime
+            );
+    }
+
+    /// @notice A deposit transaction paying `rskAddr`'s derived address `amount` wei worth of BTC.
+    function _depositTx(
+        address rskAddr,
+        uint256 amount,
+        uint256 nonce
+    ) internal view returns (bytes memory) {
+        return _buildTx(_depositPkScript(rskAddr), _toSats(amount), nonce);
+    }
+
+    function _depositTx(
+        address rskAddr,
+        uint256 amount
+    ) internal view returns (bytes memory) {
+        return _depositTx(rskAddr, amount, DEFAULT_TX_NONCE);
+    }
+
+    /// @notice The default deposit fixture: DEFAULT_AMOUNT paid to rskUser's derived address.
+    function _defaultTx() internal view returns (bytes memory) {
+        return _depositTx(rskUser, DEFAULT_AMOUNT);
+    }
+
+    /// @notice A confirmed transaction that pays no address this protocol derives — the
+    /// "any confirmed txid" an attacker would reach for.
+    function _unrelatedTx() internal pure returns (bytes memory) {
+        // Plain P2PKH to an arbitrary hash160, 1 BTC.
+        bytes memory pkScript = abi.encodePacked(
+            hex"76a914",
+            bytes20(uint160(0xDEADBEEF)),
+            hex"88ac"
+        );
+        return _buildTx(pkScript, 100_000_000, 7);
+    }
+
+    function _toSats(uint256 amountWei) internal pure returns (uint64) {
+        require(
+            amountWei % Quotes.SAT_TO_WEI_CONVERSION == 0,
+            "fixture amount is not a whole number of satoshis"
+        );
+        return uint64(amountWei / Quotes.SAT_TO_WEI_CONVERSION);
+    }
+
     // ---- call helpers ----
 
     function _emptyBranch() internal pure returns (bytes32[] memory) {
         return new bytes32[](0);
     }
 
-    function _requestPegIn(
+    /// @notice Claims `btcTx`, which must already pay the address derived for `rskAddr`.
+    function _requestPegInTx(
         address caller,
         address rskAddr,
-        uint256 amount,
-        bytes32 btcTxHash,
+        bytes memory btcTx,
         uint256 value
     ) internal returns (bytes32) {
         vm.prank(caller);
         return
             pegInContract.requestPegIn{value: value}(
                 rskAddr,
-                amount,
-                btcTxHash,
+                btcTx,
                 "",
                 bytes32(0),
                 0,
                 _emptyBranch()
+            );
+    }
+
+    /// @notice Builds the deposit fixture for `amount` and claims it.
+    function _requestPegIn(
+        address caller,
+        address rskAddr,
+        uint256 amount,
+        uint256 value
+    ) internal returns (bytes32) {
+        return
+            _requestPegInTx(
+                caller,
+                rskAddr,
+                _depositTx(rskAddr, amount),
+                value
             );
     }
 


### PR DESCRIPTION
Closes [FLY-2575](https://rsklabs.atlassian.net/browse/FLY-2575) (S4.3, under FLY-2476).

**Base**: `feature/FLY-2521` — this rebases on the per-network placeholder work, which threads the network flag through the derivation. Retarget to `v3.0.0` once FLY-2521 merges.

## The defect

`requestPegIn` received `uint256 amount` from the caller and nothing bound it to Bitcoin. The function was given `btcTxHash`, a hash, so it could not read the deposit's value even in principle. The only BTC-side check, `getBtcTransactionConfirmations`, proves a txid sits in a block at some depth — it says nothing about who the transaction paid or how much.

That unverified number decided the confirmation tier, the service fee, and the RBTC delivered to the user.

So the reachable attack was: take any confirmed Bitcoin txid, pair it with any registered `rskAddr`, declare a dust `amount`, front that dust as `msg.value`. Every check passed. The caller became the recorded claimer under `pegInId`, the user received dust, and every honest LP was locked out by `PegInAlreadyProcessed` — deliberately the first check in the function. No deposit to Flyover had to exist. Cost was dust plus gas; the result was a permanently unservable peg-in for a real user who really did deposit.

## The change

`requestPegIn` takes the raw witness-stripped deposit transaction in place of **both** `amount` and `btcTxHash`:

```solidity
function requestPegIn(
    address rskAddr,
    bytes calldata btcTxSerialized,
    bytes calldata opReturn,
    bytes32 btcBlockHash,
    uint256 merkleBranchPath,
    bytes32[] calldata merkleBranchHashes
) external payable returns (bytes32 pegInId);
```

The txid is hashed out of those same bytes with `BtcUtils.hashBtcTx`, so the SPV proof, the peg-in id and the amount provably describe one transaction — keeping the txid as an independent input would leave them free to disagree. The contract then derives the deposit `scriptPubKey` for `rskAddr` and reads the amount off the output paying it, scaled by `10 ** 10`.

The confirmation tier, the fee, the `msg.value` fronting equality, the claim record and the `PegInRequested` event all run against that derived amount with their current semantics and error types unchanged. Event field order and indexing are untouched.

Ordered checks in `requestPegIn`, with the new one at position 4:

1. `PegInAlreadyProcessed`
2. dependencies wired
3. `AddressNotRegistered`
4. **`DepositOutputNotFound(rskAddr, btcTxHash)`** ← new
5. `InsufficientConfirmations` (tier looked up with the derived amount)
6. `IncorrectFronting` (against the derived amount minus the derived fee)

## Shared helper

`PegInAddressRegistry` no longer holds its own output-matching implementation. `expectedDepositPkScript` and `matchedDepositValue` moved into `PegInDerivation`, which already declares itself the single source of truth for the derivation, and both contracts call them. `matchedDepositValue` returns a `(value, found)` pair rather than reverting, so each contract keeps its own named error — the registry's `DepositOutputNotFound(rskAddr)`, the peg-in contract's `DepositOutputNotFound(rskAddr, btcTxHash)`.

The registry's existing derivation and registration tests pass unchanged.

## The two decisions the ticket left open

**Where the helper lives** — `PegInDerivation`. The matching step is the consumer-side half of the same pipeline the library already owns, every step is already a separate function there, and the library's own doc comment states the byte-for-byte-agreement rule the matching has to honour.

**Split deposits** — **first match, not the sum.** Unchanged from the registry, so the value that gates registration and the value that fixes the peg-in amount stay identical; changing to a sum would have to change both call sites at once. First match understates a split deposit, and that direction is the safe one: the claimer fronts less than the bridge will release, so settlement covers the claim.

## Tests

31 tests across the migrated suites, all green; full unit run is 643 passing.

New coverage:

- A confirmed transaction unrelated to Flyover reverts `DepositOutputNotFound` — the case that closes the dust lockout.
- A real Flyover deposit derived for a *different* destination reverts `DepositOutputNotFound` (mismatched transaction).
- End to end on the original defect: the dust claim is rejected and the real depositor is served afterwards under the same `pegInId` the attacker tried to burn.
- A 50-RBTC deposit presented with only the low tier's confirmations reverts `InsufficientConfirmations`; the same depth still serves a deposit that really is small.
- Understating and overstating `msg.value` are separate `IncorrectFronting` cases, plus dust fronted against a real deposit.
- Satoshi-to-wei pinned to a literal fixture (123,456,789 sats == 1.23456789 RBTC), so an off-by-a-power-of-ten cannot pass CI.
- Atomicity: a failed deposit match writes no claim and delivers nothing.
- Ordering: `PegInAlreadyProcessed` still wins over the deposit match, since only the txid feeds the id.

Test fixtures now build real deposit transactions paying the address derived for their destination. A test that wants a bad claim has to build a bad transaction; it can no longer just pass a bad number.

## Notes for review

- **Deployment wiring.** `PegInContract` derives with `address(this)`, the live powpeg script, and its own `_mainnet` flag; the registry derives with its stored `pegInContract` and `isMainnet`. If a deployment sets those to disagree, every claim reverts `DepositOutputNotFound` — fail-closed, but a total outage. Neither `getPegInContract()` nor `getBridge()` is on the frozen `IPegInAddressRegistry`, so asserting agreement in `setPegInDependencies` needs a second frozen-interface amendment. Worth a follow-up ticket; not taken here.
- **Gas on the claim race.** The txid is hashed before the already-processed check, because the id is keyed on it. The loser of a race now pays one double-SHA256 over the transaction before reverting. Nothing else moved ahead of that check.
- **Not in scope.** `requestPegIn` still enforces neither `minAmount` nor `maxAmount` from `FlyoverConfigurations` (exceptions A4 and A7). Real, but it only becomes meaningful now that the amount is trustworthy, so it should land after this. No ticket exists yet.

## Cross-lane

- **LPS (FLY-2507)** — this is an ABI break. The LPS already holds the raw transaction for its settlement call, so it is a call-site change, not new plumbing. The contract side is asserted here; the caller update is asserted by FLY-2507. **Announce before merging.**
- **Spec** — the walkthrough step 11 amendment and the S0 frozen-signature amendment (S0.2, not yet created) belong to the doc owner and gate this merge. `IPegInCommitFirst`'s NatSpec is updated here to match.
