### PR TITLE
test(FLY-2523): cover the time-locked bounds change

### DIFF
--- a/test/configurations/AdminGating.t.sol
+++ b/test/configurations/AdminGating.t.sol
@@ -215,4 +215,134 @@ contract AdminGatingTest is ConfigurationsTestBase {
         );
         config.queueChange(c);
     }
+
+    // ============================================================ bounds changes (FLY-2523)
+
+    // ------------------------------------------------------------------ role gating
+
+    function test_queueBoundsChange_nonAdminReverts() public {
+        IFlyoverConfigurations.PegConfiguration memory min = _wideMin();
+        IFlyoverConfigurations.PegConfiguration memory max = _wideMax();
+        bytes memory err = _unauthorized(stranger);
+        vm.prank(stranger);
+        vm.expectRevert(err);
+        config.queueBoundsChange(min, max);
+    }
+
+    function test_applyBoundsChange_nonAdminReverts() public {
+        _queueWideBounds();
+        vm.warp(block.timestamp + TIMELOCK_DELAY);
+        bytes memory err = _unauthorized(stranger);
+        vm.prank(stranger);
+        vm.expectRevert(err);
+        config.applyBoundsChange();
+    }
+
+    function test_admin_canQueueAndApplyBounds() public {
+        _queueWideBounds();
+        vm.warp(block.timestamp + TIMELOCK_DELAY);
+        vm.prank(owner);
+        config.applyBoundsChange();
+        (IFlyoverConfigurations.PegConfiguration memory min, ) = config
+            .getPegInConfigurationBounds();
+        assertEq(min.fixedFee, WIDE_MIN_FIXED_FEE);
+    }
+
+    /// @notice There is no way to move a bound outside the time lock: no setter exists, so the
+    /// only two selectors that write the bounds namespace are the queue/apply pair.
+    function test_noPlainBoundsSetterExists() public {
+        // A single-step setter would be the obvious name; it must not be routable.
+        (bool ok, ) = address(config).call(
+            abi.encodeWithSignature(
+                "setPegInConfigurationBounds((uint256,uint256,uint256,uint256,(uint256,uint256)[]),"
+                "(uint256,uint256,uint256,uint256,(uint256,uint256)[]))",
+                _wideMin(),
+                _wideMax()
+            )
+        );
+        assertFalse(ok, "no single-step bounds setter may exist");
+    }
+
+    // ------------------------------------------------------ inverted pair, one case per field
+
+    function test_queueBoundsChange_invertedFixedFeeReverts() public {
+        IFlyoverConfigurations.PegConfiguration memory max = _boundsMax();
+        max.fixedFee = BOUND_MIN_FIXED_FEE - 1; // max below min
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FlyoverConfigurations.InvalidBounds.selector,
+                FlyoverConfigurations.Field.FixedFee,
+                BOUND_MIN_FIXED_FEE,
+                BOUND_MIN_FIXED_FEE - 1
+            )
+        );
+        config.queueBoundsChange(_boundsMin(), max);
+    }
+
+    function test_queueBoundsChange_invertedPercentageFeeReverts() public {
+        IFlyoverConfigurations.PegConfiguration memory min = _boundsMin();
+        min.percentageFee = BOUND_MAX_PCT + 1;
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FlyoverConfigurations.InvalidBounds.selector,
+                FlyoverConfigurations.Field.PercentageFee,
+                BOUND_MAX_PCT + 1,
+                BOUND_MAX_PCT
+            )
+        );
+        config.queueBoundsChange(min, _boundsMax());
+    }
+
+    function test_queueBoundsChange_invertedMinAmountReverts() public {
+        IFlyoverConfigurations.PegConfiguration memory min = _boundsMin();
+        min.minAmount = BOUND_MAX_MIN_AMOUNT + 1;
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FlyoverConfigurations.InvalidBounds.selector,
+                FlyoverConfigurations.Field.MinAmount,
+                BOUND_MAX_MIN_AMOUNT + 1,
+                BOUND_MAX_MIN_AMOUNT
+            )
+        );
+        config.queueBoundsChange(min, _boundsMax());
+    }
+
+    function test_queueBoundsChange_invertedMaxAmountReverts() public {
+        IFlyoverConfigurations.PegConfiguration memory min = _boundsMin();
+        min.maxAmount = BOUND_MAX_MAX_AMOUNT + 1;
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FlyoverConfigurations.InvalidBounds.selector,
+                FlyoverConfigurations.Field.MaxAmount,
+                BOUND_MAX_MAX_AMOUNT + 1,
+                BOUND_MAX_MAX_AMOUNT
+            )
+        );
+        config.queueBoundsChange(min, _boundsMax());
+    }
+
+    /// @notice min == max is a degenerate but well-formed pair: it pins the field to one value.
+    function test_queueBoundsChange_equalMinAndMaxAccepted() public {
+        IFlyoverConfigurations.PegConfiguration memory min = _boundsMin();
+        IFlyoverConfigurations.PegConfiguration memory max = _boundsMax();
+        min.fixedFee = SEED_FIXED_FEE;
+        max.fixedFee = SEED_FIXED_FEE;
+
+        vm.prank(owner);
+        config.queueBoundsChange(min, max);
+        vm.warp(block.timestamp + TIMELOCK_DELAY);
+        vm.prank(owner);
+        config.applyBoundsChange();
+
+        (
+            IFlyoverConfigurations.PegConfiguration memory activeMin,
+            IFlyoverConfigurations.PegConfiguration memory activeMax
+        ) = config.getPegInConfigurationBounds();
+        assertEq(activeMin.fixedFee, SEED_FIXED_FEE);
+        assertEq(activeMax.fixedFee, SEED_FIXED_FEE);
+    }
 }

