### PR TITLE
feat(FLY-2523): make the FlyoverConfigurations bounds editable through the timelock

### DIFF
--- a/src/FlyoverConfigurations.sol
+++ b/src/FlyoverConfigurations.sol
@@ -11,8 +11,11 @@ import {Flyover} from "./libraries/Flyover.sol";
 /// @notice The single on-chain source of the commit-first peg-in parameters (fee, confirmation
 /// tiers, amount limits) that every party reads: the SDK for its estimate, every LPS for its
 /// serve decision, and the settlement path for its amount validation. Admin changes are
-/// time-locked in two steps (queue then apply) and re-validated at both steps against immutable
-/// bounds fixed at deployment, so an admin mistake cannot set absurd values even with the role.
+/// time-locked in two steps (queue then apply) and re-validated at both steps against the active
+/// bounds, so an admin mistake cannot set absurd values even with the role. The bounds themselves
+/// are seeded at deployment and are editable by the admin only through the same two-step time
+/// lock ({queueBoundsChange} / {applyBoundsChange}), so widening or tightening them is observable
+/// for a full delay before it can take effect and never needs a contract upgrade.
 /// @dev Implements the frozen {IFlyoverConfigurations} (peg-in only); its function signatures and
 /// structs are the shared ABI every consumer depends on, so they must not be changed here.
 /// Upgradeable, ERC-7201 namespaced storage, deployed behind a TransparentUpgradeableProxy per
@@ -33,13 +36,18 @@ contract FlyoverConfigurations is
     }
 
     /// @custom:storage-location erc7201:rsk.flyover.FlyoverConfigurations.bounds
-    /// @dev Held in a separate namespace from the mutable config. Written once in `initialize`
-    /// and never again; these are the immutable deployment bounds every queued change is
-    /// re-validated against.
+    /// @dev Held in a separate namespace from the mutable config: a bounds change and a
+    /// configuration change are independent pending slots, so queueing one never clobbers the
+    /// other. `min`/`max` are seeded in `initialize` and thereafter only ever written by
+    /// `applyBoundsChange`, which the same time lock as a configuration change guards.
+    /// `timelockDelay` is not editable; it is the review window itself.
     struct FlyoverConfigurationsBounds {
         uint256 timelockDelay;
         PegConfiguration min;
         PegConfiguration max;
+        PegConfiguration pendingMin;
+        PegConfiguration pendingMax;
+        uint256 pendingEta;
     }
 
     /// @notice The version of the contract
@@ -71,8 +79,21 @@ contract FlyoverConfigurations is
     /// @param newConfiguration The now-active configuration
     event ChangeApplied(PegConfiguration newConfiguration);
 
-    /// @notice Raised when a scalar field falls outside its immutable deployment bound.
+    /// @notice Emitted when a bounds change is queued by the admin.
+    /// @param newMin The lower bounds that will take effect once the time lock elapses
+    /// @param newMax The upper bounds that will take effect once the time lock elapses
+    /// @param eta The earliest timestamp `applyBoundsChange` may activate the queued bounds
+    event BoundsChangeQueued(PegConfiguration newMin, PegConfiguration newMax, uint256 eta);
+
+    /// @notice Emitted when a queued bounds change is applied and becomes active.
+    /// @param newMin The now-active lower bounds
+    /// @param newMax The now-active upper bounds
+    event BoundsChangeApplied(PegConfiguration newMin, PegConfiguration newMax);
+
+    /// @notice Raised when a scalar field falls outside its active bound.
     error ConfigValueOutOfBounds(Field field, uint256 value, uint256 min, uint256 max);
+    /// @notice Raised when a bounds pair inverts a field, i.e. its min exceeds its max.
+    error InvalidBounds(Field field, uint256 min, uint256 max);
     /// @notice Raised when minAmount exceeds maxAmount.
     error InvalidAmountLimits(uint256 minAmount, uint256 maxAmount);
     /// @notice Raised when percentageFee exceeds the 10_000 denominator (100%).
@@ -85,6 +106,10 @@ contract FlyoverConfigurations is
     error TimelockNotElapsed(uint256 eta, uint256 nowTime);
     /// @notice Raised when applying while no change is queued.
     error NoQueuedChange();
+    /// @notice Raised when applying while no bounds change is queued.
+    error NoQueuedBoundsChange();
+    /// @notice Raised when applying bounds that would leave the active configuration outside them.
+    error ActiveConfigOutsideNewBounds(Field field, uint256 value, uint256 min, uint256 max);
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -97,12 +122,15 @@ contract FlyoverConfigurations is
         revert Flyover.PaymentNotAllowed();
     }
 
