### PR TITLE
feat(FLY-2575): derive the peg-in amount from the BTC deposit transaction

### DIFF
--- a/src/FlyoverConfigurations.sol
+++ b/src/FlyoverConfigurations.sol
@@ -49,8 +49,14 @@ contract FlyoverConfigurations is
     uint256 public constant FEE_PERCENTAGE_DENOMINATOR = 10_000;
 
     /// @notice 1 satoshi expressed in wei; fees are rounded down to a satoshi boundary so on-chain
-    /// fees agree with the bridge. Mirrors `Quotes.SAT_TO_WEI_CONVERSION`.
-    uint256 public constant SAT_TO_WEI_CONVERSION = 10 ** 10;
+    /// fees agree with the bridge.
+    /// @dev The public home of the scale for the commit-first path: this getter is what the SDK
+    /// and every LPS read. The value itself is defined once in {Flyover} so the peg-in contract
+    /// can share it without an external call — see that declaration for why it cannot live here.
+    /// `Quotes.SAT_TO_WEI_CONVERSION` is the legacy quote path's own copy, left alone because that
+    /// path's ABI is frozen; `test/configurations/Fee.t.sol` asserts the two agree so they cannot
+    /// drift. `PegOutContract` holds a third, private copy.
+    uint256 public constant SAT_TO_WEI_CONVERSION = Flyover.SAT_TO_WEI_CONVERSION;
 
     // ERC-7201: keccak256(abi.encode(uint256(keccak256("rsk.flyover.FlyoverConfigurations")) - 1)) &
     // ~bytes32(uint256(0xff))

--- a/src/PegInAddressRegistry.sol
+++ b/src/PegInAddressRegistry.sol
@@ -206,33 +206,33 @@ contract PegInAddressRegistry is
     }
 
     /// @notice Derives the on-chain P2SH scriptPubkey for a deposit output match.
+    /// @dev Reads the live powpeg script and hands the composition to
+    /// {PegInDerivation-expectedDepositPkScript}. The registry holds no derivation of its own:
+    /// `PegInContract.requestPegIn` matches deposits against that same helper, so the script that
+    /// gates registration is the script that fixes the peg-in amount.
     function _expectedDepositPkScript(address rskAddr, address pegInContract, IBridge bridge_)
         private
         view
         returns (bytes memory)
     {
-        bytes memory powpegRedeemScript = bridge_.getActivePowpegRedeemScript();
-        bytes32 derivationValue = PegInDerivation.derivationValue(rskAddr, pegInContract);
-        bytes memory redeemScript = PegInDerivation.flyoverRedeemScript(derivationValue, powpegRedeemScript);
-        bytes20 scriptHash = PegInDerivation.flyoverScriptHash(redeemScript);
-        return PegInDerivation.p2shScriptPubkey(scriptHash);
+        return PegInDerivation.expectedDepositPkScript(
+            rskAddr, pegInContract, bridge_.getActivePowpegRedeemScript()
+        );
     }
 
     /// @notice Returns the satoshi value of the output paying the derived deposit script.