--- a/test/configurations/ConfigurationsTestBase.sol
+++ b/test/configurations/ConfigurationsTestBase.sol
@@ -28,7 +28,7 @@ abstract contract ConfigurationsTestBase is Test {
     uint256 internal constant SEED_MIN_AMOUNT = 0.001 ether;
     uint256 internal constant SEED_MAX_AMOUNT = 100 ether;
 
-    // --- immutable deployment bounds ---
+    // --- seed bounds, written at deployment ---
     // fixedFee lower bound IS the 2·D security floor; no queued change may drop below it.
     uint256 internal constant BOUND_MIN_FIXED_FEE = 100 * SAT;
     uint256 internal constant BOUND_MAX_FIXED_FEE = 1 ether;
@@ -41,9 +41,25 @@ abstract contract ConfigurationsTestBase is Test {
     uint256 internal constant BOUND_MIN_MAX_AMOUNT = 0;
     uint256 internal constant BOUND_MAX_MAX_AMOUNT = 10_000 ether;
 
+    // --- widened bounds, for the bounds-change tests ---
+    // Chosen to strictly contain both the current bounds and the seed config, so applying them
+    // is always legal and the widening is observable (values the old bounds rejected pass).
+    uint256 internal constant WIDE_MIN_FIXED_FEE = 50 * SAT;
+    uint256 internal constant WIDE_MAX_FIXED_FEE = 2 ether;
+    uint256 internal constant WIDE_MIN_PCT = 0;
+    uint256 internal constant WIDE_MAX_PCT = 30_000;
+    uint256 internal constant WIDE_MIN_MIN_AMOUNT = 0;
+    uint256 internal constant WIDE_MAX_MIN_AMOUNT = 2 ether;
+    uint256 internal constant WIDE_MIN_MAX_AMOUNT = 0;
+    uint256 internal constant WIDE_MAX_MAX_AMOUNT = 20_000 ether;
+
     // ERC-7201 base slot of the mutable namespace `rsk.flyover.FlyoverConfigurations`.
     bytes32 internal constant STORAGE_SLOT =
         0x13aa2a37a5354fe7c5dcced2a6c33933ec66091f98f22792660cd2862f158700;
+
+    // ERC-7201 base slot of the bounds namespace `rsk.flyover.FlyoverConfigurations.bounds`.
+    bytes32 internal constant BOUNDS_SLOT =
+        0x62f8e0a1022a246e45081dab13f708870be3f38423627ed9d784f6bc5369e500;
 
     address internal owner = makeAddr("owner");
     address internal stranger = makeAddr("stranger");
@@ -156,5 +172,62 @@ abstract contract ConfigurationsTestBase is Test {
         c = _altConfig();
         vm.prank(owner);
         config.queueChange(c);
+    }
+
+    // ------------------------------------------------------------------ bounds-change helpers
+
+    /// @notice Widened lower bounds: strictly below the deployment min on every field.
+    function _wideMin()
+        internal
+        pure
+        returns (IFlyoverConfigurations.PegConfiguration memory c)
+    {
+        c.fixedFee = WIDE_MIN_FIXED_FEE;
+        c.percentageFee = WIDE_MIN_PCT;
+        c.minAmount = WIDE_MIN_MIN_AMOUNT;
+        c.maxAmount = WIDE_MIN_MAX_AMOUNT;
+        c.confirmationTiers = new IFlyoverConfigurations.ConfirmationTier[](0);
+    }
+
+    /// @notice Widened upper bounds: strictly above the deployment max on every field.
+    function _wideMax()
+        internal
+        pure
+        returns (IFlyoverConfigurations.PegConfiguration memory c)
+    {
+        c.fixedFee = WIDE_MAX_FIXED_FEE;
+        c.percentageFee = WIDE_MAX_PCT;
+        c.minAmount = WIDE_MAX_MIN_AMOUNT;
+        c.maxAmount = WIDE_MAX_MAX_AMOUNT;
+        c.confirmationTiers = new IFlyoverConfigurations.ConfirmationTier[](0);
+    }
+
+    /// @notice Convenience: queue the widened bounds as the admin.
+    function _queueWideBounds() internal {
+        vm.prank(owner);
+        config.queueBoundsChange(_wideMin(), _wideMax());
+    }
+
+    /// @notice Queue a bounds pair as the admin, wait the delay, and apply it.
+    function _applyBounds(
+        IFlyoverConfigurations.PegConfiguration memory min,
+        IFlyoverConfigurations.PegConfiguration memory max
+    ) internal {
+        vm.prank(owner);
+        config.queueBoundsChange(min, max);
+        vm.warp(block.timestamp + TIMELOCK_DELAY);
+        vm.prank(owner);
+        config.applyBoundsChange();
+    }
+
+    /// @notice Queue a configuration as the admin, wait the delay, and apply it.
+    function _applyConfig(
+        IFlyoverConfigurations.PegConfiguration memory c
+    ) internal {
+        vm.prank(owner);
+        config.queueChange(c);
+        vm.warp(block.timestamp + TIMELOCK_DELAY);
+        vm.prank(owner);
+        config.applyChange();
     }
 }

--- a/test/configurations/Getters.t.sol
+++ b/test/configurations/Getters.t.sol
@@ -5,8 +5,8 @@ import {ConfigurationsTestBase} from "./ConfigurationsTestBase.sol";
 import {IFlyoverConfigurations} from "../../src/interfaces/IFlyoverConfigurations.sol";
 
 /// @title GettersTest
-/// @notice Every read surface: the active configuration (incl. limits), the immutable bounds,
-/// the pending change, and the time-lock delay.
+/// @notice Every read surface: the active configuration (incl. limits), the active bounds, the
+/// pending configuration change, the pending bounds change, and the time-lock delay.
 contract GettersTest is ConfigurationsTestBase {
     function setUp() public {
         _deploy();
@@ -120,5 +120,63 @@ contract GettersTest is ConfigurationsTestBase {
 
     function test_version_isSet() public view {
         assertEq(config.VERSION(), "1.0.0");
+    }
+
+    // ------------------------------------------------- pending bounds change (FLY-2523)
+
+    function test_getPendingBoundsChange_zeroedWhenNothingQueued() public view {
+        (
+            IFlyoverConfigurations.PegConfiguration memory min,
+            IFlyoverConfigurations.PegConfiguration memory max,
+            uint256 eta
+        ) = config.getPendingBoundsChange();
+        assertEq(eta, 0);
+        assertEq(min.fixedFee, 0);
+        assertEq(min.percentageFee, 0);
+        assertEq(min.minAmount, 0);
+        assertEq(min.maxAmount, 0);
+        assertEq(max.fixedFee, 0);
+        assertEq(max.percentageFee, 0);
+        assertEq(max.minAmount, 0);
+        assertEq(max.maxAmount, 0);
+    }
+
+    function test_getPendingBoundsChange_reflectsQueuedChange() public {
+        uint256 expectedEta = block.timestamp + TIMELOCK_DELAY;
+        _queueWideBounds();
+
+        (
+            IFlyoverConfigurations.PegConfiguration memory min,
+            IFlyoverConfigurations.PegConfiguration memory max,
+            uint256 eta
+        ) = config.getPendingBoundsChange();
+        assertEq(eta, expectedEta);
+        assertEq(min.fixedFee, WIDE_MIN_FIXED_FEE);
+        assertEq(min.percentageFee, WIDE_MIN_PCT);
+        assertEq(min.minAmount, WIDE_MIN_MIN_AMOUNT);
+        assertEq(min.maxAmount, WIDE_MIN_MAX_AMOUNT);
+        assertEq(max.fixedFee, WIDE_MAX_FIXED_FEE);
+        assertEq(max.percentageFee, WIDE_MAX_PCT);
+        assertEq(max.minAmount, WIDE_MAX_MIN_AMOUNT);
+        assertEq(max.maxAmount, WIDE_MAX_MAX_AMOUNT);
+    }
+
+    function test_getPendingBoundsChange_clearedAfterApply() public {
+        _applyBounds(_wideMin(), _wideMax());
+
+        (
+            IFlyoverConfigurations.PegConfiguration memory min,
+            IFlyoverConfigurations.PegConfiguration memory max,
+            uint256 eta
+        ) = config.getPendingBoundsChange();
+        assertEq(eta, 0);
+        assertEq(min.fixedFee, 0);
+        assertEq(max.fixedFee, 0);
+    }
+
+    /// @notice The delay is not editable by the bounds path; it is the review window itself.
+    function test_getTimelockDelay_unchangedByBoundsChange() public {
+        _applyBounds(_wideMin(), _wideMax());
+        assertEq(config.getTimelockDelay(), TIMELOCK_DELAY);
     }
 }

--- a/test/configurations/Scaffolding.t.sol
+++ b/test/configurations/Scaffolding.t.sol
@@ -66,6 +66,36 @@ contract ScaffoldingTest is ConfigurationsTestBase {
         new ERC1967Proxy(address(impl), initData);
     }
 
+    /// @notice An inverted seed bounds pair is rejected at initialization, so no code path can
+    /// install bounds that admit no value at all.
+    function test_initialize_invertedBounds_reverts() public {
+        FlyoverConfigurations impl = new FlyoverConfigurations();
+        IFlyoverConfigurations.PegConfiguration memory badMax = _boundsMax();
+        badMax.fixedFee = BOUND_MIN_FIXED_FEE - 1;
+
+        bytes memory initData = abi.encodeCall(
+            FlyoverConfigurations.initialize,
+            (
+                owner,
+                ADMIN_DELAY,
+                TIMELOCK_DELAY,
+                _seedConfig(),
+                _boundsMin(),
+                badMax
+            )
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FlyoverConfigurations.InvalidBounds.selector,
+                FlyoverConfigurations.Field.FixedFee,
+                BOUND_MIN_FIXED_FEE,
+                BOUND_MIN_FIXED_FEE - 1
+            )
+        );
+        new ERC1967Proxy(address(impl), initData);
+    }
+
     /// @notice The contract does not accept plain value transfers.
     function test_receive_rejectsValue() public {
         vm.deal(stranger, 1 ether);

--- a/test/configurations/Timelock.t.sol
+++ b/test/configurations/Timelock.t.sol
@@ -115,7 +115,7 @@ contract TimelockTest is ConfigurationsTestBase {
         config.queueChange(c);
     }
 
-    /// @notice applyChange re-validates against the immutable bounds. Since queueChange blocks
+    /// @notice applyChange re-validates against the active bounds. Since queueChange blocks
     /// out-of-bounds values, we prove the apply-time guard by queuing a valid change and then
     /// corrupting the stored pending value directly before applying.
     function test_case3_outOfBounds_revertsAtApplyTime() public {
@@ -207,5 +207,360 @@ contract TimelockTest is ConfigurationsTestBase {
         emit FlyoverConfigurations.ChangeApplied(c);
         vm.prank(owner);
         config.applyChange();
+    }
+
+    // ================================================================== bounds changes (FLY-2523)
+    //
+    // The bounds run through the same two-step time lock as a configuration change. These mirror
+    // the four cases above for the bounds path, then pin the two rules unique to it: a pair may
+    // not invert, and a pair the active configuration falls outside is rejected at apply time.
+
+    /// @dev pendingMin.fixedFee lives at the bounds namespace base + 11 (timelockDelay occupies
+    /// slot 0, then min and max take 5 slots each: fixedFee, percentageFee, minAmount, maxAmount,
+    /// confirmationTiers-length).
+    bytes32 private constant _PENDING_MIN_FIXED_FEE_SLOT =
+        bytes32(uint256(BOUNDS_SLOT) + 11);
+
+    // ------------------------------------------------ case 1: queue then apply after the delay
+
+    function test_bounds_queueThenApplyAfterDelay_succeeds() public {
+        _queueWideBounds();
+
+        // Not applied yet: the active bounds are still the deployment ones.
+        (IFlyoverConfigurations.PegConfiguration memory minBefore, ) = config
+            .getPegInConfigurationBounds();
+        assertEq(minBefore.fixedFee, BOUND_MIN_FIXED_FEE);
+
+        vm.warp(block.timestamp + TIMELOCK_DELAY);
+        vm.prank(owner);
+        config.applyBoundsChange();
+
+        (
+            IFlyoverConfigurations.PegConfiguration memory min,
+            IFlyoverConfigurations.PegConfiguration memory max
+        ) = config.getPegInConfigurationBounds();
+        assertEq(min.fixedFee, WIDE_MIN_FIXED_FEE);
+        assertEq(min.percentageFee, WIDE_MIN_PCT);
+        assertEq(min.minAmount, WIDE_MIN_MIN_AMOUNT);
+        assertEq(min.maxAmount, WIDE_MIN_MAX_AMOUNT);
+        assertEq(max.fixedFee, WIDE_MAX_FIXED_FEE);
+        assertEq(max.percentageFee, WIDE_MAX_PCT);
+        assertEq(max.minAmount, WIDE_MAX_MIN_AMOUNT);
+        assertEq(max.maxAmount, WIDE_MAX_MAX_AMOUNT);
+
+        // The pending slot is cleared.
+        (, , uint256 eta) = config.getPendingBoundsChange();
+        assertEq(eta, 0);
+    }
+
+    function test_bounds_applyAtExactEta_succeeds() public {
+        _queueWideBounds();
+        (, , uint256 eta) = config.getPendingBoundsChange();
+        vm.warp(eta); // block.timestamp == eta is allowed (>=)
+        vm.prank(owner);
+        config.applyBoundsChange();
+        (IFlyoverConfigurations.PegConfiguration memory min, ) = config
+            .getPegInConfigurationBounds();
+        assertEq(min.fixedFee, WIDE_MIN_FIXED_FEE);
+    }
+
+    /// @notice The point of the feature: after widening, a fee the old bounds rejected is
+    /// accepted, and the widening required no upgrade.
+    function test_bounds_widening_admitsPreviouslyRejectedValue() public {
+        uint256 highFee = BOUND_MAX_FIXED_FEE + 1 ether; // above the old max, below the new one
+
+        // Rejected under the deployment bounds.
+        IFlyoverConfigurations.PegConfiguration memory c = _altConfig();
+        c.fixedFee = highFee;
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FlyoverConfigurations.ConfigValueOutOfBounds.selector,
+                FlyoverConfigurations.Field.FixedFee,
+                highFee,
+                BOUND_MIN_FIXED_FEE,
+                BOUND_MAX_FIXED_FEE
+            )
+        );
+        config.queueChange(c);
+
+        _applyBounds(_wideMin(), _wideMax());
+
+        // Accepted under the widened bounds.
+        vm.prank(owner);
+        config.queueChange(c);
+        (IFlyoverConfigurations.PegConfiguration memory pending, ) = config
+            .getPendingChange();
+        assertEq(pending.fixedFee, highFee);
+    }
+
+    /// @notice The mirror direction: after tightening, a value the old bounds accepted is
+    /// rejected, so a queued change is measured against the bounds in force when it is queued.
+    function test_bounds_tightening_rejectsPreviouslyAcceptedValue() public {
+        uint256 fee = _altConfig().fixedFee; // accepted under the deployment bounds
+
+        // Tighten the fixed-fee ceiling to just below that value. The seed config's fixedFee is
+        // lower still, so the active configuration stays inside the new pair.
+        IFlyoverConfigurations.PegConfiguration memory tightMax = _boundsMax();
+        tightMax.fixedFee = fee - 1;
+        _applyBounds(_boundsMin(), tightMax);
+
+        IFlyoverConfigurations.PegConfiguration memory c = _altConfig();
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FlyoverConfigurations.ConfigValueOutOfBounds.selector,
+                FlyoverConfigurations.Field.FixedFee,
+                fee,
+                BOUND_MIN_FIXED_FEE,
+                fee - 1
+            )
+        );
+        config.queueChange(c);
+    }
+
+    // ------------------------------------------------------- case 2: apply before delay reverts
+
+    function test_bounds_applyBeforeDelay_reverts() public {
+        _queueWideBounds();
+        (, , uint256 eta) = config.getPendingBoundsChange();
+
+        vm.warp(eta - 1);
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FlyoverConfigurations.TimelockNotElapsed.selector,
+                eta,
+                eta - 1
+            )
+        );
+        config.applyBoundsChange();
+
+        // The active bounds are untouched.
+        (IFlyoverConfigurations.PegConfiguration memory min, ) = config
+            .getPegInConfigurationBounds();
+        assertEq(min.fixedFee, BOUND_MIN_FIXED_FEE);
+    }
+
+    function test_bounds_applyWithoutQueue_reverts() public {
+        vm.prank(owner);
+        vm.expectRevert(FlyoverConfigurations.NoQueuedBoundsChange.selector);
+        config.applyBoundsChange();
+    }
+
+    // ----------------------------------------------------- case 3: re-validated at both steps
+
+    function test_bounds_invertedPair_revertsAtQueueTime() public {
+        IFlyoverConfigurations.PegConfiguration memory min = _boundsMin();
+        min.fixedFee = BOUND_MAX_FIXED_FEE + 1; // min above max
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FlyoverConfigurations.InvalidBounds.selector,
+                FlyoverConfigurations.Field.FixedFee,
+                BOUND_MAX_FIXED_FEE + 1,
+                BOUND_MAX_FIXED_FEE
+            )
+        );
+        config.queueBoundsChange(min, _boundsMax());
+    }
+
+    /// @notice applyBoundsChange re-validates well-formedness. Since queueBoundsChange blocks an
+    /// inverted pair, we prove the apply-time guard by queuing a valid pair and then corrupting
+    /// the stored pending min directly before applying.
+    function test_bounds_invertedPair_revertsAtApplyTime() public {
+        _queueWideBounds();
+        (, , uint256 eta) = config.getPendingBoundsChange();
+
+        // Corrupt pendingMin.fixedFee to just above pendingMax.fixedFee, bypassing the queue.
+        uint256 corrupted = WIDE_MAX_FIXED_FEE + 1;
+        vm.store(
+            address(config),
+            _PENDING_MIN_FIXED_FEE_SLOT,
+            bytes32(corrupted)
+        );
+        // Sanity: the poke landed on the pending min.
+        (IFlyoverConfigurations.PegConfiguration memory pendingMin, , ) = config
+            .getPendingBoundsChange();
+        assertEq(pendingMin.fixedFee, corrupted);
+
+        vm.warp(eta);
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FlyoverConfigurations.InvalidBounds.selector,
+                FlyoverConfigurations.Field.FixedFee,
+                corrupted,
+                WIDE_MAX_FIXED_FEE
+            )
+        );
+        config.applyBoundsChange();
+
+        // The active bounds remain the deployment ones.
+        (IFlyoverConfigurations.PegConfiguration memory min, ) = config
+            .getPegInConfigurationBounds();
+        assertEq(min.fixedFee, BOUND_MIN_FIXED_FEE);
+    }
+
+    // --------------------------------------------------- case 4: second queue replaces pending
+
+    function test_bounds_secondQueueReplacesPending() public {
+        // First queued pair.
+        IFlyoverConfigurations.PegConfiguration memory firstMax = _wideMax();
+        firstMax.fixedFee = 2 ether;
+        vm.prank(owner);
+        config.queueBoundsChange(_wideMin(), firstMax);
+
+        // Advance time so the second queue gets a distinct eta.
+        vm.warp(block.timestamp + 1 hours);
+        uint256 expectedEta = block.timestamp + TIMELOCK_DELAY;
+
+        // Second queued pair replaces the first.
+        IFlyoverConfigurations.PegConfiguration memory secondMax = _wideMax();
+        secondMax.fixedFee = 3 ether;
+        vm.prank(owner);
+        config.queueBoundsChange(_wideMin(), secondMax);
+
+        (
+            ,
+            IFlyoverConfigurations.PegConfiguration memory pendingMax,
+            uint256 eta
+        ) = config.getPendingBoundsChange();
+        assertEq(
+            pendingMax.fixedFee,
+            3 ether,
+            "pending must be the second pair"
+        );
+        assertEq(eta, expectedEta, "eta must be refreshed by the second queue");
+
+        // Applying activates the second pair, never the replaced first.
+        vm.warp(eta);
+        vm.prank(owner);
+        config.applyBoundsChange();
+        (, IFlyoverConfigurations.PegConfiguration memory max) = config
+            .getPegInConfigurationBounds();
+        assertEq(max.fixedFee, 3 ether);
+    }
+
+    // ------------------------------------- the documented decision: active config must still fit
+
+    /// @notice Bounds that would strand the active configuration outside them are rejected at
+    /// apply time. This is the choice documented on applyBoundsChange: the active configuration
+    /// is always within the active bounds, with no qualification a reader has to know about.
+    function test_bounds_applyRejectedWhenActiveConfigFallsOutside() public {
+        // Tighten the fixed-fee floor above the seed config's fixedFee.
+        IFlyoverConfigurations.PegConfiguration memory min = _boundsMin();
+        min.fixedFee = SEED_FIXED_FEE + 1;
+
+        vm.prank(owner);
+        config.queueBoundsChange(min, _boundsMax());
+        vm.warp(block.timestamp + TIMELOCK_DELAY);
+
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FlyoverConfigurations.ActiveConfigOutsideNewBounds.selector,
+                FlyoverConfigurations.Field.FixedFee,
+                SEED_FIXED_FEE,
+                SEED_FIXED_FEE + 1,
+                BOUND_MAX_FIXED_FEE
+            )
+        );
+        config.applyBoundsChange();
+
+        // Nothing moved: the bounds and the active configuration are both unchanged.
+        (IFlyoverConfigurations.PegConfiguration memory activeMin, ) = config
+            .getPegInConfigurationBounds();
+        assertEq(activeMin.fixedFee, BOUND_MIN_FIXED_FEE);
+        assertEq(config.getPegInConfiguration().fixedFee, SEED_FIXED_FEE);
+    }
+
+    /// @notice The documented remedy for the case above: move the active configuration into the
+    /// new range first, then the same tightening applies. Both steps are time-locked, and the
+    /// configuration change can run during the bounds change's own delay.
+    function test_bounds_tighteningSucceedsAfterMovingActiveConfigFirst()
+        public
+    {
+        uint256 newFloor = SEED_FIXED_FEE + 1000 * SAT;
+
+        IFlyoverConfigurations.PegConfiguration memory min = _boundsMin();
+        min.fixedFee = newFloor;
+
+        // Queue the tightening now; the configuration move happens during its delay.
+        vm.prank(owner);
+        config.queueBoundsChange(min, _boundsMax());
+
+        IFlyoverConfigurations.PegConfiguration memory c = _altConfig();
+        c.fixedFee = newFloor; // inside both the old and the new bounds
+        _applyConfig(c);
+
+        (, , uint256 eta) = config.getPendingBoundsChange();
+        vm.warp(eta);
+        vm.prank(owner);
+        config.applyBoundsChange();
+
+        (IFlyoverConfigurations.PegConfiguration memory activeMin, ) = config
+            .getPegInConfigurationBounds();
+        assertEq(activeMin.fixedFee, newFloor);
+        assertEq(config.getPegInConfiguration().fixedFee, newFloor);
+    }
+
+    // ------------------------------------------------------------ the two pending slots are separate
+
+    /// @notice A queued bounds change and a queued configuration change occupy independent slots,
+    /// so queueing one never clobbers the other.
+    function test_bounds_pendingSlotIsIndependentOfConfigPending() public {
+        IFlyoverConfigurations.PegConfiguration memory c = _queueAlt();
+        _queueWideBounds();
+
+        (
+            IFlyoverConfigurations.PegConfiguration memory pending,
+            uint256 cEta
+        ) = config.getPendingChange();
+        (
+            IFlyoverConfigurations.PegConfiguration memory pendingMin,
+            ,
+            uint256 bEta
+        ) = config.getPendingBoundsChange();
+
+        assertEq(pending.fixedFee, c.fixedFee, "config pending survived");
+        assertEq(pendingMin.fixedFee, WIDE_MIN_FIXED_FEE, "bounds pending set");
+        assertTrue(cEta != 0 && bEta != 0);
+
+        // Applying the bounds leaves the queued configuration in place.
+        vm.warp(bEta);
+        vm.prank(owner);
+        config.applyBoundsChange();
+
+        (pending, cEta) = config.getPendingChange();
+        assertEq(pending.fixedFee, c.fixedFee);
+        assertTrue(cEta != 0);
+
+        vm.prank(owner);
+        config.applyChange();
+        assertEq(config.getPegInConfiguration().fixedFee, c.fixedFee);
+    }
+
+    // ------------------------------------------------------------------------------ events
+
+    function test_queueBoundsChange_emitsBoundsChangeQueued() public {
+        IFlyoverConfigurations.PegConfiguration memory min = _wideMin();
+        IFlyoverConfigurations.PegConfiguration memory max = _wideMax();
+        uint256 expectedEta = block.timestamp + TIMELOCK_DELAY;
+
+        vm.expectEmit(true, true, true, true, address(config));
+        emit FlyoverConfigurations.BoundsChangeQueued(min, max, expectedEta);
+        vm.prank(owner);
+        config.queueBoundsChange(min, max);
+    }
+
+    function test_applyBoundsChange_emitsBoundsChangeApplied() public {
+        _queueWideBounds();
+        vm.warp(block.timestamp + TIMELOCK_DELAY);
+
+        vm.expectEmit(true, true, true, true, address(config));
+        emit FlyoverConfigurations.BoundsChangeApplied(_wideMin(), _wideMax());
+        vm.prank(owner);
+        config.applyBoundsChange();
     }
 }