-    /// @notice Initializes the contract with the seed peg-in configuration and immutable bounds.
-    /// @dev Writes the bounds and time-lock delay once, then validates and stores the seed config
-    /// against those bounds. Must be called only once (proxy initializer).
+    /// @notice Initializes the contract with the seed peg-in configuration and the seed bounds.
+    /// @dev Writes the time-lock delay and the seed bounds, then validates and stores the seed
+    /// config against those bounds. The bounds are checked for well-formedness here for the same
+    /// reason `queueBoundsChange` checks them: no code path may install an inverted pair. Must be
+    /// called only once (proxy initializer).
     /// @param defaultAdmin The default admin and initial owner address
     /// @param initialDelay The initial admin delay for `AccessControlDefaultAdminRules`
-    /// @param timelockDelay The delay (seconds) every queued configuration change must wait
+    /// @param timelockDelay The delay (seconds) every queued change must wait, configuration and
+    /// bounds alike
     /// @param pegInConfig The initial peg-in configuration
     /// @param pegInMin Lower bound for every peg-in scalar field
     /// @param pegInMax Upper bound for every peg-in scalar field
@@ -116,6 +144,8 @@ contract FlyoverConfigurations is
         PegConfiguration calldata pegInMax
     ) external initializer {
         __AccessControlDefaultAdminRules_init(initialDelay, defaultAdmin);
+
+        _validateBoundsPair(pegInMin, pegInMax);
 
         FlyoverConfigurationsBounds storage bounds = _getBounds();
         bounds.timelockDelay = timelockDelay;
@@ -145,8 +175,8 @@ contract FlyoverConfigurations is
         if (block.timestamp < eta) revert TimelockNotElapsed(eta, block.timestamp);
 
         PegConfiguration memory pending = $.pending;
-        // Re-validate at apply time: bounds are immutable, but this closes the window where a
-        // value queued as valid could be applied after any invariant assumption changed.
+        // Re-validate at apply time: the bounds may themselves have moved during the delay, so a
+        // value that was in range when queued is not guaranteed to be in range when it lands.
         _validateConfig(pending);
 
         // Storage-to-storage deep copy (the memory-to-storage form is not supported for the
@@ -155,6 +185,79 @@ contract FlyoverConfigurations is
         delete $.pending;
         $.pendingEta = 0;
         emit ChangeApplied(pending);
+    }
+
+    /// @notice Queues a change to the configuration bounds, the first step of the time-locked
+    /// admin change. Admin-only.
+    /// @dev Deliberately no plain setter. A bound and a configuration value that could move in a
+    /// single transaction would make the bounds useless: catching an admin mistake is their only
+    /// job, and they cannot catch a mistake the same actor is free to redefine on the spot. The
+    /// delay is the review window, so a queued widening is observable before it can take effect.
+    ///
+    /// Only well-formedness (`min <= max` per field) is checked here. Whether the *active*
+    /// configuration still fits the new bounds is deliberately checked at apply time only: the
+    /// active configuration may legitimately change during the delay, so a queue-time verdict
+    /// would be advisory at best and would block the legitimate sequence of queueing a
+    /// tightening now and moving the active configuration into the new range during the wait.
+    ///
+    /// Follows the single-pending-change pattern: queueing again overwrites the pending bounds
+    /// and refreshes the eta. Independent of the configuration slot used by {queueChange}.
+    ///
+    /// The `confirmationTiers` field of a bounds pair is ignored, as it is at initialization: the
+    /// tier array is validated structurally (non-empty, strictly ascending), never min/max
+    /// bounded, so there is nothing for a bound to constrain.
+    /// @param newMin Lower bound for every peg-in scalar field
+    /// @param newMax Upper bound for every peg-in scalar field
+    // solhint-disable-next-line comprehensive-interface
+    function queueBoundsChange(PegConfiguration calldata newMin, PegConfiguration calldata newMax)
+        external
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
+        _validateBoundsPair(newMin, newMax);
+
+        FlyoverConfigurationsBounds storage bounds = _getBounds();
+        uint256 eta = block.timestamp + bounds.timelockDelay;
+        bounds.pendingMin = newMin;
+        bounds.pendingMax = newMax;
+        bounds.pendingEta = eta;
+        emit BoundsChangeQueued(newMin, newMax, eta);
+    }
+
+    /// @notice Activates the queued bounds change, the second step of the time-locked admin
+    /// change. Admin-only.
+    /// @dev Reverts before the delay has elapsed, and reverts when nothing is queued.
+    ///
+    /// Bounds that the active configuration does not satisfy are rejected rather than accepted
+    /// as forward-only constraints. The alternative would leave `getPegInConfiguration` returning
+    /// values `getPegInConfigurationBounds` declares illegal, and no reader could tell whether
+    /// the pair it just read was consistent. Rejecting keeps one invariant that holds at every
+    /// block and needs no qualification: the active configuration is always within the active
+    /// bounds. The admin's remedy for a tightening that excludes the active configuration is to
+    /// move the configuration into the new range first (itself time-locked, and runnable during
+    /// this change's delay), then apply the bounds. Widening — the case this feature exists for —
+    /// is never blocked by this rule.
+    // solhint-disable-next-line comprehensive-interface
+    function applyBoundsChange() external onlyRole(DEFAULT_ADMIN_ROLE) {
+        FlyoverConfigurationsBounds storage bounds = _getBounds();
+        uint256 eta = bounds.pendingEta;
+        if (eta == 0) revert NoQueuedBoundsChange();
+        if (block.timestamp < eta) revert TimelockNotElapsed(eta, block.timestamp);
+
+        // Re-validate at apply time for the same reason applyChange does: the queued pair must
+        // still be well-formed when it lands, not only when it was queued.
+        _validateBoundsPair(bounds.pendingMin, bounds.pendingMax);
+        _checkActiveConfigFits(bounds.pendingMin, bounds.pendingMax);
+
+        // Storage-to-storage deep copies (the memory-to-storage form is not supported for the
+        // nested ConfirmationTier[] array).
+        bounds.min = bounds.pendingMin;
+        bounds.max = bounds.pendingMax;
+        PegConfiguration memory newMin = bounds.min;
+        PegConfiguration memory newMax = bounds.max;
+        delete bounds.pendingMin;
+        delete bounds.pendingMax;
+        bounds.pendingEta = 0;
+        emit BoundsChangeApplied(newMin, newMax);
     }
 
     /// @inheritdoc IFlyoverConfigurations