+    /// @dev Thin wrapper over {PegInDerivation-matchedDepositValue} that turns the library's
+    /// found flag into the registry's own named error.
     function _matchedDepositValue(bytes calldata btcTxSerialized, bytes memory expectedPkScript, address rskAddr)
         private
         pure
         returns (uint64 depositValue)
     {
-        BtcUtils.TxRawOutput[] memory outputs = BtcUtils.getOutputs(btcTxSerialized);
-        bytes32 expectedHash = keccak256(expectedPkScript);
-        uint256 outputCount = outputs.length;
-        for (uint256 i = 0; i < outputCount; ++i) {
-            if (keccak256(outputs[i].pkScript) == expectedHash) {
-                return outputs[i].value;
-            }
+        bool found;
+        (depositValue, found) = PegInDerivation.matchedDepositValue(btcTxSerialized, expectedPkScript);
+        if (!found) {
+            revert DepositOutputNotFound(rskAddr);
         }
-        revert DepositOutputNotFound(rskAddr);
     }
 
     /// @notice Derives the BTC deposit address for an RSK address against a supplied powpeg script.

--- a/src/PegInAddressRegistry.sol
+++ b/src/PegInAddressRegistry.sol
@@ -10,6 +10,7 @@ import {EmergencyPause} from "./EmergencyPause/EmergencyPause.sol";
 import {IBridge} from "./interfaces/IBridge.sol";
 import {IPauseRegistry} from "./interfaces/IPauseRegistry.sol";
 import {IPegInAddressRegistry} from "./interfaces/IPegInAddressRegistry.sol";
+import {BtcTransactionReader} from "./libraries/BtcTransactionReader.sol";
 import {Flyover} from "./libraries/Flyover.sol";
 import {PegInDerivation} from "./libraries/PegInDerivation.sol";
 
@@ -222,7 +223,7 @@ contract PegInAddressRegistry is
 
     /// @notice Returns the satoshi value of the first output paying the derived deposit script,
     /// reverting when the transaction has none.
-    /// @dev Thin wrapper over {PegInDerivation-findFirstBtcOutputPaying} that turns the library's
+    /// @dev Thin wrapper over {BtcTransactionReader-findFirstOutputPaying} that turns the library's
     /// found flag into the registry's own named error. Here the value is only compared against
     /// MIN_DEPOSIT_SATS, so the library's first-match rule undercounts in the conservative
     /// direction; `PegInContract` uses the same helper for the peg-in amount, where it does not.
@@ -232,7 +233,7 @@ contract PegInAddressRegistry is
         returns (uint64 depositValue)
     {
         bool found;
-        (depositValue, found) = PegInDerivation.findFirstBtcOutputPaying(btcTxSerialized, pkScript);
+        (depositValue, found) = BtcTransactionReader.findFirstOutputPaying(btcTxSerialized, pkScript);
         if (!found) {
             revert DepositOutputNotFound(rskAddr);
         }

--- a/src/PegInAddressRegistry.sol
+++ b/src/PegInAddressRegistry.sol
@@ -122,8 +122,8 @@ contract PegInAddressRegistry is
         address pegInContract = $.pegInContract;
         if (pegInContract == address(0)) revert PegInContractNotSet();
 
-        bytes memory expectedPkScript = _expectedDepositPkScript(rskAddr, pegInContract, $.bridge);
-        uint64 depositValue = _matchedDepositValue(btcTxSerialized, expectedPkScript, rskAddr);
+        bytes memory expectedPkScript = _depositPkScript(rskAddr, pegInContract, $.bridge);
+        uint64 depositValue = _requireDepositValue(btcTxSerialized, expectedPkScript, rskAddr);
 
         if (depositValue < MIN_DEPOSIT_SATS) {
             revert DepositBelowMinimum(depositValue, MIN_DEPOSIT_SATS);
@@ -207,29 +207,32 @@ contract PegInAddressRegistry is
 
     /// @notice Derives the on-chain P2SH scriptPubkey for a deposit output match.
     /// @dev Reads the live powpeg script and hands the composition to
-    /// {PegInDerivation-expectedDepositPkScript}. The registry holds no derivation of its own:
+    /// {PegInDerivation-depositPkScript}. The registry holds no derivation of its own:
     /// `PegInContract.requestPegIn` matches deposits against that same helper, so the script that
     /// gates registration is the script that fixes the peg-in amount.
-    function _expectedDepositPkScript(address rskAddr, address pegInContract, IBridge bridge_)
+    function _depositPkScript(address rskAddr, address pegInContract, IBridge bridge_)
         private
         view
         returns (bytes memory)
     {
-        return PegInDerivation.expectedDepositPkScript(
+        return PegInDerivation.depositPkScript(
             rskAddr, pegInContract, bridge_.getActivePowpegRedeemScript()
         );
     }
 
-    /// @notice Returns the satoshi value of the output paying the derived deposit script.
-    /// @dev Thin wrapper over {PegInDerivation-matchedDepositValue} that turns the library's
-    /// found flag into the registry's own named error.
-    function _matchedDepositValue(bytes calldata btcTxSerialized, bytes memory expectedPkScript, address rskAddr)
+    /// @notice Returns the satoshi value of the first output paying the derived deposit script,
+    /// reverting when the transaction has none.
+    /// @dev Thin wrapper over {PegInDerivation-findFirstBtcOutputPaying} that turns the library's
+    /// found flag into the registry's own named error. Here the value is only compared against
+    /// MIN_DEPOSIT_SATS, so the library's first-match rule undercounts in the conservative
+    /// direction; `PegInContract` uses the same helper for the peg-in amount, where it does not.
+    function _requireDepositValue(bytes calldata btcTxSerialized, bytes memory pkScript, address rskAddr)
         private
         pure
         returns (uint64 depositValue)
     {
         bool found;
-        (depositValue, found) = PegInDerivation.matchedDepositValue(btcTxSerialized, expectedPkScript);
+        (depositValue, found) = PegInDerivation.findFirstBtcOutputPaying(btcTxSerialized, pkScript);
         if (!found) {
             revert DepositOutputNotFound(rskAddr);
         }

--- a/src/PegInAddressRegistry.sol
+++ b/src/PegInAddressRegistry.sol
@@ -123,6 +123,12 @@ contract PegInAddressRegistry is
         address pegInContract = $.pegInContract;
         if (pegInContract == address(0)) revert PegInContractNotSet();
 
+        // Before the bytes are read or hashed: getOutputs reads the same outputs from either
+        // serialization, but hashBtcTx returns a wtxid for the witness form and the confirmation
+        // proof below is against a txid merkle tree. See
+        // {BtcTransactionReader-WitnessSerializedTxNotAccepted}.
+        BtcTransactionReader.requireWitnessStripped(btcTxSerialized);
+
         bytes memory expectedPkScript = _depositPkScript(rskAddr, pegInContract, $.bridge, $.isMainnet);
         uint64 depositValue = _requireDepositValue(btcTxSerialized, expectedPkScript, rskAddr);
 

--- a/src/PegInContract.sol
+++ b/src/PegInContract.sol
@@ -453,8 +453,10 @@ contract PegInContract is
 
     /// @notice Reads the peg-in amount out of the deposit transaction
     /// @dev The contract derives the deposit scriptPubkey for rskAddr and takes the value of the
-    /// output paying it, through the same {PegInDerivation} helpers the registry uses at
-    /// registration. Both the derivation inputs (this proxy's address and the live powpeg script)
+    /// FIRST output paying it, through the same {PegInDerivation} helpers the registry uses at
+    /// registration. See {PegInDerivation-findFirstBtcOutputPaying} for why first-match and not the
+    /// sum, and why that is the open question here rather than in the registry.
+    /// Both the derivation inputs (this proxy's address and the live powpeg script)
     /// and the matched output come from state or from the SPV-proven bytes, so there is no
     /// argument a caller can move to change the answer.
     ///
@@ -471,10 +473,11 @@ contract PegInContract is
         view
         returns (uint256)
     {
-        bytes memory expectedPkScript = PegInDerivation.expectedDepositPkScript(
+        bytes memory expectedPkScript = PegInDerivation.depositPkScript(
             rskAddr, address(this), _bridge.getActivePowpegRedeemScript()
         );
-        (uint64 depositSats, bool found) = PegInDerivation.matchedDepositValue(btcTxSerialized, expectedPkScript);
+        (uint64 depositSats, bool found) =
+            PegInDerivation.findFirstBtcOutputPaying(btcTxSerialized, expectedPkScript);
         if (!found) {
             revert DepositOutputNotFound(rskAddr, btcTxHash);
         }

--- a/src/PegInContract.sol
+++ b/src/PegInContract.sol
@@ -335,6 +335,9 @@ contract PegInContract is
         uint256 merkleBranchPath,
         bytes32[] calldata merkleBranchHashes
     ) external payable nonReentrant whenNotHardPaused override returns (bytes32 pegInId) {
+        // Before the hash, never after: hashBtcTx would return a wtxid for the witness form, and
+        // pegInId is derived from it. See {BtcTransactionReader-WitnessSerializedTxNotAccepted}.
+        BtcTransactionReader.requireWitnessStripped(btcTxSerialized);
         bytes32 btcTxHash = BtcUtils.hashBtcTx(btcTxSerialized);
         pegInId = keccak256(abi.encodePacked(rskAddr, btcTxHash));
         if (_pegInClaims[pegInId].claimer != address(0)) {

--- a/src/PegInContract.sol
+++ b/src/PegInContract.sol
@@ -16,6 +16,7 @@ import {IPauseRegistry} from "./interfaces/IPauseRegistry.sol";
 import {IPegIn} from "./interfaces/IPegIn.sol";
 import {IPegInAddressRegistry} from "./interfaces/IPegInAddressRegistry.sol";
 import {IPegInCommitFirst} from "./interfaces/IPegInCommitFirst.sol";
+import {BtcTransactionReader} from "./libraries/BtcTransactionReader.sol";
 import {Flyover} from "./libraries/Flyover.sol";
 import {PegInDerivation} from "./libraries/PegInDerivation.sol";
 import {Quotes} from "./libraries/Quotes.sol";
@@ -455,8 +456,9 @@ contract PegInContract is
     /// @dev Two different operations, and only the first is a derivation: the deposit
     /// scriptPubkey for rskAddr is DERIVED (a formula over this proxy's address and the live
     /// powpeg script), and the amount is then READ from the FIRST output paying that script.
-    /// Both go through the {PegInDerivation} helpers the registry uses at registration. See
-    /// {PegInDerivation-findFirstBtcOutputPaying} for why first-match and not the sum, and why
+    /// Both go through the same helpers the registry uses at registration —
+    /// {PegInDerivation-depositPkScript} for the script, {BtcTransactionReader} for the lookup. See
+    /// {BtcTransactionReader-findFirstOutputPaying} for why first-match and not the sum, and why
     /// that is the open question here rather than in the registry.
     /// The derivation inputs come from state and the matched output from the SPV-proven bytes,
     /// so there is no argument a caller can move to change the answer.
@@ -478,7 +480,7 @@ contract PegInContract is
             rskAddr, address(this), _bridge.getActivePowpegRedeemScript()
         );
         (uint64 depositSats, bool found) =
-            PegInDerivation.findFirstBtcOutputPaying(btcTxSerialized, pkScript);
+            BtcTransactionReader.findFirstOutputPaying(btcTxSerialized, pkScript);
         if (!found) {
             revert DepositOutputNotFound(rskAddr, btcTxHash);
         }

--- a/src/PegInContract.sol
+++ b/src/PegInContract.sol
@@ -17,6 +17,7 @@ import {IPegIn} from "./interfaces/IPegIn.sol";
 import {IPegInAddressRegistry} from "./interfaces/IPegInAddressRegistry.sol";
 import {IPegInCommitFirst} from "./interfaces/IPegInCommitFirst.sol";
 import {Flyover} from "./libraries/Flyover.sol";
+import {PegInDerivation} from "./libraries/PegInDerivation.sol";
 import {Quotes} from "./libraries/Quotes.sol";
 import {SignatureValidator} from "./libraries/SignatureValidator.sol";
 
@@ -327,13 +328,13 @@ contract PegInContract is
     /// @inheritdoc IPegInCommitFirst
     function requestPegIn(
         address rskAddr,
-        uint256 amount,
-        bytes32 btcTxHash,
+        bytes calldata btcTxSerialized,
         bytes calldata opReturn,
         bytes32 btcBlockHash,
         uint256 merkleBranchPath,
         bytes32[] calldata merkleBranchHashes
     ) external payable nonReentrant whenNotHardPaused override returns (bytes32 pegInId) {
+        bytes32 btcTxHash = BtcUtils.hashBtcTx(btcTxSerialized);
         pegInId = keccak256(abi.encodePacked(rskAddr, btcTxHash));
         if (_pegInClaims[pegInId].claimer != address(0)) {
             revert PegInAlreadyProcessed(pegInId);
@@ -343,6 +344,7 @@ contract PegInContract is
         if (!_pegInAddressRegistry.isRegistered(rskAddr)) {
             revert AddressNotRegistered(rskAddr);
         }
+        uint256 amount = _derivePegInAmount(rskAddr, btcTxSerialized, btcTxHash);
         _requirePegInConfirmations(amount, btcTxHash, btcBlockHash, merkleBranchPath, merkleBranchHashes);
 
         uint256 fee = _configurations.calculatePegInFee(amount);
@@ -447,6 +449,36 @@ contract PegInContract is
     function _requirePegInDepsSet() private view {
         if (address(_pegInAddressRegistry) == address(0)) revert PegInAddressRegistryNotSet();
         if (address(_configurations) == address(0)) revert FlyoverConfigurationsNotSet();
+    }
+
+    /// @notice Reads the peg-in amount out of the deposit transaction
+    /// @dev The contract derives the deposit scriptPubkey for rskAddr and takes the value of the
+    /// output paying it, through the same {PegInDerivation} helpers the registry uses at
+    /// registration. Both the derivation inputs (this proxy's address and the live powpeg script)
+    /// and the matched output come from state or from the SPV-proven bytes, so there is no
+    /// argument a caller can move to change the answer.
+    ///
+    /// The powpeg script is read fresh from the bridge on every call, so a federation change
+    /// rotates the expected script here exactly as it rotates the issued address. In-flight
+    /// deposits to a pre-rotation address stop matching, which is the drain-then-rotate cost
+    /// PegInDerivation documents, not a new failure mode.
+    /// @param rskAddr The RSK destination address of the peg-in
+    /// @param btcTxSerialized The witness-stripped raw deposit transaction
+    /// @param btcTxHash The txid hashed from btcTxSerialized, for the revert reason
+    /// @return The gross peg-in amount in wei
+    function _derivePegInAmount(address rskAddr, bytes calldata btcTxSerialized, bytes32 btcTxHash)
+        private
+        view
+        returns (uint256)
+    {
+        bytes memory expectedPkScript = PegInDerivation.expectedDepositPkScript(
+            rskAddr, address(this), _bridge.getActivePowpegRedeemScript()
+        );
+        (uint64 depositSats, bool found) = PegInDerivation.matchedDepositValue(btcTxSerialized, expectedPkScript);
+        if (!found) {
+            revert DepositOutputNotFound(rskAddr, btcTxHash);
+        }
+        return uint256(depositSats) * Quotes.SAT_TO_WEI_CONVERSION;
     }
 
     /// @notice Reverts unless Bridge confirmations meet the configured tier for amount

--- a/src/PegInContract.sol
+++ b/src/PegInContract.sol
@@ -344,7 +344,7 @@ contract PegInContract is
         if (!_pegInAddressRegistry.isRegistered(rskAddr)) {
             revert AddressNotRegistered(rskAddr);
         }
-        uint256 amount = _derivePegInAmount(rskAddr, btcTxSerialized, btcTxHash);
+        uint256 amount = _readPegInAmount(rskAddr, btcTxSerialized, btcTxHash);
         _requirePegInConfirmations(amount, btcTxHash, btcBlockHash, merkleBranchPath, merkleBranchHashes);
 
         uint256 fee = _configurations.calculatePegInFee(amount);
@@ -452,13 +452,14 @@ contract PegInContract is
     }
 
     /// @notice Reads the peg-in amount out of the deposit transaction
-    /// @dev The contract derives the deposit scriptPubkey for rskAddr and takes the value of the
-    /// FIRST output paying it, through the same {PegInDerivation} helpers the registry uses at
-    /// registration. See {PegInDerivation-findFirstBtcOutputPaying} for why first-match and not the
-    /// sum, and why that is the open question here rather than in the registry.
-    /// Both the derivation inputs (this proxy's address and the live powpeg script)
-    /// and the matched output come from state or from the SPV-proven bytes, so there is no
-    /// argument a caller can move to change the answer.
+    /// @dev Two different operations, and only the first is a derivation: the deposit
+    /// scriptPubkey for rskAddr is DERIVED (a formula over this proxy's address and the live
+    /// powpeg script), and the amount is then READ from the FIRST output paying that script.
+    /// Both go through the {PegInDerivation} helpers the registry uses at registration. See
+    /// {PegInDerivation-findFirstBtcOutputPaying} for why first-match and not the sum, and why
+    /// that is the open question here rather than in the registry.
+    /// The derivation inputs come from state and the matched output from the SPV-proven bytes,
+    /// so there is no argument a caller can move to change the answer.
     ///
     /// The powpeg script is read fresh from the bridge on every call, so a federation change
     /// rotates the expected script here exactly as it rotates the issued address. In-flight
@@ -468,16 +469,16 @@ contract PegInContract is
     /// @param btcTxSerialized The witness-stripped raw deposit transaction
     /// @param btcTxHash The txid hashed from btcTxSerialized, for the revert reason
     /// @return The gross peg-in amount in wei
-    function _derivePegInAmount(address rskAddr, bytes calldata btcTxSerialized, bytes32 btcTxHash)
+    function _readPegInAmount(address rskAddr, bytes calldata btcTxSerialized, bytes32 btcTxHash)
         private
         view
         returns (uint256)
     {
-        bytes memory expectedPkScript = PegInDerivation.depositPkScript(
+        bytes memory pkScript = PegInDerivation.depositPkScript(
             rskAddr, address(this), _bridge.getActivePowpegRedeemScript()
         );
         (uint64 depositSats, bool found) =
-            PegInDerivation.findFirstBtcOutputPaying(btcTxSerialized, expectedPkScript);
+            PegInDerivation.findFirstBtcOutputPaying(btcTxSerialized, pkScript);
         if (!found) {
             revert DepositOutputNotFound(rskAddr, btcTxHash);
         }

--- a/src/PegInContract.sol
+++ b/src/PegInContract.sol
@@ -482,7 +482,7 @@ contract PegInContract is
         if (!found) {
             revert DepositOutputNotFound(rskAddr, btcTxHash);
         }
-        return uint256(depositSats) * Quotes.SAT_TO_WEI_CONVERSION;
+        return uint256(depositSats) * Flyover.SAT_TO_WEI_CONVERSION;
     }
 
     /// @notice Reverts unless Bridge confirmations meet the configured tier for amount

--- a/src/interfaces/IPegInCommitFirst.sol
+++ b/src/interfaces/IPegInCommitFirst.sol
@@ -19,7 +19,8 @@ interface IPegInCommitFirst {
     /// @param pegInId The id under which the claim was recorded
     /// @param claimer The account that fronted the RBTC and holds the claim
     /// @param rskAddr The RSK destination address that received the funds
-    /// @param amount The gross peg-in amount, in wei
+    /// @param amount The gross peg-in amount, in wei — the deposit output's satoshi value
+    /// scaled by 10**10, never a caller-supplied figure
     /// @param netToUser The amount delivered to the user (amount minus fee), in wei
     /// @param callSuccess Whether the delivery call succeeded (always true this sprint)
     event PegInRequested(
@@ -60,8 +61,10 @@ interface IPegInCommitFirst {
     );
 
     /// @notice Reverts requestPegIn when the peg-in already has a claimer
-    /// @dev First check in the function, so the loser of a claim race burns minimal gas.
-    /// Walkthrough anchors: decisions D10-D11, exception A1.
+    /// @dev First check in the function, so the loser of a claim race burns minimal gas. The
+    /// deposit txid is hashed out of the raw transaction before it, because the id is keyed on
+    /// that txid; nothing else runs ahead of it. Walkthrough anchors: decisions D10-D11,
+    /// exception A1.
     /// @param pegInId The id of the already-claimed peg-in
     error PegInAlreadyProcessed(bytes32 pegInId);
 
@@ -70,9 +73,22 @@ interface IPegInCommitFirst {
     /// @param rskAddr The unregistered RSK destination address
     error AddressNotRegistered(address rskAddr);
 
+    /// @notice Reverts requestPegIn when the presented transaction has no output paying the
+    /// deposit address derived from the destination address
+    /// @dev The check that makes the peg-in amount a derived value instead of a declared one.
+    /// Without it any confirmed txid pairs with any registered destination, so a dust claim
+    /// locks the real depositor out under PegInAlreadyProcessed. Same rule the registry
+    /// enforces at registration, through the same shared helper.
+    /// Walkthrough anchors: step 11, exception A1.
+    /// @param rskAddr The destination address whose derived deposit output was not found
+    /// @param btcTxHash The hash of the presented transaction
+    error DepositOutputNotFound(address rskAddr, bytes32 btcTxHash);
+
     /// @notice Reverts requestPegIn when the deposit lacks the confirmations the
     /// configuration requires for its amount
-    /// @dev Walkthrough anchor: step 11.
+    /// @dev The amount driving the tier lookup is the one read off the deposit output, so
+    /// understating a large deposit to buy the low tier is not expressible.
+    /// Walkthrough anchor: step 11.
     /// @param have The confirmations the bridge reports
     /// @param required The confirmations the active configuration requires
     error InsufficientConfirmations(uint256 have, uint256 required);
@@ -86,25 +102,29 @@ interface IPegInCommitFirst {
 
     /// @notice Claims a confirmed BTC deposit by fronting the net amount in RBTC, which is
     /// delivered to the destination address in the same transaction
-    /// @dev Payable: msg.value must equal amount minus the fee. The claim record stores the
-    /// claimer, the fronted amount, and the fee at claim time, because the configuration can
-    /// change before settlement pays the claimer back (~17 hours later). The opReturn
+    /// @dev Takes the raw deposit transaction, not an amount and not a txid. The gross amount
+    /// is READ from the output paying the address derived for rskAddr, and the txid is hashed
+    /// from the same bytes, so the SPV proof, the peg-in id and the amount provably describe
+    /// one transaction. Nothing about the deposit's value is caller-supplied.
+    ///
+    /// Payable: msg.value must equal the derived amount minus the fee. The claim record stores
+    /// the claimer, the fronted amount, and the fee at claim time, because the configuration
+    /// can change before settlement pays the claimer back (~17 hours later). The opReturn
     /// argument is accepted and ignored this sprint (plain transfers only; contract-call
-    /// delivery lands in sprint 2). Walkthrough anchors: step 11 (the five checks), step 12,
+    /// delivery lands in sprint 2). Walkthrough anchors: step 11 (the checks), step 12,
     /// "Why record the claim at requestPegIn time?", decisions D9-D11.
     /// @param rskAddr The RSK destination address of the peg-in
-    /// @param amount The gross peg-in amount, in wei
-    /// @param btcTxHash The hash of the BTC deposit transaction
+    /// @param btcTxSerialized The witness-stripped raw BTC deposit transaction
     /// @param opReturn The OP_RETURN payload of the deposit, if any (ignored this sprint)
     /// @param btcBlockHash The hash of the Bitcoin block containing the deposit
     /// @param merkleBranchPath The path bitmap of the merkle branch proving inclusion
     /// @param merkleBranchHashes The hashes of the merkle branch proving inclusion
     /// @return pegInId The id under which the claim was recorded:
-    /// keccak256(rskAddr ++ btcTxHash), the same id resolvePegIn re-derives at settlement
+    /// keccak256(rskAddr ++ btcTxHash), with btcTxHash hashed from btcTxSerialized — the same
+    /// id resolvePegIn re-derives at settlement
     function requestPegIn(
         address rskAddr,
-        uint256 amount,
-        bytes32 btcTxHash,
+        bytes calldata btcTxSerialized,
         bytes calldata opReturn,
         bytes32 btcBlockHash,
         uint256 merkleBranchPath,

--- a/src/interfaces/IPegInCommitFirst.sol
+++ b/src/interfaces/IPegInCommitFirst.sol
@@ -75,7 +75,8 @@ interface IPegInCommitFirst {
 
     /// @notice Reverts requestPegIn when the presented transaction has no output paying the
     /// deposit address derived from the destination address
-    /// @dev The check that makes the peg-in amount a derived value instead of a declared one.
+    /// @dev The check that makes the peg-in amount a value read off the deposit instead of one
+    /// declared by the caller.
     /// Without it any confirmed txid pairs with any registered destination, so a dust claim
     /// locks the real depositor out under PegInAlreadyProcessed. Same rule the registry
     /// enforces at registration, through the same shared helper.
@@ -107,7 +108,8 @@ interface IPegInCommitFirst {
     /// from the same bytes, so the SPV proof, the peg-in id and the amount provably describe
     /// one transaction. Nothing about the deposit's value is caller-supplied.
     ///
-    /// Payable: msg.value must equal the derived amount minus the fee. The claim record stores
+    /// Payable: msg.value must equal the amount read from the deposit minus the fee. The claim
+    /// record stores
     /// the claimer, the fronted amount, and the fee at claim time, because the configuration
     /// can change before settlement pays the claimer back (~17 hours later). The opReturn
     /// argument is accepted and ignored this sprint (plain transfers only; contract-call

--- a/src/libraries/BtcTransactionReader.sol
+++ b/src/libraries/BtcTransactionReader.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {BtcUtils} from "@rsksmart/btc-transaction-solidity-helper/contracts/BtcUtils.sol";
+
+/// @title BtcTransactionReader
+/// @notice Reads values out of a serialized Bitcoin transaction. No derivation, no script math:
+/// every function here takes bytes that already exist and looks something up in them.
+/// @dev Separate from {PegInDerivation} on purpose. That library answers "which script should a
+/// deposit carry", which is a formula; this one answers "what does this transaction actually pay",
+/// which is a lookup. The two change for different reasons — a derivation change rotates every
+/// issued address, an output-matching change does not — and keeping them apart means neither
+/// reads as the other.
+///
+/// It stays a library rather than a private function on each consumer because both
+/// `PegInAddressRegistry` (gating registration on a minimum deposit) and
+/// `PegInContract.requestPegIn` (fixing the peg-in amount) must apply the SAME matching rule. Two
+/// copies of the loop could drift, and a drift there means an address registers against one value
+/// and settles against another.
+library BtcTransactionReader {
+    /// @notice Searches the outputs of `btcTxSerialized` for the FIRST one locked by `pkScript`
+    /// and returns its satoshi value.
+    /// @dev A search, not an accessor: the `found` flag is the failure mode, and both call sites
+    /// turn it into their own named error (a library revert would flatten the two into one).
+    ///
+    /// FIRST match, not the sum of every matching output. A deposit split across several outputs
+    /// to the same derived address therefore counts only its first output, which UNDERSTATES the
+    /// deposit — the name says `First` so no caller mistakes this for the amount paid. The rule is
+    /// inherited from the registry, where the value is only a minimum-deposit gate and
+    /// undercounting is conservative. `PegInContract.requestPegIn` uses it as the peg-in AMOUNT,
+    /// where undercounting silently drops the user's remaining outputs, so summing is the likely
+    /// correct rule there; it is not applied yet because the two call sites must move together and
+    /// because the reconciling side (`resolvePegIn`, and whether the RSK bridge sums outputs to the
+    /// derivation address) is not implemented. Revisit with settlement.
+    /// @param btcTxSerialized The witness-stripped raw transaction
+    /// @param pkScript The scriptPubkey to search for, from {PegInDerivation-depositPkScript}
+    /// @return value The matched output's value in satoshis, 0 when no output matched
+    /// @return found Whether any output was locked by `pkScript`
+    function findFirstOutputPaying(bytes calldata btcTxSerialized, bytes memory pkScript)
+        internal
+        pure
+        returns (uint64 value, bool found)
+    {
+        BtcUtils.TxRawOutput[] memory outputs = BtcUtils.getOutputs(btcTxSerialized);
+        bytes32 pkScriptHash = keccak256(pkScript);
+        uint256 outputCount = outputs.length;
+        for (uint256 i = 0; i < outputCount; ++i) {
+            if (keccak256(outputs[i].pkScript) == pkScriptHash) {
+                return (outputs[i].value, true);
+            }
+        }
+        return (0, false);
+    }
+}

--- a/src/libraries/BtcTransactionReader.sol
+++ b/src/libraries/BtcTransactionReader.sol
@@ -4,8 +4,9 @@ pragma solidity 0.8.25;
 import {BtcUtils} from "@rsksmart/btc-transaction-solidity-helper/contracts/BtcUtils.sol";
 
 /// @title BtcTransactionReader
-/// @notice Reads values out of a serialized Bitcoin transaction. No derivation, no script math:
-/// every function here takes bytes that already exist and looks something up in them.
+/// @notice Reads serialized Bitcoin transactions — the values inside them, and which serialization
+/// they are. No derivation, no script math: every function here takes bytes that already exist and
+/// inspects them.
 /// @dev Separate from {PegInDerivation} on purpose. That library answers "which script should a
 /// deposit carry", which is a formula; this one answers "what does this transaction actually pay",
 /// which is a lookup. The two change for different reasons — a derivation change rotates every
@@ -18,6 +19,43 @@ import {BtcUtils} from "@rsksmart/btc-transaction-solidity-helper/contracts/BtcU
 /// copies of the loop could drift, and a drift there means an address registers against one value
 /// and settles against another.
 library BtcTransactionReader {
+    /// @notice Thrown when raw transaction bytes are too short to classify as a transaction at all.
+    /// @dev Guards the marker+flag read in {requireWitnessStripped} so malformed input reverts with
+    /// a reason instead of panicking out of bounds.
+    error InvalidBtcTransaction();
+
+    /// @notice Thrown when a caller supplies the BIP144 (witness-included) serialization of a
+    /// transaction where the witness-stripped form is required.
+    /// @dev DELIBERATE and CURRENTLY TOTAL: Flyover registers peg-ins witness-stripped, because the
+    /// LPS reads deposits with `GetRawTransaction`, which returns the non-witness form. Both
+    /// serializations of one segwit transaction carry the same outputs but hash differently (txid vs
+    /// wtxid), so accepting both would let one deposit present under two identities.
+    ///
+    /// Supporting the witness form is not a matter of relaxing this check: it needs
+    /// `registerBtcCoinbaseTransaction` and the witness merkle root. Whoever does that work must
+    /// revisit this guard rather than delete it.
+    error WitnessSerializedTxNotAccepted();
+
+    /// @notice Reverts unless `btcTxSerialized` is the witness-stripped serialization.
+    /// @dev MUST be called before hashing caller-supplied transaction bytes. `BtcUtils.hashBtcTx`
+    /// double-sha256s whatever it is handed, so it returns a wtxid for the witness form; every
+    /// identity Flyover derives from a transaction hash (`pegInId`, the SPV proof) assumes a txid.
+    /// `BtcUtils.getOutputs` skips the marker+flag and reads the same outputs from both forms, so
+    /// nothing downstream notices the difference on its own.
+    ///
+    /// The discrimination is exact in both directions. A BIP144 transaction always carries
+    /// `00 01` at offsets 4 and 5, so no witness serialization slips through. In the legacy
+    /// encoding offset 4 is the input-count compactSize, which is never `0x00` because a
+    /// transaction with no inputs is invalid — that is why BIP144 chose `0x00` as the marker — so
+    /// no valid witness-stripped transaction is rejected.
+    /// @param btcTxSerialized The raw transaction bytes to classify
+    function requireWitnessStripped(bytes calldata btcTxSerialized) internal pure {
+        if (btcTxSerialized.length < 6) revert InvalidBtcTransaction();
+        if (btcTxSerialized[4] == 0x00 && btcTxSerialized[5] == 0x01) {
+            revert WitnessSerializedTxNotAccepted();
+        }
+    }
+
     /// @notice Searches the outputs of `btcTxSerialized` for the FIRST one locked by `pkScript`
     /// and returns its satoshi value.
     /// @dev A search, not an accessor: the `found` flag is the failure mode, and both call sites

--- a/src/libraries/Flyover.sol
+++ b/src/libraries/Flyover.sol
@@ -2,6 +2,14 @@
 pragma solidity 0.8.25;
 
 library Flyover {
+    /// @notice 1 satoshi expressed in wei — the scale every BTC amount crosses when it becomes an
+    /// RBTC amount.
+    /// @dev Declared here, and not on the contract that owns the amount policy, only because
+    /// Solidity cannot reference a contract's public constant by type name: doing so needs an
+    /// external call. {FlyoverConfigurations-SAT_TO_WEI_CONVERSION} re-exports this as the public,
+    /// externally readable value, and is the one consumers should read.
+    uint256 internal constant SAT_TO_WEI_CONVERSION = 10 ** 10;
+
     enum ProviderType { PegIn, PegOut, Both }
 
     struct LiquidityProvider {

--- a/src/libraries/PegInDerivation.sol
+++ b/src/libraries/PegInDerivation.sol
@@ -34,7 +34,7 @@ import {OpCodes} from "@rsksmart/btc-transaction-solidity-helper/contracts/OpCod
 /// The pipeline does not stop at the address. Every consumer that reads a VALUE out of a deposit
 /// transaction — the registry gating registration, `PegInContract.requestPegIn` computing the
 /// peg-in amount — must match outputs against the SAME script this library derives, so
-/// {expectedDepositPkScript} and {matchedDepositValue} live here too. A caller-supplied amount is
+/// {depositPkScript} and {findFirstBtcOutputPaying} live here too. A caller-supplied amount is
 /// never an input to either path: the amount is a value the contract computes.
 ///
 /// Two known pitfalls, both proven on-chain and both encoded as negative tests:
@@ -166,7 +166,7 @@ library PegInDerivation {
     /// @param activePowpegRedeemScript The live powpeg redeem script, read from the bridge at
     /// call time — never stored
     /// @return The 23-byte P2SH scriptPubkey of the deposit address
-    function expectedDepositPkScript(
+    function depositPkScript(
         address rskAddr,
         address pegInContract,
         bytes memory activePowpegRedeemScript
@@ -176,30 +176,34 @@ library PegInDerivation {
         return p2shScriptPubkey(flyoverScriptHash(redeemScript));
     }
 
-    /// @notice The satoshi value of the FIRST output of `btcTxSerialized` paying `expectedPkScript`.
-    /// @dev First match, not the sum of every matching output. A deposit split across several
-    /// outputs to the same derived address therefore counts only its first output, which
-    /// UNDERSTATES the deposit. That direction is the safe one — the claimer fronts less than the
-    /// bridge will release and settlement covers the claim — and it is the rule the registry has
-    /// always applied, so the value that gates registration and the value that fixes the peg-in
-    /// amount stay identical. Summing would have to change both call sites at once.
+    /// @notice Searches the outputs of `btcTxSerialized` for the FIRST one locked by `pkScript`
+    /// and returns its satoshi value.
+    /// @dev A search, not an accessor: the `found` flag is the failure mode, and both call sites
+    /// turn it into their own named error (a library revert would flatten the two into one).
     ///
-    /// Returns a found flag rather than reverting: the two call sites revert with their own named
-    /// errors, and a library revert would flatten them into one.
+    /// FIRST match, not the sum of every matching output. A deposit split across several outputs
+    /// to the same derived address therefore counts only its first output, which UNDERSTATES the
+    /// deposit — the name says `First` so no caller mistakes this for the amount paid. The rule is
+    /// inherited from the registry, where the value is only a minimum-deposit gate and
+    /// undercounting is conservative. `PegInContract.requestPegIn` uses it as the peg-in AMOUNT,
+    /// where undercounting silently drops the user's remaining outputs, so summing is the likely
+    /// correct rule there; it is not applied yet because the two call sites must move together and
+    /// because the reconciling side (`resolvePegIn`, and whether the RSK bridge sums outputs to the
+    /// derivation address) is not implemented. Revisit with settlement.
     /// @param btcTxSerialized The witness-stripped raw deposit transaction
-    /// @param expectedPkScript The scriptPubkey from {expectedDepositPkScript}
+    /// @param pkScript The scriptPubkey to search for, from {depositPkScript}
     /// @return value The matched output's value in satoshis, 0 when no output matched
-    /// @return found Whether any output paid `expectedPkScript`
-    function matchedDepositValue(bytes calldata btcTxSerialized, bytes memory expectedPkScript)
+    /// @return found Whether any output was locked by `pkScript`
+    function findFirstBtcOutputPaying(bytes calldata btcTxSerialized, bytes memory pkScript)
         internal
         pure
         returns (uint64 value, bool found)
     {
         BtcUtils.TxRawOutput[] memory outputs = BtcUtils.getOutputs(btcTxSerialized);
-        bytes32 expectedHash = keccak256(expectedPkScript);
+        bytes32 pkScriptHash = keccak256(pkScript);
         uint256 outputCount = outputs.length;
         for (uint256 i = 0; i < outputCount; ++i) {
-            if (keccak256(outputs[i].pkScript) == expectedHash) {
+            if (keccak256(outputs[i].pkScript) == pkScriptHash) {
                 return (outputs[i].value, true);
             }
         }

--- a/src/libraries/PegInDerivation.sol
+++ b/src/libraries/PegInDerivation.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import {BtcUtils} from "@rsksmart/btc-transaction-solidity-helper/contracts/BtcUtils.sol";
 import {OpCodes} from "@rsksmart/btc-transaction-solidity-helper/contracts/OpCodes.sol";
 
 /// @title PegInDerivation
@@ -31,11 +30,12 @@ import {OpCodes} from "@rsksmart/btc-transaction-solidity-helper/contracts/OpCod
 /// Each step is a separate function taking the previous step's output, so every consumer enters
 /// the pipeline at the step it needs and none re-implements any script math.
 ///
-/// The pipeline does not stop at the address. Every consumer that reads a VALUE out of a deposit
+/// The pipeline ends at the script. Every consumer that reads a VALUE out of a deposit
 /// transaction — the registry gating registration, `PegInContract.requestPegIn` computing the
-/// peg-in amount — must match outputs against the SAME script this library derives, so
-/// {depositPkScript} and {findFirstBtcOutputPaying} live here too. A caller-supplied amount is
-/// never an input to either path: the amount is a value the contract computes.
+/// peg-in amount — matches outputs against the script {depositPkScript} returns, but the matching
+/// itself is a lookup over transaction bytes and lives in {BtcTransactionReader}. A
+/// caller-supplied amount is never an input to either path: the amount is a value the contract
+/// computes.
 ///
 /// Two known pitfalls, both proven on-chain and both encoded as negative tests:
 ///   1. Keying the redeem-script tag with `derivationArgumentsHash` directly (skipping step 2's
@@ -174,39 +174,5 @@ library PegInDerivation {
         bytes32 derivationValue_ = derivationValue(rskAddr, pegInContract);
         bytes memory redeemScript = flyoverRedeemScript(derivationValue_, activePowpegRedeemScript);
         return p2shScriptPubkey(flyoverScriptHash(redeemScript));
-    }
-
-    /// @notice Searches the outputs of `btcTxSerialized` for the FIRST one locked by `pkScript`
-    /// and returns its satoshi value.
-    /// @dev A search, not an accessor: the `found` flag is the failure mode, and both call sites
-    /// turn it into their own named error (a library revert would flatten the two into one).
-    ///
-    /// FIRST match, not the sum of every matching output. A deposit split across several outputs
-    /// to the same derived address therefore counts only its first output, which UNDERSTATES the
-    /// deposit — the name says `First` so no caller mistakes this for the amount paid. The rule is
-    /// inherited from the registry, where the value is only a minimum-deposit gate and
-    /// undercounting is conservative. `PegInContract.requestPegIn` uses it as the peg-in AMOUNT,
-    /// where undercounting silently drops the user's remaining outputs, so summing is the likely
-    /// correct rule there; it is not applied yet because the two call sites must move together and
-    /// because the reconciling side (`resolvePegIn`, and whether the RSK bridge sums outputs to the
-    /// derivation address) is not implemented. Revisit with settlement.
-    /// @param btcTxSerialized The witness-stripped raw deposit transaction
-    /// @param pkScript The scriptPubkey to search for, from {depositPkScript}
-    /// @return value The matched output's value in satoshis, 0 when no output matched
-    /// @return found Whether any output was locked by `pkScript`
-    function findFirstBtcOutputPaying(bytes calldata btcTxSerialized, bytes memory pkScript)
-        internal
-        pure
-        returns (uint64 value, bool found)
-    {
-        BtcUtils.TxRawOutput[] memory outputs = BtcUtils.getOutputs(btcTxSerialized);
-        bytes32 pkScriptHash = keccak256(pkScript);
-        uint256 outputCount = outputs.length;
-        for (uint256 i = 0; i < outputCount; ++i) {
-            if (keccak256(outputs[i].pkScript) == pkScriptHash) {
-                return (outputs[i].value, true);
-            }
-        }
-        return (0, false);
     }
 }

--- a/src/libraries/PegInDerivation.sol
+++ b/src/libraries/PegInDerivation.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
+import {BtcUtils} from "@rsksmart/btc-transaction-solidity-helper/contracts/BtcUtils.sol";
 import {OpCodes} from "@rsksmart/btc-transaction-solidity-helper/contracts/OpCodes.sol";
 
 /// @title PegInDerivation
@@ -29,6 +30,12 @@ import {OpCodes} from "@rsksmart/btc-transaction-solidity-helper/contracts/OpCod
 ///
 /// Each step is a separate function taking the previous step's output, so every consumer enters
 /// the pipeline at the step it needs and none re-implements any script math.
+///
+/// The pipeline does not stop at the address. Every consumer that reads a VALUE out of a deposit
+/// transaction — the registry gating registration, `PegInContract.requestPegIn` computing the
+/// peg-in amount — must match outputs against the SAME script this library derives, so
+/// {expectedDepositPkScript} and {matchedDepositValue} live here too. A caller-supplied amount is
+/// never an input to either path: the amount is a value the contract computes.
 ///
 /// Two known pitfalls, both proven on-chain and both encoded as negative tests:
 ///   1. Keying the redeem-script tag with `derivationArgumentsHash` directly (skipping step 2's
@@ -147,5 +154,55 @@ library PegInDerivation {
         bytes memory versionedHash = bytes.concat(version, scriptHash);
         bytes32 checksum = sha256(abi.encodePacked(sha256(versionedHash)));
         return bytes.concat(versionedHash, checksum[0], checksum[1], checksum[2], checksum[3]);
+    }
+
+    /// @notice Steps 2-5 composed: the on-chain P2SH scriptPubkey a deposit output must carry to
+    /// count as a deposit for `rskAddr`. The single entry point for deposit matching — the
+    /// registry and the peg-in claim path both call this rather than re-composing the steps, so
+    /// the script that gates registration and the script that fixes the peg-in amount cannot
+    /// drift apart.
+    /// @param rskAddr The RSK destination address the deposit address is derived for
+    /// @param pegInContract The PegInContract PROXY address mixed into step 2
+    /// @param activePowpegRedeemScript The live powpeg redeem script, read from the bridge at
+    /// call time — never stored
+    /// @return The 23-byte P2SH scriptPubkey of the deposit address
+    function expectedDepositPkScript(
+        address rskAddr,
+        address pegInContract,
+        bytes memory activePowpegRedeemScript
+    ) internal pure returns (bytes memory) {
+        bytes32 derivationValue_ = derivationValue(rskAddr, pegInContract);
+        bytes memory redeemScript = flyoverRedeemScript(derivationValue_, activePowpegRedeemScript);
+        return p2shScriptPubkey(flyoverScriptHash(redeemScript));
+    }
+
+    /// @notice The satoshi value of the FIRST output of `btcTxSerialized` paying `expectedPkScript`.
+    /// @dev First match, not the sum of every matching output. A deposit split across several
+    /// outputs to the same derived address therefore counts only its first output, which
+    /// UNDERSTATES the deposit. That direction is the safe one — the claimer fronts less than the
+    /// bridge will release and settlement covers the claim — and it is the rule the registry has
+    /// always applied, so the value that gates registration and the value that fixes the peg-in
+    /// amount stay identical. Summing would have to change both call sites at once.
+    ///
+    /// Returns a found flag rather than reverting: the two call sites revert with their own named
+    /// errors, and a library revert would flatten them into one.
+    /// @param btcTxSerialized The witness-stripped raw deposit transaction
+    /// @param expectedPkScript The scriptPubkey from {expectedDepositPkScript}
+    /// @return value The matched output's value in satoshis, 0 when no output matched
+    /// @return found Whether any output paid `expectedPkScript`
+    function matchedDepositValue(bytes calldata btcTxSerialized, bytes memory expectedPkScript)
+        internal
+        pure
+        returns (uint64 value, bool found)
+    {
+        BtcUtils.TxRawOutput[] memory outputs = BtcUtils.getOutputs(btcTxSerialized);
+        bytes32 expectedHash = keccak256(expectedPkScript);
+        uint256 outputCount = outputs.length;
+        for (uint256 i = 0; i < outputCount; ++i) {
+            if (keccak256(outputs[i].pkScript) == expectedHash) {
+                return (outputs[i].value, true);
+            }
+        }
+        return (0, false);
     }
 }

--- a/src/test-contracts/BridgeMock.sol
+++ b/src/test-contracts/BridgeMock.sol
@@ -10,6 +10,14 @@ contract BridgeMock is IBridge {
     mapping(uint256 => bytes) private _headers;
     mapping (bytes32 => bytes) private _headersByHash;
     int private _confirmations;
+    /// @dev Per-hash confirmations, so a test can prove WHICH hash was proven. A real merkle
+    /// proof only confirms the txid it was built for; the blanket _confirmations value cannot
+    /// express that, and hides any mismatch between the hash a caller derives and the hash it
+    /// proves.
+    mapping(bytes32 => int) private _confirmationsByTxHash;
+    /// @dev Set by setConfirmationsFor. While false the mock keeps its original blanket
+    /// behaviour, so existing tests are unaffected.
+    bool private _perTxHashConfirmations;
     int private _registerError;
 
     error SendFailed();
@@ -48,6 +56,15 @@ contract BridgeMock is IBridge {
         _confirmations = confirmations;
     }
 
+    /// @notice Confirms one specific transaction hash, as a merkle proof does.
+    /// @dev Use instead of setConfirmations when a test needs to prove WHICH hash the caller
+    /// asked the bridge about. Seeding any hash switches this mock into per-hash mode, so
+    /// unseeded hashes report no confirmations rather than falling back to the blanket value.
+    function setConfirmationsFor(bytes32 btcTxHash, int confirmations) external {
+        _confirmationsByTxHash[btcTxHash] = confirmations;
+        _perTxHashConfirmations = true;
+    }
+
     // solhint-disable-next-line no-empty-blocks
     function registerBtcTransaction ( bytes calldata atx, int256 height, bytes calldata pmt ) external override {}
     function addSignature ( bytes calldata pubkey, bytes[] calldata signatures, bytes calldata txhash )
@@ -71,8 +88,13 @@ contract BridgeMock is IBridge {
         return _headersByHash[blockHash];
     }
 
-    function getBtcTransactionConfirmations ( bytes32 , bytes32, uint256 , bytes32[] calldata  )
-        external view override returns (int256) { return _confirmations; }
+    function getBtcTransactionConfirmations ( bytes32 btcTxHash, bytes32, uint256 , bytes32[] calldata  )
+        external view override returns (int256) {
+        if (_perTxHashConfirmations) {
+            return _confirmationsByTxHash[btcTxHash];
+        }
+        return _confirmations;
+    }
 
     function getActivePowpegRedeemScript() external pure returns (bytes memory) {
         bytes memory part1 = hex"522102cd53fc53a07f211641a677d250f6de99caf620e8e77071e811a28b3bcddf0be1210362634ab5";

--- a/src/test-contracts/RequestPegInReenterReceiver.sol
+++ b/src/test-contracts/RequestPegInReenterReceiver.sol
@@ -5,13 +5,14 @@ import {IPegInCommitFirst} from "../interfaces/IPegInCommitFirst.sol";
 
 /// @notice Malicious peg-in destination that re-enters requestPegIn on delivery.
 /// @dev Mirrors the WithdrawReceiver test-contract pattern. On receiving the fronted RBTC it
-/// calls requestPegIn again with a different btcTxHash (a fresh pegInId), so the re-entry is
-/// blocked by the nonReentrant guard rather than trivially hitting the already-processed check.
+/// calls requestPegIn again with a different deposit transaction (a different txid, so a fresh
+/// pegInId), so the re-entry is blocked by the nonReentrant guard rather than trivially hitting
+/// the already-processed check.
 /* solhint-disable comprehensive-interface */
 contract RequestPegInReenterReceiver {
     IPegInCommitFirst private _pegIn;
     bool private _attack;
-    bytes32 private _reenterBtcTxHash;
+    bytes private _reenterBtcTx;
 
     constructor(address pegInContract) {
         _pegIn = IPegInCommitFirst(pegInContract);
@@ -20,14 +21,15 @@ contract RequestPegInReenterReceiver {
     receive() external payable {
         if (_attack) {
             _attack = false;
-            _pegIn.requestPegIn(address(this), 1, _reenterBtcTxHash, "", bytes32(0), 0, new bytes32[](0));
+            _pegIn.requestPegIn(address(this), _reenterBtcTx, "", bytes32(0), 0, new bytes32[](0));
         }
     }
 
-    /// @notice Arms or disarms the re-entry, and sets the btcTxHash used for the re-entrant call
-    function setAttack(bool attack, bytes32 reenterBtcTxHash) external {
+    /// @notice Arms or disarms the re-entry, and sets the deposit transaction used for the
+    /// re-entrant call
+    function setAttack(bool attack, bytes calldata reenterBtcTx) external {
         _attack = attack;
-        _reenterBtcTxHash = reenterBtcTxHash;
+        _reenterBtcTx = reenterBtcTx;
     }
 }
 /* solhint-enable comprehensive-interface */

--- a/test/pegin-registry/PegInRegistryTestBase.sol
+++ b/test/pegin-registry/PegInRegistryTestBase.sol
@@ -145,6 +145,38 @@ abstract contract PegInRegistryTestBase is Test {
             );
     }
 
+    /// @notice The BIP144 (witness-included) serialization of the same one-output deposit.
+    /// @dev Identical to {_buildDepositTx} except for the 00 01 marker+flag after the version and a
+    /// one-item witness stack before the locktime. getOutputs reads the same output from both, so
+    /// only the serialization differs — which is exactly what the registry must reject.
+    function _buildWitnessDepositTx(
+        bytes memory pkScript,
+        uint64 value
+    ) internal pure returns (bytes memory) {
+        bytes memory valueLe = new bytes(8);
+        uint64 v = value;
+        for (uint256 i = 0; i < 8; ++i) {
+            valueLe[i] = bytes1(uint8(v & 0xFF));
+            v >>= 8;
+        }
+        return
+            abi.encodePacked(
+                hex"01000000",
+                hex"0001", // segwit marker + flag
+                hex"01",
+                bytes32(uint256(1)),
+                hex"00000000",
+                hex"00",
+                hex"ffffffff",
+                hex"01",
+                valueLe,
+                bytes1(uint8(pkScript.length)),
+                pkScript,
+                hex"0102ab", // witness: 1 item, 2 bytes
+                hex"00000000"
+            );
+    }
+
     function _emptyHashes() internal pure returns (bytes32[] memory) {
         return new bytes32[](0);
     }

--- a/test/pegin-registry/Register.t.sol
+++ b/test/pegin-registry/Register.t.sol
@@ -6,6 +6,8 @@ import {IPegInAddressRegistry} from "../../src/interfaces/IPegInAddressRegistry.
 import {IPauseRegistry} from "../../src/interfaces/IPauseRegistry.sol";
 import {Flyover} from "../../src/libraries/Flyover.sol";
 import {BtcUtils} from "@rsksmart/btc-transaction-solidity-helper/contracts/BtcUtils.sol";
+import {BtcTransactionReader} from "../../src/libraries/BtcTransactionReader.sol";
+import {IBridge} from "../../src/interfaces/IBridge.sol";
 
 /// @title PegInAddressRegistry write-path tests
 contract RegisterTest is PegInRegistryTestBase {
@@ -487,6 +489,88 @@ contract RegisterTest is PegInRegistryTestBase {
             bytes32(0),
             MERKLE_PATH,
             hashes
+        );
+    }
+
+    // ---- serialization guard ----
+
+    /// @notice A witness-serialized deposit is rejected even though its outputs are valid.
+    /// @dev getOutputs reads the same output from either serialization, so nothing downstream
+    /// notices the difference; hashBtcTx does, and returns a wtxid the confirmation proof can never
+    /// match. The registry rejects the form rather than relying on the bridge to.
+    function test_revert_when_tx_is_witness_serialized() public {
+        _deploy(false);
+        bytes memory pkScript = _depositPkScript(FIXTURE_RSK);
+        bytes memory witnessTx = _buildWitnessDepositTx(pkScript, 10_000);
+        _programProof(witnessTx, BLOCK_HASH, MERKLE_PATH, _emptyHashes());
+
+        vm.expectRevert(
+            BtcTransactionReader.WitnessSerializedTxNotAccepted.selector
+        );
+        registry.registerAddress(
+            FIXTURE_RSK,
+            witnessTx,
+            BLOCK_HASH,
+            MERKLE_PATH,
+            _emptyHashes()
+        );
+        assertFalse(registry.isRegistered(FIXTURE_RSK), "nothing registered");
+    }
+
+    /// @notice The rejection is the registry's own, and lands before the bridge is consulted.
+    function test_witness_serialized_tx_rejected_before_any_bridge_call()
+        public
+    {
+        _deploy(false);
+        bytes memory witnessTx = _buildWitnessDepositTx(
+            _depositPkScript(FIXTURE_RSK),
+            10_000
+        );
+        _programProof(witnessTx, BLOCK_HASH, MERKLE_PATH, _emptyHashes());
+
+        vm.expectCall(
+            address(bridge),
+            abi.encodeWithSelector(
+                IBridge.getActivePowpegRedeemScript.selector
+            ),
+            0
+        );
+        vm.expectCall(
+            address(bridge),
+            abi.encodeWithSelector(
+                IBridge.getBtcTransactionConfirmations.selector
+            ),
+            0
+        );
+        vm.expectRevert(
+            BtcTransactionReader.WitnessSerializedTxNotAccepted.selector
+        );
+        registry.registerAddress(
+            FIXTURE_RSK,
+            witnessTx,
+            BLOCK_HASH,
+            MERKLE_PATH,
+            _emptyHashes()
+        );
+    }
+
+    /// @notice The witness-stripped presentation of the same deposit registers normally.
+    function test_stripped_presentation_of_same_deposit_registers() public {
+        _deploy(false);
+        _register(FIXTURE_RSK, 10_000, stranger);
+        assertTrue(registry.isRegistered(FIXTURE_RSK));
+    }
+
+    /// @notice A truncated transaction reverts with a reason, not an out-of-bounds panic.
+    function test_revert_when_tx_shorter_than_six_bytes() public {
+        _deploy(false);
+        vm.expectRevert(BtcTransactionReader.InvalidBtcTransaction.selector);
+        registry.registerAddress(
+            FIXTURE_RSK,
+            hex"0100000001",
+            BLOCK_HASH,
+            MERKLE_PATH,
+            _emptyHashes()
         );
     }
 }

--- a/test/pegin/BridgeMockBlindSpot.t.sol
+++ b/test/pegin/BridgeMockBlindSpot.t.sol
@@ -3,24 +3,25 @@ pragma solidity 0.8.25;
 
 import {RequestPegInTestBase} from "./RequestPegInTestBase.sol";
 import {IPegInCommitFirst} from "../../src/interfaces/IPegInCommitFirst.sol";
+import {IBridge} from "../../src/interfaces/IBridge.sol";
+import {BtcTransactionReader} from "../../src/libraries/BtcTransactionReader.sol";
 
-/// @title Why BridgeMock has to look at the txid
-/// @notice Two examples of the SAME scenario: one real deposit presented twice, once
-/// witness-stripped and once witness-serialized.
+/// @title One deposit, two serializations
+/// @notice A segwit deposit has two legal serializations (BIP144), and BtcUtils treats them
+/// inconsistently — correctly, on both sides:
+///   - getOutputs detects the segwit marker+flag and skips it, so it reads the SAME real output
+///     from both serializations. Same amount either way.
+///   - hashBtcTx double-sha256s whatever bytes it is given, so the witness serialization hashes to
+///     the WTXID, not the txid.
 ///
-/// BtcUtils treats those two byte strings inconsistently, and that is correct behaviour on both
-/// sides:
-///   - getOutputs (line 59) detects the segwit marker+flag and skips them, so it reads the SAME
-///     real output from both serializations. Same amount either way.
-///   - hashBtcTx (line 272) double-sha256s whatever bytes it is given, so the witness
-///     serialization hashes to the WTXID, not the txid.
+/// So the two presentations of one deposit yield two different pegInIds, and the already-processed
+/// guard — keyed on the hash — waves the second one through.
 ///
-/// So the two presentations of one deposit yield two different pegInIds. On a real chain the
-/// second one is dead on arrival: the bridge checks the hash against a merkle tree built from
-/// txids, and a wtxid is not in it. requestPegIn therefore reverts InsufficientConfirmations.
-///
-/// The current BridgeMock discards the hash argument, so the test environment cannot tell the two
-/// apart, and asserts behaviour that is impossible in production.
+/// `requestPegIn` now rejects the witness serialization at its own boundary, before hashing. The
+/// real bridge would also reject it (a wtxid is not in a merkle tree built from txids), but that is
+/// a collaborator we do not own, so these tests assert OUR revert and prove the bridge is never
+/// reached. The txid-aware BridgeMock stays: without it the suite still cannot see WHICH hash the
+/// contract asks the bridge about, which is a separate blind spot and the last test here.
 contract BridgeMockBlindSpotTest is RequestPegInTestBase {
     /// @notice A one-input, one-output SEGWIT-serialized transaction paying `pkScript`.
     /// @dev Identical to the base's _buildTx except for the 00 01 marker+flag after the version
@@ -67,7 +68,8 @@ contract BridgeMockBlindSpotTest is RequestPegInTestBase {
         witness = _buildWitnessTx(pkScript, sats, DEFAULT_TX_NONCE);
     }
 
-    /// @notice The premise both examples rest on: same parsed output, different hash.
+    /// @notice The premise the whole suite rests on: same parsed output, different hash.
+    /// @dev Tests raw hashing, not the entry point, so the new guard does not apply here.
     function test_premise_sameOutputDifferentHash() public view {
         (
             bytes memory stripped,
@@ -85,92 +87,37 @@ contract BridgeMockBlindSpotTest is RequestPegInTestBase {
     }
 
     // ------------------------------------------------------------------
-    // BAD: what the current, hash-blind BridgeMock lets you assert
+    // The double-claim, stopped at our boundary
     // ------------------------------------------------------------------
 
-    /// @notice Passes today. One real deposit is claimed TWICE for full value, because the mock
-    /// hands out confirmations for any hash at all — including a wtxid that no merkle tree
-    /// contains. The already-processed guard does not help: it is keyed on the hash, and the two
-    /// presentations hash differently.
-    ///
-    /// A green run here means the suite is blessing a double-claim that the real bridge rejects.
-    function test_BAD_hashBlindMock_letsOneDepositBeClaimedTwice() public {
+    /// @notice The exploit this guard exists for, run in the WEAKEST environment: a hash-blind
+    /// bridge that hands out confirmations for any hash at all, including a wtxid no merkle tree
+    /// contains. Before the guard this test claimed one deposit twice for full value. Now the
+    /// second presentation never gets far enough to be confirmed by anything.
+    function test_hashBlindMock_cannotClaimOneDepositTwice() public {
         (
             bytes memory stripped,
             bytes memory witness
         ) = _twoSerializationsOfOneDeposit();
         uint256 net = DEFAULT_AMOUNT - _expectedFee(DEFAULT_AMOUNT);
 
-        // Blanket confirmations for every hash — the current mock's only mode.
+        // Blanket confirmations for every hash — the mock's weakest mode, and the one that used to
+        // let the wtxid through.
         bridgeMock.setConfirmations(int256(DEFAULT_TIER_CONFIRMATIONS));
 
         uint256 userBefore = rskUser.balance;
 
         // Claim 1: the honest, witness-stripped presentation.
         bytes32 firstId = _requestPegInTx(claimer, rskUser, stripped, net);
-
-        // Claim 2: the SAME deposit, re-serialized with a witness. Fresh pegInId, so the
-        // already-processed check waves it through, and the mock confirms the wtxid.
-        bytes32 secondId = _requestPegInTx(claimer, rskUser, witness, net);
-
-        assertTrue(firstId != secondId, "two ids for one deposit");
-
         (address firstClaimer, uint256 firstFronted, , ) = _readClaim(firstId);
-        (address secondClaimer, uint256 secondFronted, , ) = _readClaim(
-            secondId
-        );
         assertEq(firstClaimer, claimer, "claim 1 written");
-        assertEq(
-            secondClaimer,
-            claimer,
-            "claim 2 written for the same deposit"
-        );
         assertEq(firstFronted, net, "claim 1 fronted full net");
-        assertEq(secondFronted, net, "claim 2 fronted full net");
 
-        // The user was paid twice for a single BTC deposit.
-        assertEq(
-            rskUser.balance,
-            userBefore + (net * 2),
-            "one deposit, two full deliveries"
-        );
-    }
-
-    // ------------------------------------------------------------------
-    // GOOD: what a txid-aware BridgeMock lets you assert
-    // ------------------------------------------------------------------
-
-    /// @notice The same scenario against a mock that only confirms hashes it was actually given,
-    /// which is what a merkle proof does. The stripped presentation succeeds; the witness
-    /// presentation reverts InsufficientConfirmations(0, required) — production behaviour.
-    function test_GOOD_txidAwareMock_rejectsTheSecondPresentation() public {
-        (
-            bytes memory stripped,
-            bytes memory witness
-        ) = _twoSerializationsOfOneDeposit();
-        uint256 net = DEFAULT_AMOUNT - _expectedFee(DEFAULT_AMOUNT);
-
-        // Only the real txid is in the "merkle tree". Nothing else is confirmable.
-        bridgeMock.setConfirmationsFor(
-            this.hashTx(stripped),
-            int256(DEFAULT_TIER_CONFIRMATIONS)
-        );
-
-        uint256 userBefore = rskUser.balance;
-
-        // Claim 1 still works: this is the transaction that is really on chain.
-        bytes32 firstId = _requestPegInTx(claimer, rskUser, stripped, net);
-        (address firstClaimer, , , ) = _readClaim(firstId);
-        assertEq(firstClaimer, claimer, "honest claim unaffected");
-
-        // Claim 2 is now stopped where the real bridge stops it.
+        // Claim 2: the SAME deposit, re-serialized with a witness. Rejected by us, not by the
+        // bridge, and not by the already-processed guard (which cannot see it — different hash).
         vm.prank(claimer);
         vm.expectRevert(
-            abi.encodeWithSelector(
-                IPegInCommitFirst.InsufficientConfirmations.selector,
-                0,
-                DEFAULT_TIER_CONFIRMATIONS
-            )
+            BtcTransactionReader.WitnessSerializedTxNotAccepted.selector
         );
         pegInContract.requestPegIn{value: net}(
             rskUser,
@@ -192,10 +139,114 @@ contract BridgeMockBlindSpotTest is RequestPegInTestBase {
         );
     }
 
-    /// @notice The broader point, independent of segwit: with a txid-aware mock, the suite can
-    /// finally observe that requestPegIn asks the bridge about the hash it derived from the
-    /// presented bytes. Confirm a DIFFERENT hash and the claim must still fail.
-    function test_GOOD_txidAwareMock_pinsWhichHashIsProven() public {
+    /// @notice Rejection is ours, and it lands before the bridge is consulted at all.
+    /// @dev Both bridge reads on the claim path are asserted absent: the powpeg script
+    /// `_readPegInAmount` derives against, and the confirmation lookup after it.
+    function test_witnessTx_rejectedBeforeAnyBridgeCall() public {
+        (, bytes memory witness) = _twoSerializationsOfOneDeposit();
+        uint256 net = DEFAULT_AMOUNT - _expectedFee(DEFAULT_AMOUNT);
+
+        bridgeMock.setConfirmations(int256(DEFAULT_TIER_CONFIRMATIONS));
+
+        vm.expectCall(
+            address(bridgeMock),
+            abi.encodeWithSelector(
+                IBridge.getActivePowpegRedeemScript.selector
+            ),
+            0
+        );
+        vm.expectCall(
+            address(bridgeMock),
+            abi.encodeWithSelector(
+                IBridge.getBtcTransactionConfirmations.selector
+            ),
+            0
+        );
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            BtcTransactionReader.WitnessSerializedTxNotAccepted.selector
+        );
+        pegInContract.requestPegIn{value: net}(
+            rskUser,
+            witness,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+    }
+
+    /// @notice The witness-stripped presentation of the very same deposit still succeeds. The
+    /// guard discriminates on serialization, not on the deposit.
+    function test_strippedPresentationOfTheSameDepositStillSucceeds() public {
+        (bytes memory stripped, ) = _twoSerializationsOfOneDeposit();
+        uint256 net = DEFAULT_AMOUNT - _expectedFee(DEFAULT_AMOUNT);
+
+        bridgeMock.setConfirmationsFor(
+            this.hashTx(stripped),
+            int256(DEFAULT_TIER_CONFIRMATIONS)
+        );
+
+        uint256 userBefore = rskUser.balance;
+        bytes32 pegInId = _requestPegInTx(claimer, rskUser, stripped, net);
+
+        (address writtenClaimer, uint256 fronted, , ) = _readClaim(pegInId);
+        assertEq(writtenClaimer, claimer, "honest claim written");
+        assertEq(fronted, net, "fronted full net");
+        assertEq(rskUser.balance, userBefore + net, "user delivered once");
+    }
+
+    /// @notice A truncated transaction reverts with a reason, not an out-of-bounds panic.
+    /// @dev Five bytes is one short of the marker+flag the guard reads.
+    function test_txShorterThanSixBytes_revertsInvalidBtcTransaction() public {
+        uint256 net = DEFAULT_AMOUNT - _expectedFee(DEFAULT_AMOUNT);
+
+        vm.prank(claimer);
+        vm.expectRevert(BtcTransactionReader.InvalidBtcTransaction.selector);
+        pegInContract.requestPegIn{value: net}(
+            rskUser,
+            hex"0100000001",
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+    }
+
+    /// @notice Negative control: a LEGACY transaction whose sixth byte happens to be 0x01 is not
+    /// mistaken for a witness serialization.
+    /// @dev The prevout txid begins at offset 5, so a nonce whose most-significant byte is 0x01
+    /// puts 0x01 there. What keeps the guard exact is offset 4 — the input-count compactSize, 0x01
+    /// here and never 0x00 in a valid transaction. A check that looked at the wrong offset, or at
+    /// only one of the two bytes, would reject this deposit.
+    function test_legacyTxWithLeading01Outpoint_isNotRejected() public {
+        uint256 nonce = 1 << 248; // bytes32(nonce)[0] == 0x01
+        bytes memory btcTx = _depositTx(rskUser, DEFAULT_AMOUNT, nonce);
+        assertEq(btcTx[4], bytes1(0x01), "input count sits at offset 4");
+        assertEq(btcTx[5], bytes1(0x01), "and the outpoint starts with 0x01");
+
+        uint256 net = DEFAULT_AMOUNT - _expectedFee(DEFAULT_AMOUNT);
+        bridgeMock.setConfirmationsFor(
+            this.hashTx(btcTx),
+            int256(DEFAULT_TIER_CONFIRMATIONS)
+        );
+
+        bytes32 pegInId = _requestPegInTx(claimer, rskUser, btcTx, net);
+        (address writtenClaimer, , , ) = _readClaim(pegInId);
+        assertEq(writtenClaimer, claimer, "legacy deposit claimed normally");
+    }
+
+    // ------------------------------------------------------------------
+    // The other blind spot the txid-aware mock closed
+    // ------------------------------------------------------------------
+
+    /// @notice Independent of segwit: with a txid-aware mock the suite can observe that
+    /// requestPegIn asks the bridge about the hash it derived from the presented bytes. Confirm a
+    /// DIFFERENT hash and the claim must still fail.
+    /// @dev This one is a legacy transaction and MUST reach the bridge — the rejection under test
+    /// is the bridge's, and that is the point. Only witness-serialized bytes are stopped earlier.
+    function test_txidAwareMock_pinsWhichHashIsProven() public {
         bytes memory btcTx = _defaultTx();
         uint256 net = DEFAULT_AMOUNT - _expectedFee(DEFAULT_AMOUNT);
 

--- a/test/pegin/BridgeMockBlindSpot.t.sol
+++ b/test/pegin/BridgeMockBlindSpot.t.sol
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {RequestPegInTestBase} from "./RequestPegInTestBase.sol";
+import {IPegInCommitFirst} from "../../src/interfaces/IPegInCommitFirst.sol";
+
+/// @title Why BridgeMock has to look at the txid
+/// @notice Two examples of the SAME scenario: one real deposit presented twice, once
+/// witness-stripped and once witness-serialized.
+///
+/// BtcUtils treats those two byte strings inconsistently, and that is correct behaviour on both
+/// sides:
+///   - getOutputs (line 59) detects the segwit marker+flag and skips them, so it reads the SAME
+///     real output from both serializations. Same amount either way.
+///   - hashBtcTx (line 272) double-sha256s whatever bytes it is given, so the witness
+///     serialization hashes to the WTXID, not the txid.
+///
+/// So the two presentations of one deposit yield two different pegInIds. On a real chain the
+/// second one is dead on arrival: the bridge checks the hash against a merkle tree built from
+/// txids, and a wtxid is not in it. requestPegIn therefore reverts InsufficientConfirmations.
+///
+/// The current BridgeMock discards the hash argument, so the test environment cannot tell the two
+/// apart, and asserts behaviour that is impossible in production.
+contract BridgeMockBlindSpotTest is RequestPegInTestBase {
+    /// @notice A one-input, one-output SEGWIT-serialized transaction paying `pkScript`.
+    /// @dev Identical to the base's _buildTx except for the 00 01 marker+flag after the version
+    /// and a one-item witness stack before the locktime. Same output, so getOutputs returns the
+    /// same value; different bytes, so hashBtcTx returns a different hash.
+    function _buildWitnessTx(
+        bytes memory pkScript,
+        uint64 valueSats,
+        uint256 nonce
+    ) internal pure returns (bytes memory) {
+        bytes memory valueLe = new bytes(8);
+        uint64 v = valueSats;
+        for (uint256 i = 0; i < 8; ++i) {
+            valueLe[i] = bytes1(uint8(v & 0xFF));
+            v >>= 8;
+        }
+        return
+            abi.encodePacked(
+                hex"01000000", // version
+                hex"0001", // segwit marker + flag
+                hex"01", // input count
+                bytes32(nonce), // prevout txid
+                hex"00000000", // prevout index
+                hex"00", // empty scriptSig
+                hex"ffffffff", // sequence
+                hex"01", // output count
+                valueLe,
+                bytes1(uint8(pkScript.length)),
+                pkScript,
+                hex"0102ab", // witness: 1 item, 2 bytes
+                hex"00000000" // locktime
+            );
+    }
+
+    /// @notice Shared setup: one deposit, two serializations of it.
+    function _twoSerializationsOfOneDeposit()
+        internal
+        view
+        returns (bytes memory stripped, bytes memory witness)
+    {
+        bytes memory pkScript = _depositPkScript(rskUser);
+        uint64 sats = _toSats(DEFAULT_AMOUNT);
+        stripped = _buildTx(pkScript, sats, DEFAULT_TX_NONCE);
+        witness = _buildWitnessTx(pkScript, sats, DEFAULT_TX_NONCE);
+    }
+
+    /// @notice The premise both examples rest on: same parsed output, different hash.
+    function test_premise_sameOutputDifferentHash() public view {
+        (
+            bytes memory stripped,
+            bytes memory witness
+        ) = _twoSerializationsOfOneDeposit();
+
+        assertTrue(
+            this.hashTx(stripped) != this.hashTx(witness),
+            "wtxid differs from txid"
+        );
+        assertTrue(
+            _pegInIdForTx(rskUser, stripped) !=
+                _pegInIdForTx(rskUser, witness),
+            "so the two presentations get different pegInIds"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // BAD: what the current, hash-blind BridgeMock lets you assert
+    // ------------------------------------------------------------------
+
+    /// @notice Passes today. One real deposit is claimed TWICE for full value, because the mock
+    /// hands out confirmations for any hash at all — including a wtxid that no merkle tree
+    /// contains. The already-processed guard does not help: it is keyed on the hash, and the two
+    /// presentations hash differently.
+    ///
+    /// A green run here means the suite is blessing a double-claim that the real bridge rejects.
+    function test_BAD_hashBlindMock_letsOneDepositBeClaimedTwice() public {
+        (
+            bytes memory stripped,
+            bytes memory witness
+        ) = _twoSerializationsOfOneDeposit();
+        uint256 net = DEFAULT_AMOUNT - _expectedFee(DEFAULT_AMOUNT);
+
+        // Blanket confirmations for every hash — the current mock's only mode.
+        bridgeMock.setConfirmations(int256(DEFAULT_TIER_CONFIRMATIONS));
+
+        uint256 userBefore = rskUser.balance;
+
+        // Claim 1: the honest, witness-stripped presentation.
+        bytes32 firstId = _requestPegInTx(claimer, rskUser, stripped, net);
+
+        // Claim 2: the SAME deposit, re-serialized with a witness. Fresh pegInId, so the
+        // already-processed check waves it through, and the mock confirms the wtxid.
+        bytes32 secondId = _requestPegInTx(claimer, rskUser, witness, net);
+
+        assertTrue(firstId != secondId, "two ids for one deposit");
+
+        (address firstClaimer, uint256 firstFronted, , ) = _readClaim(firstId);
+        (address secondClaimer, uint256 secondFronted, , ) = _readClaim(
+            secondId
+        );
+        assertEq(firstClaimer, claimer, "claim 1 written");
+        assertEq(secondClaimer, claimer, "claim 2 written for the same deposit");
+        assertEq(firstFronted, net, "claim 1 fronted full net");
+        assertEq(secondFronted, net, "claim 2 fronted full net");
+
+        // The user was paid twice for a single BTC deposit.
+        assertEq(
+            rskUser.balance,
+            userBefore + (net * 2),
+            "one deposit, two full deliveries"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // GOOD: what a txid-aware BridgeMock lets you assert
+    // ------------------------------------------------------------------
+
+    /// @notice The same scenario against a mock that only confirms hashes it was actually given,
+    /// which is what a merkle proof does. The stripped presentation succeeds; the witness
+    /// presentation reverts InsufficientConfirmations(0, required) — production behaviour.
+    function test_GOOD_txidAwareMock_rejectsTheSecondPresentation() public {
+        (
+            bytes memory stripped,
+            bytes memory witness
+        ) = _twoSerializationsOfOneDeposit();
+        uint256 net = DEFAULT_AMOUNT - _expectedFee(DEFAULT_AMOUNT);
+
+        // Only the real txid is in the "merkle tree". Nothing else is confirmable.
+        bridgeMock.setConfirmationsFor(
+            this.hashTx(stripped),
+            int256(DEFAULT_TIER_CONFIRMATIONS)
+        );
+
+        uint256 userBefore = rskUser.balance;
+
+        // Claim 1 still works: this is the transaction that is really on chain.
+        bytes32 firstId = _requestPegInTx(claimer, rskUser, stripped, net);
+        (address firstClaimer, , , ) = _readClaim(firstId);
+        assertEq(firstClaimer, claimer, "honest claim unaffected");
+
+        // Claim 2 is now stopped where the real bridge stops it.
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.InsufficientConfirmations.selector,
+                0,
+                DEFAULT_TIER_CONFIRMATIONS
+            )
+        );
+        pegInContract.requestPegIn{value: net}(
+            rskUser,
+            witness,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+
+        (address secondClaimer, , , ) = _readClaim(
+            _pegInIdForTx(rskUser, witness)
+        );
+        assertEq(secondClaimer, address(0), "no second claim written");
+        assertEq(
+            rskUser.balance,
+            userBefore + net,
+            "one deposit, one delivery"
+        );
+    }
+
+    /// @notice The broader point, independent of segwit: with a txid-aware mock, the suite can
+    /// finally observe that requestPegIn asks the bridge about the hash it derived from the
+    /// presented bytes. Confirm a DIFFERENT hash and the claim must still fail.
+    function test_GOOD_txidAwareMock_pinsWhichHashIsProven() public {
+        bytes memory btcTx = _defaultTx();
+        uint256 net = DEFAULT_AMOUNT - _expectedFee(DEFAULT_AMOUNT);
+
+        // Confirmations exist, but for an unrelated transaction.
+        bridgeMock.setConfirmationsFor(
+            keccak256("some other confirmed tx"),
+            int256(DEFAULT_TIER_CONFIRMATIONS)
+        );
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.InsufficientConfirmations.selector,
+                0,
+                DEFAULT_TIER_CONFIRMATIONS
+            )
+        );
+        pegInContract.requestPegIn{value: net}(
+            rskUser,
+            btcTx,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+    }
+}

--- a/test/pegin/RequestPegInAtomicity.t.sol
+++ b/test/pegin/RequestPegInAtomicity.t.sol
@@ -12,7 +12,8 @@ import {Flyover} from "../../src/libraries/Flyover.sol";
 contract RequestPegInAtomicityTest is RequestPegInTestBase {
     function test_failedCheck_isAtomic_unregistered() public {
         address unregistered = makeAddr("unregisteredAtomic");
-        bytes32 pegInId = _pegInId(unregistered, DEFAULT_BTC_TX_HASH);
+        bytes memory btcTx = _depositTx(unregistered, DEFAULT_AMOUNT);
+        bytes32 pegInId = _pegInIdForTx(unregistered, btcTx);
         uint256 userBefore = unregistered.balance;
 
         vm.prank(claimer);
@@ -24,8 +25,7 @@ contract RequestPegInAtomicityTest is RequestPegInTestBase {
         );
         pegInContract.requestPegIn{value: 1 ether}(
             unregistered,
-            DEFAULT_AMOUNT,
-            DEFAULT_BTC_TX_HASH,
+            btcTx,
             "",
             bytes32(0),
             0,
@@ -40,9 +40,40 @@ contract RequestPegInAtomicityTest is RequestPegInTestBase {
         );
     }
 
+    function test_failedCheck_isAtomic_depositOutputNotFound() public {
+        bytes memory unrelated = _unrelatedTx();
+        bytes32 pegInId = _pegInIdForTx(rskUser, unrelated);
+        uint256 userBefore = rskUser.balance;
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.DepositOutputNotFound.selector,
+                rskUser,
+                this.hashTx(unrelated)
+            )
+        );
+        pegInContract.requestPegIn{value: 1 wei}(
+            rskUser,
+            unrelated,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+
+        _assertNoClaim(pegInId);
+        assertEq(
+            rskUser.balance,
+            userBefore,
+            "no delivery when no output pays the derived address"
+        );
+    }
+
     function test_failedCheck_isAtomic_insufficientConfirmations() public {
         bridgeMock.setConfirmations(int256(DEFAULT_TIER_CONFIRMATIONS) - 1);
-        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+        bytes memory btcTx = _defaultTx();
+        bytes32 pegInId = _pegInIdForTx(rskUser, btcTx);
         uint256 userBefore = rskUser.balance;
 
         vm.prank(claimer);
@@ -55,8 +86,7 @@ contract RequestPegInAtomicityTest is RequestPegInTestBase {
         );
         pegInContract.requestPegIn{value: 1 ether}(
             rskUser,
-            DEFAULT_AMOUNT,
-            DEFAULT_BTC_TX_HASH,
+            btcTx,
             "",
             bytes32(0),
             0,
@@ -74,7 +104,8 @@ contract RequestPegInAtomicityTest is RequestPegInTestBase {
     function test_failedCheck_isAtomic_incorrectFronting() public {
         uint256 amount = DEFAULT_AMOUNT;
         uint256 wrongValue = amount; // not amount - fee
-        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+        bytes memory btcTx = _defaultTx();
+        bytes32 pegInId = _pegInIdForTx(rskUser, btcTx);
         uint256 userBefore = rskUser.balance;
 
         vm.prank(claimer);
@@ -87,8 +118,7 @@ contract RequestPegInAtomicityTest is RequestPegInTestBase {
         );
         pegInContract.requestPegIn{value: wrongValue}(
             rskUser,
-            amount,
-            DEFAULT_BTC_TX_HASH,
+            btcTx,
             "",
             bytes32(0),
             0,
@@ -112,15 +142,15 @@ contract RequestPegInAtomicityTest is RequestPegInTestBase {
 
         uint256 amount = DEFAULT_AMOUNT;
         uint256 net = amount - _expectedFee(amount);
-        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+        bytes memory btcTx = _defaultTx();
+        bytes32 pegInId = _pegInIdForTx(rskUser, btcTx);
         uint256 userBefore = rskUser.balance;
 
         vm.prank(claimer);
         vm.expectRevert(Flyover.EnforcedPause.selector);
         pegInContract.requestPegIn{value: net}(
             rskUser,
-            amount,
-            DEFAULT_BTC_TX_HASH,
+            btcTx,
             "",
             bytes32(0),
             0,

--- a/test/pegin/RequestPegInAtomicity.t.sol
+++ b/test/pegin/RequestPegInAtomicity.t.sol
@@ -42,7 +42,9 @@ contract RequestPegInAtomicityTest is RequestPegInTestBase {
 
     function test_failedCheck_isAtomic_depositOutputNotFound() public {
         bytes memory unrelated = _unrelatedTx();
-        bytes32 pegInId = _pegInIdForTx(rskUser, unrelated);
+        // Hashed before the prank: hashTx is an external self-call and would consume it.
+        bytes32 txHash = this.hashTx(unrelated);
+        bytes32 pegInId = _pegInId(rskUser, txHash);
         uint256 userBefore = rskUser.balance;
 
         vm.prank(claimer);
@@ -50,7 +52,7 @@ contract RequestPegInAtomicityTest is RequestPegInTestBase {
             abi.encodeWithSelector(
                 IPegInCommitFirst.DepositOutputNotFound.selector,
                 rskUser,
-                this.hashTx(unrelated)
+                txHash
             )
         );
         pegInContract.requestPegIn{value: 1 wei}(

--- a/test/pegin/RequestPegInFeeEdges.t.sol
+++ b/test/pegin/RequestPegInFeeEdges.t.sol
@@ -12,10 +12,11 @@ contract RequestPegInFeeEdgesTest is RequestPegInTestBase {
         uint256 amount = TEST_MIN_PEGIN;
         uint256 fee = _expectedFee(amount);
         uint256 net = amount - fee;
-        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+        bytes memory btcTx = _depositTx(rskUser, amount);
+        bytes32 pegInId = _pegInIdForTx(rskUser, btcTx);
 
         uint256 userBefore = rskUser.balance;
-        _requestPegIn(claimer, rskUser, amount, DEFAULT_BTC_TX_HASH, net);
+        _requestPegInTx(claimer, rskUser, btcTx, net);
 
         assertEq(
             rskUser.balance,
@@ -31,11 +32,12 @@ contract RequestPegInFeeEdgesTest is RequestPegInTestBase {
         uint256 amount = DEFAULT_MAX_AMOUNT;
         uint256 fee = _expectedFee(amount);
         uint256 net = amount - fee;
-        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+        bytes memory btcTx = _depositTx(rskUser, amount);
+        bytes32 pegInId = _pegInIdForTx(rskUser, btcTx);
 
         vm.deal(claimer, amount);
         uint256 userBefore = rskUser.balance;
-        _requestPegIn(claimer, rskUser, amount, DEFAULT_BTC_TX_HASH, net);
+        _requestPegInTx(claimer, rskUser, btcTx, net);
 
         assertEq(
             rskUser.balance,
@@ -52,6 +54,7 @@ contract RequestPegInFeeEdgesTest is RequestPegInTestBase {
         // Fee strictly greater than the amount: amount < fee path -> IncorrectFronting(0, msg.value).
         configurations.setFee(amount + 1, 0);
         uint256 sentValue = 1;
+        bytes memory btcTx = _depositTx(rskUser, amount);
 
         vm.prank(claimer);
         vm.expectRevert(
@@ -63,8 +66,7 @@ contract RequestPegInFeeEdgesTest is RequestPegInTestBase {
         );
         pegInContract.requestPegIn{value: sentValue}(
             rskUser,
-            amount,
-            DEFAULT_BTC_TX_HASH,
+            btcTx,
             "",
             bytes32(0),
             0,

--- a/test/pegin/RequestPegInHappyPath.t.sol
+++ b/test/pegin/RequestPegInHappyPath.t.sol
@@ -32,7 +32,8 @@ contract RequestPegInHappyPathTest is RequestPegInTestBase {
         uint256 amount = DEFAULT_AMOUNT;
         uint256 fee = _expectedFee(amount);
         uint256 expectedNet = amount - fee;
-        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+        bytes memory btcTx = _defaultTx();
+        bytes32 pegInId = _pegInIdForTx(rskUser, btcTx);
 
         uint256 claimerBefore = claimer.balance;
         uint256 userBefore = rskUser.balance;
@@ -47,11 +48,10 @@ contract RequestPegInHappyPathTest is RequestPegInTestBase {
             true
         );
 
-        bytes32 returnedId = _requestPegIn(
+        bytes32 returnedId = _requestPegInTx(
             claimer,
             rskUser,
-            amount,
-            DEFAULT_BTC_TX_HASH,
+            btcTx,
             expectedNet
         );
 
@@ -87,15 +87,10 @@ contract RequestPegInHappyPathTest is RequestPegInTestBase {
         uint256 amount = DEFAULT_AMOUNT;
         uint256 fee = _expectedFee(amount);
         uint256 expectedNet = amount - fee;
-        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+        bytes memory btcTx = _defaultTx();
+        bytes32 pegInId = _pegInIdForTx(rskUser, btcTx);
 
-        _requestPegIn(
-            claimer,
-            rskUser,
-            amount,
-            DEFAULT_BTC_TX_HASH,
-            expectedNet
-        );
+        _requestPegInTx(claimer, rskUser, btcTx, expectedNet);
 
         (, , uint256 feeAtClaimBefore, ) = _readClaim(pegInId);
         assertEq(feeAtClaimBefore, fee, "fee snapshot at claim");
@@ -116,5 +111,74 @@ contract RequestPegInHappyPathTest is RequestPegInTestBase {
             feeAtClaimBefore,
             "recorded feeAtClaim unchanged after config change"
         );
+    }
+
+    /// @notice The amount is read off the deposit output, so a caller who wants a different
+    /// amount has to present a different deposit. Two deposits of different sizes, claimed with
+    /// nothing but the transaction changing, produce two different peg-in amounts.
+    function test_amount_followsTheDepositOutput() public {
+        address second = makeAddr("rskUserSecond");
+        registry.harness_seedRegistration(second, makeAddr("registrant3"), 1);
+
+        uint256 small = 0.5 ether;
+        uint256 large = 20 ether;
+        vm.deal(claimer, 100 ether);
+
+        bytes memory smallTx = _depositTx(rskUser, small);
+        bytes memory largeTx = _depositTx(second, large);
+
+        vm.expectEmit(true, true, true, true);
+        emit IPegInCommitFirst.PegInRequested(
+            _pegInIdForTx(rskUser, smallTx),
+            claimer,
+            rskUser,
+            small,
+            small - _expectedFee(small),
+            true
+        );
+        _requestPegInTx(claimer, rskUser, smallTx, small - _expectedFee(small));
+
+        vm.expectEmit(true, true, true, true);
+        emit IPegInCommitFirst.PegInRequested(
+            _pegInIdForTx(second, largeTx),
+            claimer,
+            second,
+            large,
+            large - _expectedFee(large),
+            true
+        );
+        _requestPegInTx(claimer, second, largeTx, large - _expectedFee(large));
+    }
+
+    /// @notice Satoshi-to-wei conversion pinned to a literal fixture, so an off-by-a-power-of-ten
+    /// in the scaling cannot pass CI. 123_456_789 sats is 1.23456789 RBTC; every neighbouring
+    /// power of ten is a different number and would fail this assertion.
+    function test_satToWei_pinnedFixture() public {
+        uint64 depositSats = 123_456_789;
+        uint256 expectedAmount = 1.23456789 ether;
+        assertEq(
+            uint256(depositSats) * 10 ** 10,
+            expectedAmount,
+            "fixture self-check: 123456789 sats == 1.23456789 ether"
+        );
+
+        bytes memory btcTx = _buildTx(
+            _depositPkScript(rskUser),
+            depositSats,
+            42
+        );
+        uint256 net = expectedAmount - _expectedFee(expectedAmount);
+        vm.deal(claimer, 100 ether);
+
+        vm.expectEmit(true, true, true, true);
+        emit IPegInCommitFirst.PegInRequested(
+            _pegInIdForTx(rskUser, btcTx),
+            claimer,
+            rskUser,
+            expectedAmount,
+            net,
+            true
+        );
+        _requestPegInTx(claimer, rskUser, btcTx, net);
     }
 }

--- a/test/pegin/RequestPegInRealTransactions.t.sol
+++ b/test/pegin/RequestPegInRealTransactions.t.sol
@@ -186,7 +186,7 @@ contract RequestPegInRealTransactionsTest is RequestPegInTestBase {
     /// @notice Both outputs of a real transaction pay the derived deposit address. Today the
     /// amount is output 0's value alone (530135 sats), NOT the 998404 the two sum to.
     ///
-    /// This is the open question {PegInDerivation-findFirstBtcOutputPaying} records, pinned so it
+    /// This is the open question {BtcTransactionReader-findFirstOutputPaying} records, pinned so it
     /// cannot change silently: if first-match ever becomes sum, this test fails and forces the
     /// registry — which reads the same helper as a minimum-deposit gate — to be moved in the same
     /// change. A user whose wallet splits a deposit across two outputs to the same address is

--- a/test/pegin/RequestPegInRealTransactions.t.sol
+++ b/test/pegin/RequestPegInRealTransactions.t.sol
@@ -1,0 +1,370 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {RequestPegInTestBase} from "./RequestPegInTestBase.sol";
+import {IPegInCommitFirst} from "../../src/interfaces/IPegInCommitFirst.sol";
+import {Flyover} from "../../src/libraries/Flyover.sol";
+
+/// @title requestPegIn against real Bitcoin transactions
+/// @notice The other requestPegIn suites build their deposits with `_buildTx`: one input, an empty
+/// scriptSig, one output, a nonce where the prevout txid goes. That shape is convenient and it is
+/// nothing like a transaction off the chain. It cannot fail the way a real one can — several
+/// inputs each carrying a ~110-byte scriptSig, the deposit sitting at output 1 or 2 behind a change
+/// output, an OP_RETURN alongside it, values that are not round numbers, and length prefixes for
+/// all of it that the output walk has to step over correctly.
+///
+/// So this suite claims against real transactions, taken from fixtures already in this repo:
+/// - Two real Bitcoin transactions that the legacy `registerPegIn` tests use as Flyover peg-in
+///   deposits ([test/legacy/PegIn.t.sol]). Both spend P2SH-wrapped-segwit inputs and pay P2SH
+///   outputs — the same output type a commit-first deposit address is — so their shape is the
+///   closest thing available to the transaction this contract will be handed in production.
+/// - A real P2PKH transaction carrying a 64-byte OP_RETURN payload, from
+///   [test/libraries/BtcUtils.t.sol].
+///
+/// All three are canonically serialized (no segwit marker), so the txid `BtcUtils.hashBtcTx`
+/// returns is the real one — pinned below, and asserted, so a corrupted paste fails loudly
+/// instead of quietly testing a transaction that never existed.
+///
+/// Used two ways. As-is they pay nobody this protocol derives, which is the attacker's "any
+/// confirmed txid off the chain" — the case the DoS depended on. Spliced, one output's
+/// scriptPubkey is swapped for the derived deposit script and every other byte is left alone,
+/// which puts a real deposit inside a real transaction and asserts the amount read back is that
+/// output's real value.
+contract RequestPegInRealTransactionsTest is RequestPegInTestBase {
+    // ---- real transaction 1: mainnet Flyover deposit, 2 inputs, 2 P2SH outputs ----
+
+    bytes32 private constant _TXID_2IN =
+        0xde221070e8b4896c5542159fd12a139f7b1d378f4a8d04dd1b94ac8fb99cb834;
+    bytes private constant _SCRIPT_2IN_OUT0 =
+        hex"a9149fa51efd2954990e4974e7b13468fb8be54512d887";
+    bytes private constant _SCRIPT_2IN_OUT1 =
+        hex"a914b979999438ade0fdd2cf303fca55ea29aec2392b87";
+    uint64 private constant _SATS_2IN_OUT0 = 530_135;
+    uint64 private constant _SATS_2IN_OUT1 = 468_269;
+
+    // ---- real transaction 2: mainnet Flyover deposit, 1 input, 2 P2SH outputs ----
+
+    bytes32 private constant _TXID_1IN =
+        0xca62143692e4bde275a7c185678e08341ca783dcd258a78cf00182a31b051e9a;
+    bytes private constant _SCRIPT_1IN_OUT0 =
+        hex"a9141b67149e474f0d7757181f4db89257f27a64738387";
+    uint64 private constant _SATS_1IN_OUT0 = 810_134;
+
+    // ---- real transaction 3: P2PKH plus a 64-byte OP_RETURN ----
+
+    bytes32 private constant _TXID_OP_RETURN =
+        0x03c4522ef958f724a7d2ffef04bd534d9eca74ffc0b28308797d2853bc323ba6;
+    bytes private constant _SCRIPT_OP_RETURN_OUT0 =
+        hex"76a9143c5f66fe733e0ad361805b3053f23212e5755c8d88ac";
+    uint64 private constant _SATS_OP_RETURN_OUT0 = 60_000_000;
+
+    /// @notice Real transaction: 2 inputs with P2SH-wrapped-segwit scriptSigs, 2 P2SH outputs of
+    /// 530135 and 468269 satoshis.
+    function _realDeposit2In() private pure returns (bytes memory) {
+        return
+            hex"020000000212bebc8ba671aa9af2e3984af89366b5594ed115dbbaef64a41e8650cd4a53ea00"
+            hex"00000017160014fe7b123124c87300e8ba30f0e2eafdd8e1f2b337ffffffff046d8f4e5fa8"
+            hex"d6cc5fa23c50640249461b646e8a4722c9cfbfbff00c049d559f0000000017160014fe7b12"
+            hex"3124c87300e8ba30f0e2eafdd8e1f2b337ffffffff02d71608000000000017a9149fa51efd"
+            hex"2954990e4974e7b13468fb8be54512d8872d2507000000000017a914b979999438ade0fdd2"
+            hex"cf303fca55ea29aec2392b8700000000";
+    }
+
+    /// @notice Real transaction: 1 input, 2 P2SH outputs of 810134 and 88850 satoshis.
+    function _realDeposit1In() private pure returns (bytes memory) {
+        return
+            hex"010000000148e9e71dafee5a901be4eceb5aca361c083481b70496f4e3da71e5d969add182"
+            hex"0000000017160014b88ef07cd7bcc022b6d73c4764ce5db0887d5b05ffffffff02965c0c00"
+            hex"0000000017a9141b67149e474f0d7757181f4db89257f27a64738387125b01000000000017"
+            hex"a914785c3e807e54dc41251d6377da0673123fa87bc88700000000";
+    }
+
+    /// @notice Real transaction: 1 input with a 106-byte scriptSig, a 0.6 BTC P2PKH output and a
+    /// zero-value 64-byte OP_RETURN.
+    function _realP2pkhWithOpReturn() private pure returns (bytes memory) {
+        return
+            hex"0100000001013503c427ba46058d2d8ac9221a2f6fd50734a69f19dae65420191e3ada2d40"
+            hex"000000006a47304402205d047dbd8c49aea5bd0400b85a57b2da7e139cec632fb138b7bee1"
+            hex"d382fd70ca02201aa529f59b4f66fdf86b0728937a91a40962aedd3f6e30bce5208fec0464"
+            hex"d54901210255507b238c6f14735a7abe96a635058da47b05b61737a610bef757f009eea2a4"
+            hex"ffffffff0200879303000000001976a9143c5f66fe733e0ad361805b3053f23212e5755c8d"
+            hex"88ac0000000000000000426a4039383439343464353830393231353663356131396439363562"
+            hex"39613735383530326536646263326439353337333135656266343839373336333134656233"
+            hex"343700000000";
+    }
+
+    // ---- fixture integrity ----
+
+    /// @notice Pins each fixture to the txid its bytes really hash to. If a fixture is ever
+    /// truncated or mis-pasted, this fails here rather than turning the suite below into a test of
+    /// some transaction that does not exist.
+    function test_realTx_hashToTheirPinnedTxids() public view {
+        assertEq(
+            this.hashTx(_realDeposit2In()),
+            _TXID_2IN,
+            "2-input Flyover deposit txid"
+        );
+        assertEq(
+            this.hashTx(_realDeposit1In()),
+            _TXID_1IN,
+            "1-input Flyover deposit txid"
+        );
+        assertEq(
+            this.hashTx(_realP2pkhWithOpReturn()),
+            _TXID_OP_RETURN,
+            "P2PKH-with-OP_RETURN txid"
+        );
+    }
+
+    // ---- real transactions that pay nobody we derive ----
+
+    /// @notice A real Flyover deposit, but derived under the legacy quote flow for someone else.
+    /// It is confirmed, it pays real P2SH outputs, and it must still be refused: no output pays
+    /// the address derived for rskAddr. This is the shape of the original attack, with a txid that
+    /// is genuinely on chain rather than one built for the test.
+    function test_realTx_flyoverDepositForSomeoneElse_reverts() public {
+        _assertRealTxIsRefused(_realDeposit2In(), _TXID_2IN);
+    }
+
+    function test_realTx_singleInputFlyoverDeposit_reverts() public {
+        _assertRealTxIsRefused(_realDeposit1In(), _TXID_1IN);
+    }
+
+    /// @notice A real transaction with no P2SH output at all: the output walk has to step over a
+    /// 25-byte P2PKH script and a 66-byte OP_RETURN and report no match, not misread either as a
+    /// deposit.
+    function test_realTx_p2pkhWithOpReturn_reverts() public {
+        _assertRealTxIsRefused(_realP2pkhWithOpReturn(), _TXID_OP_RETURN);
+    }
+
+    // ---- real transactions carrying a real deposit ----
+
+    /// @notice Deposit at output 0 of a 2-input transaction, with a real P2SH change output behind
+    /// it. The amount read is that output's real value, 530135 satoshis, not the fixture's round
+    /// 5 ether.
+    function test_realTx_depositAtFirstOutput_readsThatOutputsValue() public {
+        _assertReadsAmount(
+            _payToDepositInstead(_realDeposit2In(), _SCRIPT_2IN_OUT0),
+            _SATS_2IN_OUT0
+        );
+    }
+
+    /// @notice Deposit at output 1, behind a real 23-byte P2SH output the walk has to step over
+    /// first. The synthetic fixtures always put the deposit at output 0, so this is the first
+    /// assertion that a non-zero output index is read correctly at all.
+    function test_realTx_depositAtSecondOutput_readsThatOutputsValue() public {
+        _assertReadsAmount(
+            _payToDepositInstead(_realDeposit2In(), _SCRIPT_2IN_OUT1),
+            _SATS_2IN_OUT1
+        );
+    }
+
+    function test_realTx_depositInSingleInputTransaction_readsThatOutputsValue()
+        public
+    {
+        _assertReadsAmount(
+            _payToDepositInstead(_realDeposit1In(), _SCRIPT_1IN_OUT0),
+            _SATS_1IN_OUT0
+        );
+    }
+
+    /// @notice Deposit alongside a real OP_RETURN. Also the one case where the spliced script is
+    /// SHORTER than the one it replaces (23 bytes over a 25-byte P2PKH), so the output that
+    /// follows shifts and the walk has to find it from the rewritten length prefix.
+    function test_realTx_depositBesideRealOpReturn_readsTheDepositValue()
+        public
+    {
+        _assertReadsAmount(
+            _payToDepositInstead(
+                _realP2pkhWithOpReturn(),
+                _SCRIPT_OP_RETURN_OUT0
+            ),
+            _SATS_OP_RETURN_OUT0
+        );
+    }
+
+    /// @notice Both outputs of a real transaction pay the derived deposit address. Today the
+    /// amount is output 0's value alone (530135 sats), NOT the 998404 the two sum to.
+    ///
+    /// This is the open question {PegInDerivation-findFirstBtcOutputPaying} records, pinned so it
+    /// cannot change silently: if first-match ever becomes sum, this test fails and forces the
+    /// registry — which reads the same helper as a minimum-deposit gate — to be moved in the same
+    /// change. A user whose wallet splits a deposit across two outputs to the same address is
+    /// currently credited only the first.
+    function test_realTx_twoOutputsPayTheDeposit_readsOnlyTheFirst() public {
+        bytes memory spliced = _payToDepositInstead(
+            _payToDepositInstead(_realDeposit2In(), _SCRIPT_2IN_OUT0),
+            _SCRIPT_2IN_OUT1
+        );
+
+        assertEq(
+            uint256(_SATS_2IN_OUT0) + uint256(_SATS_2IN_OUT1),
+            998_404,
+            "fixture self-check: the two outputs sum to 998404 sats"
+        );
+        _assertReadsAmount(spliced, _SATS_2IN_OUT0);
+    }
+
+    // ---- assertions ----
+
+    /// @notice Claims `realTx` for rskUser and asserts it is refused for having no output that
+    /// pays the derived deposit address, under its real txid.
+    function _assertRealTxIsRefused(
+        bytes memory realTx,
+        bytes32 expectedTxid
+    ) private {
+        bytes32 pegInId = _pegInId(rskUser, expectedTxid);
+        uint256 userBefore = rskUser.balance;
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.DepositOutputNotFound.selector,
+                rskUser,
+                expectedTxid
+            )
+        );
+        pegInContract.requestPegIn{value: 1 wei}(
+            rskUser,
+            realTx,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+
+        _assertNoClaim(pegInId);
+        assertEq(
+            rskUser.balance,
+            userBefore,
+            "no delivery on a transaction that pays us nothing"
+        );
+    }
+
+    /// @notice Claims `btcTx` and asserts the amount the contract read is `expectedSats` scaled to
+    /// wei, by requiring the event to carry it and the fronting equality to hold against it. Both
+    /// are checked against a satoshi count written down here, never one re-derived from the
+    /// transaction by the code under test.
+    function _assertReadsAmount(
+        bytes memory btcTx,
+        uint64 expectedSats
+    ) private {
+        uint256 expectedAmount = uint256(expectedSats) *
+            Flyover.SAT_TO_WEI_CONVERSION;
+        uint256 net = expectedAmount - _expectedFee(expectedAmount);
+        bytes32 pegInId = _pegInIdForTx(rskUser, btcTx);
+        uint256 userBefore = rskUser.balance;
+
+        vm.expectEmit(true, true, true, true);
+        emit IPegInCommitFirst.PegInRequested(
+            pegInId,
+            claimer,
+            rskUser,
+            expectedAmount,
+            net,
+            true
+        );
+        _requestPegInTx(claimer, rskUser, btcTx, net);
+
+        (
+            address claimerAddr,
+            uint256 frontedAmount,
+            uint256 feeAtClaim,
+
+        ) = _readClaim(pegInId);
+        assertEq(claimerAddr, claimer, "claim recorded to the claimer");
+        assertEq(
+            frontedAmount,
+            net,
+            "fronted amount is the real deposit minus the fee"
+        );
+        assertEq(
+            feeAtClaim,
+            _expectedFee(expectedAmount),
+            "fee computed on the real amount"
+        );
+        assertEq(
+            rskUser.balance - userBefore,
+            net,
+            "user received the real deposit minus the fee"
+        );
+    }
+
+    function _assertNoClaim(bytes32 pegInId) private view {
+        (
+            address claimerAddr,
+            uint256 frontedAmount,
+            ,
+            uint256 requestBlock
+        ) = _readClaim(pegInId);
+        assertEq(claimerAddr, address(0), "no claimer recorded");
+        assertEq(frontedAmount, 0, "no fronted amount recorded");
+        assertEq(requestBlock, 0, "no request block recorded");
+    }
+
+    // ---- splicing ----
+
+    /// @notice Rewrites the output currently paying `originalScript` to pay the deposit script
+    /// derived for rskUser instead, leaving every other byte of the real transaction as it is.
+    /// @dev Both scripts are well under 0xfd bytes, so the output's length prefix stays a single
+    /// byte and only its value changes. The transaction stops being a valid spend, which does not
+    /// matter here: requestPegIn parses outputs and takes confirmations from the bridge, and the
+    /// bridge is mocked.
+    function _payToDepositInstead(
+        bytes memory realTx,
+        bytes memory originalScript
+    ) private view returns (bytes memory) {
+        return
+            _replaceOnce(
+                realTx,
+                abi.encodePacked(
+                    bytes1(uint8(originalScript.length)),
+                    originalScript
+                ),
+                abi.encodePacked(
+                    bytes1(uint8(_depositPkScript(rskUser).length)),
+                    _depositPkScript(rskUser)
+                )
+            );
+    }
+
+    /// @notice Replaces the one occurrence of `needle` in `haystack` with `replacement`.
+    /// @dev Reverts unless the needle occurs exactly once, so a fixture whose output script is
+    /// ambiguous (or absent, after an edit) fails the test instead of splicing the wrong bytes.
+    function _replaceOnce(
+        bytes memory haystack,
+        bytes memory needle,
+        bytes memory replacement
+    ) private pure returns (bytes memory out) {
+        uint256 at;
+        uint256 count;
+        for (uint256 i = 0; i + needle.length <= haystack.length; ++i) {
+            bool hit = true;
+            for (uint256 j = 0; j < needle.length; ++j) {
+                if (haystack[i + j] != needle[j]) {
+                    hit = false;
+                    break;
+                }
+            }
+            if (hit) {
+                if (count == 0) {
+                    at = i;
+                }
+                ++count;
+            }
+        }
+        require(count == 1, "fixture: output script must occur exactly once");
+
+        out = new bytes(haystack.length - needle.length + replacement.length);
+        uint256 k;
+        for (uint256 i = 0; i < at; ++i) {
+            out[k++] = haystack[i];
+        }
+        for (uint256 i = 0; i < replacement.length; ++i) {
+            out[k++] = replacement[i];
+        }
+        for (uint256 i = at + needle.length; i < haystack.length; ++i) {
+            out[k++] = haystack[i];
+        }
+    }
+}

--- a/test/pegin/RequestPegInReentrancy.t.sol
+++ b/test/pegin/RequestPegInReentrancy.t.sol
@@ -7,12 +7,13 @@ import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol
 import {Flyover} from "../../src/libraries/Flyover.sol";
 
 /// @title requestPegIn reentrancy-guard test
-/// @notice A malicious destination re-enters requestPegIn on delivery with a different btcTxHash
-/// (a fresh pegInId), so the block comes from the nonReentrant guard rather than the
-/// already-processed check. The re-entry's revert bubbles through the delivery call, so the whole
-/// transaction reverts atomically and no claim is written for either pegInId.
+/// @notice A malicious destination re-enters requestPegIn on delivery with a second, genuine
+/// deposit transaction of its own (a different txid, so a fresh pegInId), so the block comes from
+/// the nonReentrant guard rather than the already-processed check or the deposit match. The
+/// re-entry's revert bubbles through the delivery call, so the whole transaction reverts
+/// atomically and no claim is written for either pegInId.
 contract RequestPegInReentrancyTest is RequestPegInTestBase {
-    bytes32 internal constant REENTER_BTC_TX_HASH = keccak256("reenter-btc-tx");
+    uint256 internal constant REENTER_TX_NONCE = 99;
 
     function test_reentrancy_maliciousRskAddr_differentPegInId() public {
         RequestPegInReenterReceiver receiver = new RequestPegInReenterReceiver(
@@ -26,10 +27,20 @@ contract RequestPegInReentrancyTest is RequestPegInTestBase {
 
         uint256 amount = DEFAULT_AMOUNT;
         uint256 net = amount - _expectedFee(amount);
-        receiver.setAttack(true, REENTER_BTC_TX_HASH);
 
-        bytes32 outerId = _pegInId(address(receiver), DEFAULT_BTC_TX_HASH);
-        bytes32 reenterId = _pegInId(address(receiver), REENTER_BTC_TX_HASH);
+        // Both transactions really pay the receiver's derived deposit address, so the re-entry
+        // is stopped by the guard and not by a failed derivation.
+        bytes memory outerTx = _depositTx(address(receiver), amount);
+        bytes memory reenterTx = _depositTx(
+            address(receiver),
+            amount,
+            REENTER_TX_NONCE
+        );
+        receiver.setAttack(true, reenterTx);
+
+        bytes32 outerId = _pegInIdForTx(address(receiver), outerTx);
+        bytes32 reenterId = _pegInIdForTx(address(receiver), reenterTx);
+        assertTrue(outerId != reenterId, "re-entry targets a fresh pegInId");
 
         // The re-entry reverts with the reentrancy guard error, which the delivery call surfaces
         // (and the implementation wraps) as PaymentFailed, reverting the whole transaction.
@@ -47,8 +58,7 @@ contract RequestPegInReentrancyTest is RequestPegInTestBase {
         );
         pegInContract.requestPegIn{value: net}(
             address(receiver),
-            amount,
-            DEFAULT_BTC_TX_HASH,
+            outerTx,
             "",
             bytes32(0),
             0,

--- a/test/pegin/RequestPegInReverts.t.sol
+++ b/test/pegin/RequestPegInReverts.t.sol
@@ -248,9 +248,9 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
         );
     }
 
-    /// @notice The tier is looked up with the DERIVED amount, so a large deposit presented with
-    /// only enough confirmations for a small one is rejected. Under the old signature the
-    /// claimer simply declared the small amount and bought the low tier.
+    /// @notice The tier is looked up with the amount READ off the deposit, so a large deposit
+    /// presented with only enough confirmations for a small one is rejected. Under the old
+    /// signature the claimer simply declared the small amount and bought the low tier.
     function test_revert_largeDeposit_cannotBuyTheLowConfirmationTier() public {
         uint256 smallAmount = 1 ether;
         uint256 largeAmount = 50 ether;

--- a/test/pegin/RequestPegInReverts.t.sol
+++ b/test/pegin/RequestPegInReverts.t.sol
@@ -167,6 +167,10 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
         // is served afterwards under the same pegInId the attacker tried to burn.
         bytes memory realDeposit = _defaultTx();
         bytes32 pegInId = _pegInIdForTx(rskUser, realDeposit);
+        // Built and hashed before the prank: hashTx is an external self-call and would consume
+        // it, dropping the dust claim back to the default sender instead of the attacker.
+        bytes memory dustClaimTx = _unrelatedTx();
+        bytes32 dustClaimTxHash = this.hashTx(dustClaimTx);
         address attacker = makeAddr("attacker");
         vm.deal(attacker, 1 ether);
 
@@ -175,12 +179,12 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
             abi.encodeWithSelector(
                 IPegInCommitFirst.DepositOutputNotFound.selector,
                 rskUser,
-                this.hashTx(_unrelatedTx())
+                dustClaimTxHash
             )
         );
         pegInContract.requestPegIn{value: 1 wei}(
             rskUser,
-            _unrelatedTx(),
+            dustClaimTx,
             "",
             bytes32(0),
             0,

--- a/test/pegin/RequestPegInReverts.t.sol
+++ b/test/pegin/RequestPegInReverts.t.sol
@@ -17,9 +17,10 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
     function test_revert_alreadyProcessed_secondClaimSameId() public {
         uint256 amount = DEFAULT_AMOUNT;
         uint256 net = amount - _expectedFee(amount);
-        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+        bytes memory btcTx = _defaultTx();
+        bytes32 pegInId = _pegInIdForTx(rskUser, btcTx);
 
-        _requestPegIn(claimer, rskUser, amount, DEFAULT_BTC_TX_HASH, net);
+        _requestPegInTx(claimer, rskUser, btcTx, net);
 
         vm.prank(claimer);
         vm.expectRevert(
@@ -30,8 +31,7 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
         );
         pegInContract.requestPegIn{value: net}(
             rskUser,
-            amount,
-            DEFAULT_BTC_TX_HASH,
+            btcTx,
             "",
             bytes32(0),
             0,
@@ -45,14 +45,14 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
         // Both branches of _requirePegInDepsSet on one unwired deployment: registry is checked
         // before configurations, so the errors surface in that order as each pointer is wired.
         PegInContract unwired = _deployUnwiredPegInContract();
+        bytes memory btcTx = _defaultTx();
 
         // Branch 1: nothing wired -> registry pointer nil is reported first.
         vm.prank(claimer);
         vm.expectRevert(PegInContract.PegInAddressRegistryNotSet.selector);
         unwired.requestPegIn{value: 1 ether}(
             rskUser,
-            DEFAULT_AMOUNT,
-            DEFAULT_BTC_TX_HASH,
+            btcTx,
             "",
             bytes32(0),
             0,
@@ -70,8 +70,7 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
         vm.expectRevert(PegInContract.FlyoverConfigurationsNotSet.selector);
         unwired.requestPegIn{value: 1 ether}(
             rskUser,
-            DEFAULT_AMOUNT,
-            DEFAULT_BTC_TX_HASH,
+            btcTx,
             "",
             bytes32(0),
             0,
@@ -83,6 +82,9 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
 
     function test_revert_unregisteredRskAddr() public {
         address unregistered = makeAddr("unregistered");
+        // Fixtures are built before vm.expectRevert: _depositTx reads the powpeg script from the
+        // bridge, and expectRevert would otherwise arm against that read.
+        bytes memory btcTx = _depositTx(unregistered, DEFAULT_AMOUNT);
 
         vm.prank(claimer);
         vm.expectRevert(
@@ -93,8 +95,7 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
         );
         pegInContract.requestPegIn{value: 1 ether}(
             unregistered,
-            DEFAULT_AMOUNT,
-            DEFAULT_BTC_TX_HASH,
+            btcTx,
             "",
             bytes32(0),
             0,
@@ -102,11 +103,103 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
         );
     }
 
-    // ---- Check 4: insufficient confirmations ----
+    // ---- Check 4: no output pays the derived deposit address ----
+    //
+    // This is the check that closes the dust lockout. Before it existed, any confirmed txid
+    // paired with any registered destination and a declared dust amount wrote the claim record
+    // and locked every honest LP out of the real deposit under PegInAlreadyProcessed.
+
+    function test_revert_depositOutputNotFound_unrelatedConfirmedTx() public {
+        // A confirmed transaction that pays nothing this protocol derives — the attacker's
+        // "any txid off the chain". Confirmations are satisfied; the derivation is not.
+        bytes memory unrelated = _unrelatedTx();
+        bytes32 txHash = this.hashTx(unrelated);
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.DepositOutputNotFound.selector,
+                rskUser,
+                txHash
+            )
+        );
+        pegInContract.requestPegIn{value: 1 wei}(
+            rskUser,
+            unrelated,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+    }
+
+    function test_revert_depositOutputNotFound_txPaysAnotherDestination()
+        public
+    {
+        // A real Flyover deposit, but derived for someone else. Claiming it against rskUser is
+        // the mismatched-transaction case: the output exists, it just is not rskUser's.
+        address other = makeAddr("otherDestination");
+        registry.harness_seedRegistration(other, makeAddr("registrant4"), 1);
+
+        bytes memory othersDeposit = _depositTx(other, DEFAULT_AMOUNT);
+        bytes32 txHash = this.hashTx(othersDeposit);
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.DepositOutputNotFound.selector,
+                rskUser,
+                txHash
+            )
+        );
+        pegInContract.requestPegIn{value: 1 wei}(
+            rskUser,
+            othersDeposit,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+    }
+
+    function test_dustClaim_cannotLockOutTheRealDeposit() public {
+        // End to end on the original defect: the dust claim is rejected, and the real depositor
+        // is served afterwards under the same pegInId the attacker tried to burn.
+        bytes memory realDeposit = _defaultTx();
+        bytes32 pegInId = _pegInIdForTx(rskUser, realDeposit);
+        address attacker = makeAddr("attacker");
+        vm.deal(attacker, 1 ether);
+
+        vm.prank(attacker);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.DepositOutputNotFound.selector,
+                rskUser,
+                this.hashTx(_unrelatedTx())
+            )
+        );
+        pegInContract.requestPegIn{value: 1 wei}(
+            rskUser,
+            _unrelatedTx(),
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+
+        uint256 net = DEFAULT_AMOUNT - _expectedFee(DEFAULT_AMOUNT);
+        _requestPegInTx(claimer, rskUser, realDeposit, net);
+
+        (address claimerAddr, , , ) = _readClaim(pegInId);
+        assertEq(claimerAddr, claimer, "honest LP still able to claim");
+    }
+
+    // ---- Check 5: insufficient confirmations ----
 
     function test_revert_insufficientConfirmations_tierBoundary() public {
         uint256 required = DEFAULT_TIER_CONFIRMATIONS;
         bridgeMock.setConfirmations(int256(required) - 1);
+        bytes memory btcTx = _defaultTx();
 
         vm.prank(claimer);
         vm.expectRevert(
@@ -118,8 +211,7 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
         );
         pegInContract.requestPegIn{value: 1 ether}(
             rskUser,
-            DEFAULT_AMOUNT,
-            DEFAULT_BTC_TX_HASH,
+            btcTx,
             "",
             bytes32(0),
             0,
@@ -132,6 +224,7 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
     {
         uint256 required = DEFAULT_TIER_CONFIRMATIONS;
         bridgeMock.setConfirmations(-1);
+        bytes memory btcTx = _defaultTx();
 
         vm.prank(claimer);
         vm.expectRevert(
@@ -143,12 +236,51 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
         );
         pegInContract.requestPegIn{value: 1 ether}(
             rskUser,
-            DEFAULT_AMOUNT,
-            DEFAULT_BTC_TX_HASH,
+            btcTx,
             "",
             bytes32(0),
             0,
             _emptyBranch()
+        );
+    }
+
+    /// @notice The tier is looked up with the DERIVED amount, so a large deposit presented with
+    /// only enough confirmations for a small one is rejected. Under the old signature the
+    /// claimer simply declared the small amount and bought the low tier.
+    function test_revert_largeDeposit_cannotBuyTheLowConfirmationTier() public {
+        uint256 smallAmount = 1 ether;
+        uint256 largeAmount = 50 ether;
+        uint256 lowTierConfirmations = 2;
+        uint256 highTierConfirmations = 40;
+        _applyTwoTierConfiguration(
+            smallAmount,
+            lowTierConfirmations,
+            highTierConfirmations
+        );
+
+        // Exactly the depth the small tier asks for, and no more.
+        bridgeMock.setConfirmations(int256(lowTierConfirmations));
+        vm.deal(claimer, 100 ether);
+        bytes memory largeTx = _depositTx(rskUser, largeAmount);
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.InsufficientConfirmations.selector,
+                lowTierConfirmations,
+                highTierConfirmations
+            )
+        );
+        pegInContract.requestPegIn{
+            value: largeAmount - _expectedFee(largeAmount)
+        }(rskUser, largeTx, "", bytes32(0), 0, _emptyBranch());
+
+        // The same depth serves a deposit that really is small.
+        _requestPegIn(
+            claimer,
+            rskUser,
+            smallAmount,
+            smallAmount - _expectedFee(smallAmount)
         );
     }
 
@@ -157,13 +289,7 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
         uint256 amount = DEFAULT_AMOUNT;
         uint256 net = amount - _expectedFee(amount);
 
-        bytes32 pegInId = _requestPegIn(
-            claimer,
-            rskUser,
-            amount,
-            DEFAULT_BTC_TX_HASH,
-            net
-        );
+        bytes32 pegInId = _requestPegIn(claimer, rskUser, amount, net);
         (address claimerAddr, , , ) = _readClaim(pegInId);
         assertEq(
             claimerAddr,
@@ -172,12 +298,13 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
         );
     }
 
-    // ---- Check 5: incorrect fronting ----
+    // ---- Check 6: incorrect fronting ----
 
-    function test_revert_incorrectFronting_wrongValue() public {
+    function test_revert_incorrectFronting_overstated() public {
         uint256 amount = DEFAULT_AMOUNT;
         uint256 expectedNet = amount - _expectedFee(amount);
         uint256 wrongValue = expectedNet + 1;
+        bytes memory btcTx = _defaultTx();
 
         vm.prank(claimer);
         vm.expectRevert(
@@ -189,8 +316,56 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
         );
         pegInContract.requestPegIn{value: wrongValue}(
             rskUser,
-            amount,
-            DEFAULT_BTC_TX_HASH,
+            btcTx,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+    }
+
+    function test_revert_incorrectFronting_understated() public {
+        uint256 amount = DEFAULT_AMOUNT;
+        uint256 expectedNet = amount - _expectedFee(amount);
+        uint256 wrongValue = expectedNet - 1;
+        bytes memory btcTx = _defaultTx();
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.IncorrectFronting.selector,
+                expectedNet,
+                wrongValue
+            )
+        );
+        pegInContract.requestPegIn{value: wrongValue}(
+            rskUser,
+            btcTx,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+    }
+
+    /// @notice Fronting dust against a real, large deposit. The expected value in the error is
+    /// the one derived from the deposit output, not anything the caller offered.
+    function test_revert_incorrectFronting_dustAgainstRealDeposit() public {
+        uint256 amount = DEFAULT_AMOUNT;
+        uint256 expectedNet = amount - _expectedFee(amount);
+        bytes memory btcTx = _defaultTx();
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.IncorrectFronting.selector,
+                expectedNet,
+                1 wei
+            )
+        );
+        pegInContract.requestPegIn{value: 1 wei}(
+            rskUser,
+            btcTx,
             "",
             bytes32(0),
             0,
@@ -203,9 +378,10 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
     function test_race_secondClaim_ordersBeforeFrontingCheck() public {
         uint256 amount = DEFAULT_AMOUNT;
         uint256 net = amount - _expectedFee(amount);
-        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+        bytes memory btcTx = _defaultTx();
+        bytes32 pegInId = _pegInIdForTx(rskUser, btcTx);
 
-        _requestPegIn(claimer, rskUser, amount, DEFAULT_BTC_TX_HASH, net);
+        _requestPegInTx(claimer, rskUser, btcTx, net);
 
         // Second claim with a deliberately wrong value still reverts already-processed,
         // never IncorrectFronting.
@@ -218,8 +394,7 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
         );
         pegInContract.requestPegIn{value: net + 123}(
             rskUser,
-            amount,
-            DEFAULT_BTC_TX_HASH,
+            btcTx,
             "",
             bytes32(0),
             0,
@@ -230,9 +405,10 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
     function test_race_secondClaim_ordersBeforeConfirmationsCheck() public {
         uint256 amount = DEFAULT_AMOUNT;
         uint256 net = amount - _expectedFee(amount);
-        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+        bytes memory btcTx = _defaultTx();
+        bytes32 pegInId = _pegInIdForTx(rskUser, btcTx);
 
-        _requestPegIn(claimer, rskUser, amount, DEFAULT_BTC_TX_HASH, net);
+        _requestPegInTx(claimer, rskUser, btcTx, net);
 
         // Drop confirmations below tier; already-processed still wins.
         bridgeMock.setConfirmations(0);
@@ -245,8 +421,7 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
         );
         pegInContract.requestPegIn{value: net}(
             rskUser,
-            amount,
-            DEFAULT_BTC_TX_HASH,
+            btcTx,
             "",
             bytes32(0),
             0,
@@ -258,7 +433,8 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
         // Unwired contract (deps unset) with a pre-seeded claim and an unregistered rskAddr:
         // check 1 must still win over the deps-set and registration checks.
         PegInContract unwired = _deployUnwiredPegInContract();
-        bytes32 pegInId = _pegInId(rskUser, DEFAULT_BTC_TX_HASH);
+        bytes memory btcTx = _defaultTx();
+        bytes32 pegInId = _pegInIdForTx(rskUser, btcTx);
         _seedClaim(unwired, pegInId, claimer);
 
         vm.prank(claimer);
@@ -270,8 +446,32 @@ contract RequestPegInRevertsTest is RequestPegInTestBase {
         );
         unwired.requestPegIn{value: 1 ether}(
             rskUser,
-            DEFAULT_AMOUNT,
-            DEFAULT_BTC_TX_HASH,
+            btcTx,
+            "",
+            bytes32(0),
+            0,
+            _emptyBranch()
+        );
+    }
+
+    /// @notice The already-processed check also wins over the derivation check: a second claim
+    /// presenting a transaction that pays nobody still reports the claim race, not the
+    /// derivation failure. Only the txid feeds the id, so the two are independent inputs.
+    function test_ordering_alreadyProcessed_beforeDepositMatch() public {
+        bytes memory unrelated = _unrelatedTx();
+        bytes32 pegInId = _pegInIdForTx(rskUser, unrelated);
+        _seedClaim(pegInContract, pegInId, claimer);
+
+        vm.prank(claimer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegInCommitFirst.PegInAlreadyProcessed.selector,
+                pegInId
+            )
+        );
+        pegInContract.requestPegIn{value: 1 wei}(
+            rskUser,
+            unrelated,
             "",
             bytes32(0),
             0,

--- a/test/pegin/RequestPegInTestBase.sol
+++ b/test/pegin/RequestPegInTestBase.sol
@@ -213,7 +213,7 @@ abstract contract RequestPegInTestBase is PegInTestBase {
         address rskAddr
     ) internal view returns (bytes memory) {
         return
-            PegInDerivation.expectedDepositPkScript(
+            PegInDerivation.depositPkScript(
                 rskAddr,
                 address(pegInContract),
                 bridgeMock.getActivePowpegRedeemScript()

--- a/test/pegin/RequestPegInTestBase.sol
+++ b/test/pegin/RequestPegInTestBase.sol
@@ -7,7 +7,7 @@ import {PegInContract} from "../../src/PegInContract.sol";
 import {PegInAddressRegistryHarness} from "../pegin-registry/PegInAddressRegistryHarness.sol";
 import {IFlyoverConfigurations} from "../../src/interfaces/IFlyoverConfigurations.sol";
 import {PegInDerivation} from "../../src/libraries/PegInDerivation.sol";
-import {Quotes} from "../../src/libraries/Quotes.sol";
+import {Flyover} from "../../src/libraries/Flyover.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {BtcUtils} from "@rsksmart/btc-transaction-solidity-helper/contracts/BtcUtils.sol";
 
@@ -289,10 +289,10 @@ abstract contract RequestPegInTestBase is PegInTestBase {
 
     function _toSats(uint256 amountWei) internal pure returns (uint64) {
         require(
-            amountWei % Quotes.SAT_TO_WEI_CONVERSION == 0,
+            amountWei % Flyover.SAT_TO_WEI_CONVERSION == 0,
             "fixture amount is not a whole number of satoshis"
         );
-        return uint64(amountWei / Quotes.SAT_TO_WEI_CONVERSION);
+        return uint64(amountWei / Flyover.SAT_TO_WEI_CONVERSION);
     }
 
     // ---- call helpers ----

--- a/test/pegin/RequestPegInTestBase.sol
+++ b/test/pegin/RequestPegInTestBase.sol
@@ -132,6 +132,10 @@ abstract contract RequestPegInTestBase is PegInTestBase {
     /// @notice Exposes BtcUtils.hashBtcTx to the memory-held fixtures. The library takes
     /// calldata, so the tests reach it through an external self-call rather than
     /// re-implementing the txid.
+    /// @dev Being an external self-call, this CONSUMES a pending vm.prank. Call it (and the
+    /// helpers below that wrap it) before vm.prank, never inside a vm.expectRevert payload that
+    /// follows one, or the call under test runs as the test contract instead of the pranked
+    /// sender and the test silently stops asserting who claimed.
     function hashTx(bytes calldata btcTx) external pure returns (bytes32) {
         return BtcUtils.hashBtcTx(btcTx);
     }

--- a/test/pegin/RequestPegInTestBase.sol
+++ b/test/pegin/RequestPegInTestBase.sol
@@ -6,7 +6,10 @@ import {FlyoverConfigurationsMock} from "./FlyoverConfigurationsMock.sol";
 import {PegInContract} from "../../src/PegInContract.sol";
 import {PegInAddressRegistryHarness} from "../pegin-registry/PegInAddressRegistryHarness.sol";
 import {IFlyoverConfigurations} from "../../src/interfaces/IFlyoverConfigurations.sol";
+import {PegInDerivation} from "../../src/libraries/PegInDerivation.sol";
+import {Quotes} from "../../src/libraries/Quotes.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {BtcUtils} from "@rsksmart/btc-transaction-solidity-helper/contracts/BtcUtils.sol";
 
 /// @title Base for commit-first requestPegIn tests
 /// @notice Deploys and wires a PegInContract against a real PegInAddressRegistry (seeded through
@@ -34,8 +37,12 @@ abstract contract RequestPegInTestBase is PegInTestBase {
     address internal claimer;
     address internal rskUser;
 
-    bytes32 internal constant DEFAULT_BTC_TX_HASH = keccak256("default-btc-tx");
     uint256 internal constant DEFAULT_AMOUNT = 5 ether;
+
+    /// @dev Varies the deposit transaction's input outpoint, and therefore its txid, without
+    /// touching the output being matched. Tests that need two distinct pegInIds for the same
+    /// destination and amount pass different nonces.
+    uint256 internal constant DEFAULT_TX_NONCE = 1;
 
     function setUp() public virtual {
         deployPegInContract();
@@ -88,6 +95,26 @@ abstract contract RequestPegInTestBase is PegInTestBase {
         configurations.setConfirmationTiers(tiers);
     }
 
+    /// @notice Replaces the single flat tier with a low tier up to `lowTierMaxAmount` and a high
+    /// tier above it, so tests can prove the tier is chosen by the DERIVED amount.
+    function _applyTwoTierConfiguration(
+        uint256 lowTierMaxAmount,
+        uint256 lowTierConfirmations,
+        uint256 highTierConfirmations
+    ) internal {
+        IFlyoverConfigurations.ConfirmationTier[]
+            memory tiers = new IFlyoverConfigurations.ConfirmationTier[](2);
+        tiers[0] = IFlyoverConfigurations.ConfirmationTier({
+            maxAmount: lowTierMaxAmount,
+            confirmations: lowTierConfirmations
+        });
+        tiers[1] = IFlyoverConfigurations.ConfirmationTier({
+            maxAmount: type(uint256).max,
+            confirmations: highTierConfirmations
+        });
+        configurations.setConfirmationTiers(tiers);
+    }
+
     /// @notice Deploys a second PegInContract with its dependencies left unset
     function _deployUnwiredPegInContract() internal returns (PegInContract) {
         return deployPegInContract(false);
@@ -100,6 +127,22 @@ abstract contract RequestPegInTestBase is PegInTestBase {
         bytes32 btcTxHash
     ) internal pure returns (bytes32) {
         return keccak256(abi.encodePacked(rskAddr, btcTxHash));
+    }
+
+    /// @notice Exposes BtcUtils.hashBtcTx to the memory-held fixtures. The library takes
+    /// calldata, so the tests reach it through an external self-call rather than
+    /// re-implementing the txid.
+    function hashTx(bytes calldata btcTx) external pure returns (bytes32) {
+        return BtcUtils.hashBtcTx(btcTx);
+    }
+
+    /// @notice The pegInId a claim of `btcTx` for `rskAddr` will be recorded under. The txid is
+    /// hashed out of the transaction, mirroring what the contract does.
+    function _pegInIdForTx(
+        address rskAddr,
+        bytes memory btcTx
+    ) internal view returns (bytes32) {
+        return _pegInId(rskAddr, this.hashTx(btcTx));
     }
 
     function _claimSlot(bytes32 pegInId) internal pure returns (uint256) {
@@ -156,29 +199,136 @@ abstract contract RequestPegInTestBase is PegInTestBase {
         );
     }
 
+    // ---- deposit-transaction fixtures ----
+    //
+    // requestPegIn no longer takes an amount or a txid: it reads both out of the raw deposit
+    // transaction. So every call site needs a transaction that really pays the address derived
+    // for its destination, built against the SAME inputs the contract derives with — this proxy's
+    // address and the bridge mock's powpeg script. A test that wants a bad claim builds a bad
+    // transaction; it can no longer just pass a bad number.
+
+    /// @notice The P2SH scriptPubkey a deposit for `rskAddr` must pay, derived exactly as
+    /// PegInContract derives it.
+    function _depositPkScript(
+        address rskAddr
+    ) internal view returns (bytes memory) {
+        return
+            PegInDerivation.expectedDepositPkScript(
+                rskAddr,
+                address(pegInContract),
+                bridgeMock.getActivePowpegRedeemScript()
+            );
+    }
+
+    /// @notice A one-input, one-output raw transaction paying `pkScript` `valueSats` satoshis.
+    /// @param nonce Mixed into the input outpoint so otherwise identical deposits get distinct
+    /// txids, and therefore distinct pegInIds.
+    function _buildTx(
+        bytes memory pkScript,
+        uint64 valueSats,
+        uint256 nonce
+    ) internal pure returns (bytes memory) {
+        bytes memory valueLe = new bytes(8);
+        uint64 v = valueSats;
+        for (uint256 i = 0; i < 8; ++i) {
+            valueLe[i] = bytes1(uint8(v & 0xFF));
+            v >>= 8;
+        }
+        return
+            abi.encodePacked(
+                hex"01000000", // version
+                hex"01", // input count
+                bytes32(nonce), // prevout txid
+                hex"00000000", // prevout index
+                hex"00", // empty scriptSig
+                hex"ffffffff", // sequence
+                hex"01", // output count
+                valueLe,
+                bytes1(uint8(pkScript.length)),
+                pkScript,
+                hex"00000000" // locktime
+            );
+    }
+
+    /// @notice A deposit transaction paying `rskAddr`'s derived address `amount` wei worth of BTC.
+    function _depositTx(
+        address rskAddr,
+        uint256 amount,
+        uint256 nonce
+    ) internal view returns (bytes memory) {
+        return _buildTx(_depositPkScript(rskAddr), _toSats(amount), nonce);
+    }
+
+    function _depositTx(
+        address rskAddr,
+        uint256 amount
+    ) internal view returns (bytes memory) {
+        return _depositTx(rskAddr, amount, DEFAULT_TX_NONCE);
+    }
+
+    /// @notice The default deposit fixture: DEFAULT_AMOUNT paid to rskUser's derived address.
+    function _defaultTx() internal view returns (bytes memory) {
+        return _depositTx(rskUser, DEFAULT_AMOUNT);
+    }
+
+    /// @notice A confirmed transaction that pays no address this protocol derives — the
+    /// "any confirmed txid" an attacker would reach for.
+    function _unrelatedTx() internal pure returns (bytes memory) {
+        // Plain P2PKH to an arbitrary hash160, 1 BTC.
+        bytes memory pkScript = abi.encodePacked(
+            hex"76a914",
+            bytes20(uint160(0xDEADBEEF)),
+            hex"88ac"
+        );
+        return _buildTx(pkScript, 100_000_000, 7);
+    }
+
+    function _toSats(uint256 amountWei) internal pure returns (uint64) {
+        require(
+            amountWei % Quotes.SAT_TO_WEI_CONVERSION == 0,
+            "fixture amount is not a whole number of satoshis"
+        );
+        return uint64(amountWei / Quotes.SAT_TO_WEI_CONVERSION);
+    }
+
     // ---- call helpers ----
 
     function _emptyBranch() internal pure returns (bytes32[] memory) {
         return new bytes32[](0);
     }
 
-    function _requestPegIn(
+    /// @notice Claims `btcTx`, which must already pay the address derived for `rskAddr`.
+    function _requestPegInTx(
         address caller,
         address rskAddr,
-        uint256 amount,
-        bytes32 btcTxHash,
+        bytes memory btcTx,
         uint256 value
     ) internal returns (bytes32) {
         vm.prank(caller);
         return
             pegInContract.requestPegIn{value: value}(
                 rskAddr,
-                amount,
-                btcTxHash,
+                btcTx,
                 "",
                 bytes32(0),
                 0,
                 _emptyBranch()
+            );
+    }
+
+    /// @notice Builds the deposit fixture for `amount` and claims it.
+    function _requestPegIn(
+        address caller,
+        address rskAddr,
+        uint256 amount,
+        uint256 value
+    ) internal returns (bytes32) {
+        return
+            _requestPegInTx(
+                caller,
+                rskAddr,
+                _depositTx(rskAddr, amount),
+                value
             );
     }
 

--- a/test/pegin/RequestPegInTestBase.sol
+++ b/test/pegin/RequestPegInTestBase.sol
@@ -96,7 +96,7 @@ abstract contract RequestPegInTestBase is PegInTestBase {
     }
 
     /// @notice Replaces the single flat tier with a low tier up to `lowTierMaxAmount` and a high
-    /// tier above it, so tests can prove the tier is chosen by the DERIVED amount.
+    /// tier above it, so tests can prove the tier is chosen by the amount READ off the deposit.
     function _applyTwoTierConfiguration(
         uint256 lowTierMaxAmount,
         uint256 lowTierConfirmations,


### PR DESCRIPTION
Closes [FLY-2575](https://rsklabs.atlassian.net/browse/FLY-2575) (S4.3, under FLY-2476).

**Base**: `v3.0.0`. One commit on top of `dbcf7b0`.

The ticket said to rebase on FLY-2521 first, but that branch is not merged and basing here on it would have pulled its two commits into this diff. Built on `v3.0.0` instead, so the derivation helper takes no network flag. When FLY-2521 lands, `expectedDepositPkScript` gains its `isMainnet` parameter and passes it through to `derivationValue` — a one-line change at each of the three call sites (registry, `PegInContract._derivePegInAmount`, and the test base). The ticket has been corrected.

## The defect

`requestPegIn` received `uint256 amount` from the caller and nothing bound it to Bitcoin. The function was given `btcTxHash`, a hash, so it could not read the deposit's value even in principle. The only BTC-side check, `getBtcTransactionConfirmations`, proves a txid sits in a block at some depth — it says nothing about who the transaction paid or how much.

That unverified number decided the confirmation tier, the service fee, and the RBTC delivered to the user.

So the reachable attack was: take any confirmed Bitcoin txid, pair it with any registered `rskAddr`, declare a dust `amount`, front that dust as `msg.value`. Every check passed. The caller became the recorded claimer under `pegInId`, the user received dust, and every honest LP was locked out by `PegInAlreadyProcessed` — deliberately the first check in the function. No deposit to Flyover had to exist. Cost was dust plus gas; the result was a permanently unservable peg-in for a real user who really did deposit.

## The change

`requestPegIn` takes the raw witness-stripped deposit transaction in place of **both** `amount` and `btcTxHash`:

```solidity
function requestPegIn(
    address rskAddr,
    bytes calldata btcTxSerialized,
    bytes calldata opReturn,
    bytes32 btcBlockHash,
    uint256 merkleBranchPath,
    bytes32[] calldata merkleBranchHashes
) external payable returns (bytes32 pegInId);
```

The txid is hashed out of those same bytes with `BtcUtils.hashBtcTx`, so the SPV proof, the peg-in id and the amount provably describe one transaction — keeping the txid as an independent input would leave them free to disagree. The contract then derives the deposit `scriptPubKey` for `rskAddr` and reads the amount off the output paying it, scaled by `10 ** 10`.

The confirmation tier, the fee, the `msg.value` fronting equality, the claim record and the `PegInRequested` event all run against that derived amount with their current semantics and error types unchanged. Event field order and indexing are untouched.

Ordered checks in `requestPegIn`, with the new one at position 4:

1. `PegInAlreadyProcessed`
2. dependencies wired
3. `AddressNotRegistered`
4. **`DepositOutputNotFound(rskAddr, btcTxHash)`** ← new
5. `InsufficientConfirmations` (tier looked up with the derived amount)
6. `IncorrectFronting` (against the derived amount minus the derived fee)

## Shared helper

`PegInAddressRegistry` no longer holds its own output-matching implementation. `expectedDepositPkScript` and `matchedDepositValue` moved into `PegInDerivation`, which already declares itself the single source of truth for the derivation, and both contracts call them. `matchedDepositValue` returns a `(value, found)` pair rather than reverting, so each contract keeps its own named error — the registry's `DepositOutputNotFound(rskAddr)`, the peg-in contract's `DepositOutputNotFound(rskAddr, btcTxHash)`.

The registry's existing derivation and registration tests pass unchanged.

## The two decisions the ticket left open

**Where the helper lives** — `PegInDerivation`. The matching step is the consumer-side half of the same pipeline the library already owns, every step is already a separate function there, and the library's own doc comment states the byte-for-byte-agreement rule the matching has to honour.

**Split deposits** — **first match, not the sum.** Unchanged from the registry, so the value that gates registration and the value that fixes the peg-in amount stay identical; changing to a sum would have to change both call sites at once. First match understates a split deposit, and that direction is the safe one: the claimer fronts less than the bridge will release, so settlement covers the claim.

## Tests

31 tests across the migrated suites, all green; full unit run is 636 passing.

New coverage:

- A confirmed transaction unrelated to Flyover reverts `DepositOutputNotFound` — the case that closes the dust lockout.
- A real Flyover deposit derived for a *different* destination reverts `DepositOutputNotFound` (mismatched transaction).
- End to end on the original defect: the dust claim is rejected and the real depositor is served afterwards under the same `pegInId` the attacker tried to burn.
- A 50-RBTC deposit presented with only the low tier's confirmations reverts `InsufficientConfirmations`; the same depth still serves a deposit that really is small.
- Understating and overstating `msg.value` are separate `IncorrectFronting` cases, plus dust fronted against a real deposit.
- Satoshi-to-wei pinned to a literal fixture (123,456,789 sats == 1.23456789 RBTC), so an off-by-a-power-of-ten cannot pass CI.
- Atomicity: a failed deposit match writes no claim and delivers nothing.
- Ordering: `PegInAlreadyProcessed` still wins over the deposit match, since only the txid feeds the id.

Test fixtures now build real deposit transactions paying the address derived for their destination. A test that wants a bad claim has to build a bad transaction; it can no longer just pass a bad number.

## Notes for review

- **Deployment wiring.** `PegInContract` derives with `address(this)` and the live powpeg script; the registry derives with its stored `pegInContract`. If a deployment sets those to disagree, every claim reverts `DepositOutputNotFound` — fail-closed, but a total outage. `getPegInContract()` is not on the frozen `IPegInAddressRegistry`, so asserting agreement in `setPegInDependencies` needs a second frozen-interface amendment. Worth a follow-up ticket; not taken here. FLY-2521 adds a network flag to the same derivation, which widens this surface by one more field.
- **Gas on the claim race.** The txid is hashed before the already-processed check, because the id is keyed on it. The loser of a race now pays one double-SHA256 over the transaction before reverting. Nothing else moved ahead of that check.
- **Not in scope.** `requestPegIn` still enforces neither `minAmount` nor `maxAmount` from `FlyoverConfigurations` (exceptions A4 and A7). Real, but it only becomes meaningful now that the amount is trustworthy, so it should land after this. No ticket exists yet.

## Cross-lane

- **LPS (FLY-2507)** — this is an ABI break. The LPS already holds the raw transaction for its settlement call, so it is a call-site change, not new plumbing. The contract side is asserted here; the caller update is asserted by FLY-2507. **Announce before merging.**
- **Spec** — the walkthrough step 11 amendment and the S0 frozen-signature amendment (S0.2, not yet created) belong to the doc owner and gate this merge. `IPegInCommitFirst`'s NatSpec is updated here to match.