### PR DESCRIPTION
**Stack: 2 of 2.** Stacked on #519 — this PR targets `feature/FLY-2523`, not `v3.0.0`, so its diff shows tests only. GitHub retargets it to `v3.0.0` automatically once #519 merges. Review #519 first.

JIRA: [FLY-2523](https://rsklabs.atlassian.net/browse/FLY-2523)

## What

Coverage for the time-locked bounds change added in #519. Extends the two suites the ticket named, plus the getter and initialize suites for the surfaces the change added. `test/configurations` goes from 48 tests to 76.

### Timelock.t.sol

The four spec cases, mirrored for the bounds path: queue-then-apply after the delay, apply at the exact eta, apply before the delay reverts, apply with nothing queued reverts, and a second queue replacing the pending pair.

Two tests prove the change is *observable*, not merely stored: after widening, a fixed fee the old bounds rejected is accepted; after tightening, one they accepted is rejected. A third proves the pending bounds slot and the pending configuration slot are independent — queue both, apply one, and the other survives to apply cleanly.

The documented decision is pinned in both directions:
- `test_bounds_applyRejectedWhenActiveConfigFallsOutside` — a tightening that would strand the active configuration reverts with `ActiveConfigOutsideNewBounds`, and neither the bounds nor the configuration move.
- `test_bounds_tighteningSucceedsAfterMovingActiveConfigFirst` — the documented remedy works, with the configuration change running *inside* the bounds change's own delay.

Apply-time well-formedness is proven the same way the existing apply-time bounds test does it: queue a valid pair, then corrupt the stored pending min via `vm.store` (bounds namespace base + 11) so the guard is reachable.

### AdminGating.t.sol

Role gating on both entry points. One inverted-pair rejection per field (`fixedFee`, `percentageFee`, `minAmount`, `maxAmount`), each asserting the exact `InvalidBounds` payload. `min == max` is accepted as a degenerate pair that pins a field to one value. `test_noPlainBoundsSetterExists` asserts no single-step bounds setter selector is routable, so the "no code path changes bounds without the timelock" criterion is checked rather than assumed.

### Getters.t.sol / Scaffolding.t.sol

`getPendingBoundsChange()` zeroed / populated / cleared after apply. The timelock delay is unchanged by a bounds change, since the delay is the review window and is not editable. `initialize` rejects an inverted seed pair.

## Acceptance criteria

| Criterion | Test |
|---|---|
| Admin can queue and apply after the delay; both emit | `test_bounds_queueThenApplyAfterDelay_succeeds`, `test_queueBoundsChange_emitsBoundsChangeQueued`, `test_applyBoundsChange_emitsBoundsChangeApplied` |
| Applying before the delay reverts | `test_bounds_applyBeforeDelay_reverts` |
| Either function without the admin role reverts | `test_queueBoundsChange_nonAdminReverts`, `test_applyBoundsChange_nonAdminReverts` |
| `min > max` on any field reverts | four `test_queueBoundsChange_inverted*Reverts` |
| Bounds/active-config interaction documented and tested | `test_bounds_applyRejectedWhenActiveConfigFallsOutside`, `test_bounds_tighteningSucceedsAfterMovingActiveConfigFirst` |
| No path changes bounds outside the timelock | `test_noPlainBoundsSetterExists` |

## Testing

76 pass in `test/configurations`, 0 failures. Full suite: 773 pass, with 2 pre-existing failures in `test/differential/` that fail identically on `v3.0.0` and are unrelated to this change.