@@ -177,7 +280,9 @@ contract FlyoverConfigurations is
         return _requiredConfirmations(_getStorage().activePegIn, amount);
     }
 
-    /// @notice Returns the immutable deployment bounds every queued change is validated against.
+    /// @notice Returns the active bounds every queued configuration change is validated against.
+    /// @dev Seeded at deployment; changed only through {queueBoundsChange} / {applyBoundsChange}.
+    /// The active configuration is always within the pair returned here.
     /// @return min The lower bound for every peg-in scalar field
     /// @return max The upper bound for every peg-in scalar field
     // solhint-disable-next-line comprehensive-interface
@@ -188,6 +293,20 @@ contract FlyoverConfigurations is
     {
         FlyoverConfigurationsBounds storage bounds = _getBounds();
         return (bounds.min, bounds.max);
+    }
+
+    /// @notice Returns the queued bounds change and its activation time.
+    /// @return min The queued lower bounds (zeroed when nothing is queued)
+    /// @return max The queued upper bounds (zeroed when nothing is queued)
+    /// @return eta The earliest activation timestamp; `0` means no bounds change is queued
+    // solhint-disable-next-line comprehensive-interface
+    function getPendingBoundsChange()
+        external
+        view
+        returns (PegConfiguration memory min, PegConfiguration memory max, uint256 eta)
+    {
+        FlyoverConfigurationsBounds storage bounds = _getBounds();
+        return (bounds.pendingMin, bounds.pendingMax, bounds.pendingEta);
     }
 
     /// @notice Returns the queued configuration change and its activation time.
@@ -233,7 +352,7 @@ contract FlyoverConfigurations is
         return tiers[length - 1].confirmations;
     }
 
-    /// @dev Validates a full config against the immutable bounds and the structural invariants:
+    /// @dev Validates a full config against the active bounds and the structural invariants:
     /// every scalar within [min, max], minAmount <= maxAmount, percentageFee <= 10_000, and the
     /// confirmation tiers non-empty and strictly ascending by maxAmount. The tier array itself is
     /// only ordering/non-emptiness checked; it is not min/max-bounded.
@@ -261,9 +380,55 @@ contract FlyoverConfigurations is
         _validateTiers(config.confirmationTiers);
     }
 
+    /// @dev Enforces the invariant that makes the bounds readable at all: the active
+    /// configuration lies within the active bounds. Called before a bounds change lands, so a
+    /// pair that would strand the live configuration outside it is rejected instead of applied.
+    /// See {applyBoundsChange} for why rejecting beats accepting it as a forward-only constraint.
+    function _checkActiveConfigFits(PegConfiguration memory min, PegConfiguration memory max)
+        private
+        view
+    {
+        PegConfiguration storage active = _getStorage().activePegIn;
+        _checkActiveField(Field.FixedFee, active.fixedFee, min.fixedFee, max.fixedFee);
+        _checkActiveField(
+            Field.PercentageFee,
+            active.percentageFee,
+            min.percentageFee,
+            max.percentageFee
+        );
+        _checkActiveField(Field.MinAmount, active.minAmount, min.minAmount, max.minAmount);
+        _checkActiveField(Field.MaxAmount, active.maxAmount, min.maxAmount, max.maxAmount);
+    }
+
     function _checkBound(Field field, uint256 value, uint256 minV, uint256 maxV) private pure {
         if (value < minV || value > maxV) {
             revert ConfigValueOutOfBounds(field, value, minV, maxV);
+        }
+    }
+
+    /// @dev A bounds pair is well-formed when no field inverts, i.e. `min <= max` on all four
+    /// scalars. An inverted field admits no value at all, which would wedge every future
+    /// configuration change. `confirmationTiers` carries no bound and is not inspected.
+    function _validateBoundsPair(PegConfiguration memory min, PegConfiguration memory max)
+        private
+        pure
+    {
+        _checkPairOrdered(Field.FixedFee, min.fixedFee, max.fixedFee);
+        _checkPairOrdered(Field.PercentageFee, min.percentageFee, max.percentageFee);
+        _checkPairOrdered(Field.MinAmount, min.minAmount, max.minAmount);
+        _checkPairOrdered(Field.MaxAmount, min.maxAmount, max.maxAmount);
+    }
+
+    function _checkPairOrdered(Field field, uint256 minV, uint256 maxV) private pure {
+        if (minV > maxV) revert InvalidBounds(field, minV, maxV);
+    }
+
+    function _checkActiveField(Field field, uint256 value, uint256 minV, uint256 maxV)
+        private
+        pure
+    {
+        if (value < minV || value > maxV) {
+            revert ActiveConfigOutsideNewBounds(field, value, minV, maxV);
         }
     }
 

--- a/src/interfaces/IFlyoverConfigurations.sol
+++ b/src/interfaces/IFlyoverConfigurations.sol
@@ -62,7 +62,7 @@ interface IFlyoverConfigurations {
 
     /// @notice Queues a configuration change, the first step of the time-locked admin change
     /// @dev Admin-only. The change activates only through applyChange after the configured
-    /// delay; the values are validated against the immutable deployment bounds at queue time.
+    /// delay; the values are validated against the active bounds at queue time.
     /// Returns nothing. Walkthrough anchors: step 2, decision block 2·D.
     /// @param newConfiguration The configuration to activate after the delay
     function queueChange(PegConfiguration calldata newConfiguration) external;
@@ -70,7 +70,9 @@ interface IFlyoverConfigurations {
     /// @notice Activates the queued configuration change, the second step of the time-locked
     /// admin change
     /// @dev Admin-only. Reverts before the configured delay has elapsed; the values are
-    /// re-validated against the immutable deployment bounds at apply time. Returns nothing.
+    /// re-validated against the active bounds at apply time, which may themselves have moved
+    /// during the delay through the implementation's own time-locked bounds change.
+    /// Returns nothing.
     /// Walkthrough anchors: step 2, decision block 2·D.
     function applyChange() external;
 }

--- a/src/libraries/FlyoverConfigurationsRegtest.sol
+++ b/src/libraries/FlyoverConfigurationsRegtest.sol
@@ -5,8 +5,10 @@ import {IFlyoverConfigurations} from "../interfaces/IFlyoverConfigurations.sol";
 
 /// @title FlyoverConfigurationsRegtest
 /// @notice Provisional regtest values for {FlyoverConfigurations}: the seed peg-in configuration,
-/// the immutable deployment bounds, and the time-lock delay. Shipped with the contract so the
-/// deploy wiring can consume them without hardcoding numbers in a script.
+/// the seed bounds, and the time-lock delay. Shipped with the contract so the deploy wiring can
+/// consume them without hardcoding numbers in a script. The bounds seeded here are the starting
+/// pair, not a permanent one: the admin can move them later through the contract's time-locked
+/// bounds change.
 /// @dev EVERY value here is provisional and calibrated only for regtest; none are production
 /// values. The fixed-fee floor is a SECURITY parameter, not just pricing: if it drops below
 /// worst-case RSK gas during congestion, an attacker can make minimum-amount peg-ins no LP will
@@ -29,9 +31,10 @@ library FlyoverConfigurationsRegtest {
         config.confirmationTiers = _tiers();
     }
 
-    /// @notice Lower bound for every peg-in scalar field (immutable at deployment).
+    /// @notice Lower bound for every peg-in scalar field, as seeded at deployment.
     /// @dev min.fixedFee IS the security floor: no queued change may set the fixed fee below it,
-    /// so the floor holds even against a compromised admin role.
+    /// so the floor holds even against a compromised admin role. Lowering the floor is itself a
+    /// time-locked bounds change, so it stays observable for a full delay before it takes effect.
     /// @return bound The lower bound configuration
     function pegInMin() internal pure returns (IFlyoverConfigurations.PegConfiguration memory bound) {
         bound.fixedFee = 0.0001 ether; // SECURITY floor: hard minimum fixed fee
@@ -42,7 +45,7 @@ library FlyoverConfigurationsRegtest {
         bound.confirmationTiers = new IFlyoverConfigurations.ConfirmationTier[](0);
     }
 
-    /// @notice Upper bound for every peg-in scalar field (immutable at deployment).
+    /// @notice Upper bound for every peg-in scalar field, as seeded at deployment.
     /// @dev Caps how high the admin can push each field, so a mistake cannot set absurd values.
     /// @return bound The upper bound configuration
     function pegInMax() internal pure returns (IFlyoverConfigurations.PegConfiguration memory bound) {


### PR DESCRIPTION
**Stack: 1 of 2.** Implementation only — coverage is in the stacked follow-up, [feature/FLY-2523-tests](https://github.com/rsksmart/liquidity-bridge-contract/compare/feature/FLY-2523...feature/FLY-2523-tests). Review this one first; the tests PR targets this branch, so it will retarget to `v3.0.0` automatically once this merges.

JIRA: [FLY-2523](https://rsklabs.atlassian.net/browse/FLY-2523)

## What

The configuration bounds were written once in `initialize` and never again, so widening them later needed a contract upgrade. They now move through the same queue-and-apply timelock a configuration change already uses.

- `queueBoundsChange(newMin, newMax)` and `applyBoundsChange()`, both gated on `DEFAULT_ADMIN_ROLE` and the existing delay.
- Pending bounds live in their own slot inside the existing `rsk.flyover.FlyoverConfigurations.bounds` namespace (appended, no migration), so a queued bounds change and a queued configuration change never collide.
- `BoundsChangeQueued` / `BoundsChangeApplied` mirror the visibility of the configuration events.
- Queueing again overwrites the pending pair and refreshes the eta, following the existing single-pending-change pattern.
- `getPendingBoundsChange()` exposes the queued pair, matching `getPendingChange()`.

## Decisions worth reviewing

**No plain setter.** If the admin could move a bound and a configuration value in one transaction, the bounds would stop catching admin mistakes, which is their only job — they cannot catch a mistake the same actor is free to redefine on the spot. The delay is the review window the feedback asked for.

**Bounds that would strand the active configuration outside them are rejected at apply time.** This is the open question in the ticket. The alternative — accept them and let the new bounds constrain only future changes — leaves `getPegInConfiguration()` returning values that `getPegInConfigurationBounds()` declares illegal, with no way for a reader to tell whether the pair it just read is consistent. Rejecting keeps one invariant that holds at every block and needs no qualification: *the active configuration is always within the active bounds*. The remedy for a tightening that excludes the active configuration is to move the configuration into range first — itself timelocked, and runnable during this change's own delay, so it costs no extra cycle. Widening, the case this feature exists for, is never blocked. Reasoning is in the `applyBoundsChange` NatSpec.

**Fit is checked at apply time only, not at queue time.** The active configuration can legitimately change during the delay, so a queue-time verdict would be advisory at best, and it would block the legitimate sequence of queueing a tightening now and moving the configuration into range during the wait.

**`min > max` on any field reverts** with `InvalidBounds(field, min, max)`, at queue and at apply. `initialize` now runs the same check, so no code path installs an inverted pair.

## NatSpec

The contract described the bounds as immutable deployment bounds; that language is corrected here, in `FlyoverConfigurationsRegtest`, and in the `IFlyoverConfigurations` doc comments.

⚠️ `IFlyoverConfigurations.sol` is marked frozen (S0). The edits there are **comments only** — no signature or struct is touched, so there is no ABI change — but flagging it since the file's own header calls any change to it a cross-lane event.

## Testing

`test/configurations` passes unchanged on this branch (48 tests) — this PR adds no coverage of its own by design. The new surfaces are covered in the stacked PR, which brings that suite to 76. Full suite: 773 pass, with 2 pre-existing failures in `test/differential/` (`vm.parseJsonAddress` on `.rskMainnet…`) that fail identically on `v3.0.0` and are unrelated. `solhint`: 0 errors.
