### PR TITLE
Feat/fly 2541

### DIFF
--- a/src/FlyoverConfigurations.sol
+++ b/src/FlyoverConfigurations.sol
@@ -13,10 +13,10 @@ import {Flyover} from "./libraries/Flyover.sol";
 /// serve decision, and the settlement path for its amount validation. Admin changes are
 /// time-locked in two steps (queue then apply) and re-validated at both steps against immutable
 /// bounds fixed at deployment, so an admin mistake cannot set absurd values even with the role.
-/// @dev Implements the frozen {IFlyoverConfigurations} (peg-in only); its function signatures and
-/// structs are the shared ABI every consumer depends on, so they must not be changed here.
-/// Upgradeable, ERC-7201 namespaced storage, deployed behind a TransparentUpgradeableProxy per
-/// repo pattern.
+/// @dev Implements the frozen {IFlyoverConfigurations}. Peg-in is fully wired; peg-out interface
+/// methods stub with {PegOutNotImplemented} until the dedicated config storage lands (keeps this
+/// contract compiling against the frozen ABI). Upgradeable, ERC-7201 namespaced storage, deployed
+/// behind a TransparentUpgradeableProxy per repo pattern.
 /// @author Rootstock Labs
 contract FlyoverConfigurations is
     AccessControlDefaultAdminRulesUpgradeable,
@@ -85,6 +85,9 @@ contract FlyoverConfigurations is
     error TimelockNotElapsed(uint256 eta, uint256 nowTime);
     /// @notice Raised when applying while no change is queued.
     error NoQueuedChange();
+    /// @notice Peg-out config storage is not wired yet; interface methods stub until then.
+    /// @dev TODO: wire peg-out config storage and implement peg-out configuration methods
+    error PegOutNotImplemented();
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -203,6 +206,41 @@ contract FlyoverConfigurations is
     // solhint-disable-next-line comprehensive-interface
     function getTimelockDelay() external view returns (uint256) {
         return _getBounds().timelockDelay;
+    }
+
+    /// @inheritdoc IFlyoverConfigurations
+    function getPegOutConfiguration()
+        external
+        view
+        override
+        returns (PegOutConfiguration memory)
+    {
+        revert PegOutNotImplemented();
+    }
+
+    /// @inheritdoc IFlyoverConfigurations
+    function calculatePegOutFee(uint256) external view override returns (uint256) {
+        revert PegOutNotImplemented();
+    }
+
+    /// @inheritdoc IFlyoverConfigurations
+    function getRequiredPegOutBtcConfirmations(uint256)
+        external
+        view
+        override
+        returns (uint256)
+    {
+        revert PegOutNotImplemented();
+    }
+
+    /// @inheritdoc IFlyoverConfigurations
+    function queuePegOutChange(PegOutConfiguration calldata) external override {
+        revert PegOutNotImplemented();
+    }
+
+    /// @inheritdoc IFlyoverConfigurations
+    function applyPegOutChange() external override {
+        revert PegOutNotImplemented();
     }
 
     /// @dev fee = fixedFee + amount * percentageFee / 10_000, then rounded DOWN to a satoshi

--- a/src/interfaces/IFlyoverConfigurations.sol
+++ b/src/interfaces/IFlyoverConfigurations.sol
@@ -5,15 +5,15 @@ pragma solidity 0.8.25;
 /// @notice The single shared read for the commit-first protocol parameters. With no quote,
 /// the fee, the confirmation tiers, and the amount limits still need a source every party
 /// trusts equally: the SDK's estimate, every LPS's serve decision, and the settlement
-/// validation all read the same numbers from this contract.
-/// @dev Walkthrough (WALKTHROUGH-pegin.md) anchors: step 2, decision block 2·D, decision D2.
-/// This interface is frozen (S0): any change to it is a cross-lane ABI event, not a side
+/// validation all read the same numbers from this contract. Peg-in and peg-out share this
+/// deployment (paired getters).
+/// @dev This interface is frozen: any change to it is a cross-lane ABI event, not a side
 /// effect of another task.
 interface IFlyoverConfigurations {
 
     /// @notice One confirmation tier: deposits up to maxAmount require confirmations
-    /// @dev Struct fields are ABI, so they freeze here, not in S2. Tiers are kept strictly
-    /// ascending by maxAmount. Walkthrough anchor: step 2.
+    /// @dev Struct fields are ABI and freeze here. Tiers are kept strictly ascending by
+    /// maxAmount.
     /// @param maxAmount The upper amount bound of the tier, in wei
     /// @param confirmations The BTC confirmations required for amounts in the tier
     struct ConfirmationTier {
@@ -22,8 +22,8 @@ interface IFlyoverConfigurations {
     }
 
     /// @notice The full peg-in parameter set
-    /// @dev Struct fields are ABI, so they freeze here, not in S2. The fee floor is a
-    /// security parameter, not just pricing (2·D). Walkthrough anchors: step 2, decision D2.
+    /// @dev Struct fields are ABI and freeze here. The fee floor is a security parameter,
+    /// not just pricing.
     /// @param fixedFee The fixed component of the peg-in fee, in wei
     /// @param percentageFee The proportional component of the fee, in basis points over
     /// 10,000
@@ -39,15 +39,13 @@ interface IFlyoverConfigurations {
     }
 
     /// @notice Returns the active peg-in parameter set
-    /// @dev The SDK reads it for the user's estimate (step 1-2), every LPS for its serve
-    /// decision (step 10), and settlement for the amount validation (exception A4).
-    /// Walkthrough anchors: step 2, decision D2.
+    /// @dev The SDK reads it for the user's estimate, every LPS for its serve decision,
+    /// and settlement for amount validation.
     /// @return configuration The active PegConfiguration
     function getPegInConfiguration() external view returns (PegConfiguration memory configuration);
 
     /// @notice Calculates the peg-in fee for an amount under the active configuration
-    /// @dev fixedFee plus the percentage of the amount. Walkthrough anchors: step 2,
-    /// decision block 2·D.
+    /// @dev fixedFee plus the percentage of the amount.
     /// @param amount The peg-in amount, in wei
     /// @return fee The fee, in wei
     function calculatePegInFee(uint256 amount) external view returns (uint256 fee);
@@ -55,7 +53,7 @@ interface IFlyoverConfigurations {
     /// @notice Returns the BTC confirmations required before a peg-in of the given amount
     /// may be claimed
     /// @dev The first tier covering the amount answers. Read by the LPS before claiming
-    /// (step 10) and enforced by requestPegIn (step 11). Walkthrough anchor: step 2.
+    /// and enforced by requestPegIn.
     /// @param amount The peg-in amount, in wei
     /// @return confirmations The required BTC confirmations
     function getRequiredPegInBtcConfirmations(uint256 amount) external view returns (uint256 confirmations);
@@ -63,14 +61,76 @@ interface IFlyoverConfigurations {
     /// @notice Queues a configuration change, the first step of the time-locked admin change
     /// @dev Admin-only. The change activates only through applyChange after the configured
     /// delay; the values are validated against the immutable deployment bounds at queue time.
-    /// Returns nothing. Walkthrough anchors: step 2, decision block 2·D.
     /// @param newConfiguration The configuration to activate after the delay
     function queueChange(PegConfiguration calldata newConfiguration) external;
 
     /// @notice Activates the queued configuration change, the second step of the time-locked
     /// admin change
     /// @dev Admin-only. Reverts before the configured delay has elapsed; the values are
-    /// re-validated against the immutable deployment bounds at apply time. Returns nothing.
-    /// Walkthrough anchors: step 2, decision block 2·D.
+    /// re-validated against the immutable deployment bounds at apply time.
     function applyChange() external;
+
+    // -------------------------------------------------------------------------
+    // Peg-out
+    // -------------------------------------------------------------------------
+
+    /// @notice The full peg-out parameter set
+    /// @dev Struct fields are ABI and freeze here. Peg-in fee/limits/tiers plus claim /
+    /// fulfillment deadlines and `maxMinerFee`. Escrow request-id preimage, amount/fee
+    /// split, and overpayment rule: see {IPegOutEscrow}.
+    /// @param fixedFee Fixed component of the peg-out fee, in wei (security floor)
+    /// @param percentageFee Proportional fee, basis points over 10_000
+    /// @param minAmount Minimum serviceable peg-out amount, in wei
+    /// @param maxAmount Maximum serviceable peg-out amount, in wei
+    /// @param confirmationTiers BTC confirmations by amount (transferConfirmations)
+    /// @param penaltyFee Individual / global slash total, in wei
+    /// @param claimWindow Seconds from request → claim-by deadline (`depositDateLimit`)
+    /// @param claimWindowBlocks Blocks from request → claim-by block bound
+    /// @param callTime Fulfillment window duration from claim (`transferTime`)
+    /// @param expireTime Seconds after latest claim time → user-refund `expireDate`
+    /// @param expireBlocks Blocks after latest claim block → user-refund `expireBlock`
+    /// @param maxMinerFee Cap used by the short-delivery floor, in wei
+    struct PegOutConfiguration {
+        uint256 fixedFee;
+        uint256 percentageFee;
+        uint256 minAmount;
+        uint256 maxAmount;
+        ConfirmationTier[] confirmationTiers;
+        uint256 penaltyFee;
+        uint256 claimWindow;
+        uint256 claimWindowBlocks;
+        uint256 callTime;
+        uint256 expireTime;
+        uint256 expireBlocks;
+        uint256 maxMinerFee;
+    }
+
+    /// @notice Returns the active peg-out parameter set
+    /// @dev SDK estimate, every LPS serve decision, and PegOutEscrow.requestPegOut all
+    /// read this. Fee inputs for the frozen amount / fee split live here (`fixedFee`,
+    /// `percentageFee`, `minAmount`, `maxAmount`).
+    function getPegOutConfiguration() external view returns (PegOutConfiguration memory configuration);
+
+    /// @notice Calculates the peg-out fee for an amount under the active peg-out configuration
+    /// @dev `fixedFee + percentageFee·amount / 10_000` (satoshi-floored). Same formula
+    /// escrow uses for `callFee` under the frozen amount / fee split.
+    /// @param amount The peg-out principal, in wei
+    /// @return fee The fee, in wei
+    function calculatePegOutFee(uint256 amount) external view returns (uint256 fee);
+
+    /// @notice Returns BTC confirmations required before a peg-out of this amount may settle
+    /// @dev First covering tier. Consumed at request (snapshotted into the quote) and at
+    /// refundPegOut.
+    /// @param amount The peg-out principal, in wei
+    /// @return confirmations The required BTC confirmations
+    function getRequiredPegOutBtcConfirmations(uint256 amount) external view returns (uint256 confirmations);
+
+    /// @notice Queues a peg-out configuration change (time-locked admin path)
+    /// @dev Admin-only. Activates only through {applyPegOutChange} after the configured
+    /// delay (shared timelock policy with peg-in).
+    function queuePegOutChange(PegOutConfiguration calldata newConfiguration) external;
+
+    /// @notice Activates the queued peg-out configuration change
+    /// @dev Admin-only. Reverts before the configured delay has elapsed.
+    function applyPegOutChange() external;
 }

--- a/src/interfaces/IPegOutEscrow.sol
+++ b/src/interfaces/IPegOutEscrow.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {Quotes} from "../libraries/Quotes.sol";
+
+/// @title Peg-out escrow interface (commit-first)
+/// @notice Holds the user's RBTC commitment before an LP claims. Settlement after claim
+/// stays on PegOutContract. LPs discover work via {PegOutRequested}; there is no off-chain
+/// quote acceptance and no liquidity reservation before this deposit.
+/// @dev This interface is frozen: any change to it is a cross-lane ABI event, not a side
+/// effect of another task.
+interface IPegOutEscrow {
+    /// @notice Lifecycle of one escrowed peg-out. `NONE` is the storage default so unset
+    /// ids are never confused with `REQUESTED`.
+    enum EscrowedPegOutState {
+        NONE,
+        REQUESTED,
+        CLAIMED,
+        CANCELLED,
+        FULFILLED,
+        REFUNDED
+    }
+
+    /// @notice Emitted when a user escrows RBTC for a peg-out (the sole commitment)
+    /// @dev Fee / deadline / confirmation snapshots live on the stored quote
+    /// ({getPegOutQuote}); this event is the LPS discovery signal only.
+    /// @param requestHash Escrow-minted request id (mapping key, LPS watch topic, BTC
+    /// OP_RETURN payload). **Id preimage (frozen):**
+    /// `requestHash = keccak256(abi.encode(chainId, address(this), nonce, msg.sender,
+    /// refundTo, keccak256(destinationAddress), amount, callFee, block.timestamp))`
+    /// where `nonce` is a per-escrow sequence (`++requestCount`). Two identical user
+    /// requests therefore yield distinct ids. Named `requestHash` (not `quoteHash`) so it
+    /// is not mistaken for `keccak256(encodePegOutQuote)`.
+    /// @param refundAddress Who may cancel and who receives refunds
+    /// @param amount BTC-equivalent principal in wei after the fee split
+    /// @param destinationAddress User BTC payout script / address bytes
+    event PegOutRequested(
+        bytes32 indexed requestHash,
+        address indexed refundAddress,
+        uint256 indexed amount,
+        bytes destinationAddress
+    );
+
+    /// @notice Emitted when an LP claims a REQUESTED peg-out and funds move to PegOutContract
+    /// @dev A claim is a hard commitment: there is no release / unclaim path.
+    event PegOutClaimed(address indexed lpAddress, bytes32 indexed requestHash);
+
+    /// @notice Emitted when the refund address cancels while still REQUESTED (no slash)
+    event PegOutCancelled(bytes32 indexed requestHash);
+
+    /// @notice Emitted when nobody claimed by the claim deadline and the user is refunded
+    event PegOutRefundedOnNoClaim(bytes32 indexed requestHash, address indexed refundAddress, uint256 amount);
+
+    /// @notice Emitted when {refundOnNoClaim}'s global slash attempt reverts (user still refunded)
+    event GlobalSlashSkipped(bytes32 indexed requestHash);
+
+    error InvalidDestination();
+    error NotServiceable(uint256 amount, uint256 minAmount, uint256 maxAmount);
+    error InvalidState(bytes32 requestHash, EscrowedPegOutState expected, EscrowedPegOutState actual);
+    error ClaimWindowClosed(uint256 depositDateLimit);
+    error ClaimWindowOpen(uint256 depositDateLimit);
+    error PegOutContractNotSet();
+    error CollateralManagementNotSet();
+    error OnlyPegOutContract(address caller);
+
+    /// @notice User commits RBTC. Splits `msg.value` into `amount` + `callFee` from
+    /// FlyoverConfigurations, stores a quote-shaped record, emits {PegOutRequested}.
+    /// @dev **Amount / fee split (frozen):** `requestPegOut` takes no explicit `amount`.
+    /// For active config `fixedFee` and `percentageFee` (basis points over
+    /// `FEE_PERCENTAGE_DENOMINATOR` = 10_000):
+    /// `amount = ((msg.value - fixedFee) * DEN) / (DEN + percentageFee)`;
+    /// then `amount -= amount % SAT_TO_WEI` (satoshi floor);
+    /// `callFee = calculatePegOutFee(amount)` (same satoshi-floor fee as configs).
+    /// **Overpayment rule (frozen):** `required = amount + callFee`. If
+    /// `msg.value - required` is at least the wired PegOutContract `dustThreshold`,
+    /// the excess is refunded to the refund address (legacy `depositPegOut` dust-change
+    /// semantics). Otherwise the residual is absorbed into `callFee` so escrow balance
+    /// stays attributed. `msg.value` must exceed `fixedFee` and the derived `amount`
+    /// must lie in `[minAmount, maxAmount]` or the call reverts.
+    /// @param destinationAddress User BTC payout script / address bytes
+    /// @param refundAddress Who may cancel and who receives refunds; address(0) → msg.sender
+    /// @return requestHash The id under the frozen preimage above
+    function requestPegOut(
+        bytes calldata destinationAddress,
+        address refundAddress
+    ) external payable returns (bytes32 requestHash);
+
+    /// @notice User cancels while still REQUESTED. Only `rskRefundAddress` on the quote.
+    /// @dev Full refund, no slash.
+    function cancelPegOut(bytes32 requestHash) external;
+
+    /// @notice Registered LP claims the peg-out and moves funds into PegOutContract.
+    /// @dev Hard commitment: no release/unclaim path. Caller must pass EIP-712 over the
+    /// reconstructed quote with `lpRskAddress = msg.sender`.
+    function claimPegOut(bytes32 requestHash, bytes calldata signature) external;
+
+    /// @notice Permissionless refund after `depositDateLimit` if nobody claimed.
+    /// @dev Attempts global slash; user refund must not depend on slash success.
+    function refundOnNoClaim(bytes32 requestHash) external;
+
+    /// @notice Current lifecycle state for `requestHash` (`NONE` if never requested)
+    function getPegOutState(bytes32 requestHash) external view returns (EscrowedPegOutState);
+
+    /// @notice Quote-shaped terms snapshotted at request (and `lpRskAddress` after claim)
+    /// @dev Reverts if state is `NONE`. Fee/deadline/confirmation fields are the LPS and
+    /// settlement source of truth alongside the lean {PegOutRequested} event.
+    function getPegOutQuote(bytes32 requestHash) external view returns (Quotes.PegOutQuote memory);
+
+    /// @notice Number of requests ever minted (monotone nonce high-water mark)
+    /// @dev With {requestIdAt}, an LPS can rebuild the pending set after missed events.
+    function totalRequests() external view returns (uint256);
+
+    /// @notice `requestHash` minted for sequence `nonce` (1-based); zero if unused
+    function requestIdAt(uint256 nonce) external view returns (bytes32);
+
+    /// @notice Called by PegOutContract when settlement finishes (`FULFILLED` or `REFUNDED`)
+    /// @dev Escrow does not move funds here; custody already left at claim.
+    function onSettlement(bytes32 requestHash, EscrowedPegOutState finalState) external;
+}

--- a/test/pegin/FlyoverConfigurationsMock.sol
+++ b/test/pegin/FlyoverConfigurationsMock.sol
@@ -15,6 +15,10 @@ contract FlyoverConfigurationsMock is IFlyoverConfigurations {
     PegConfiguration private _config;
     PegConfiguration private _queued;
 
+    /// @notice Peg-out stubs only; real mock wiring lands with peg-out config tests.
+    /// @dev TODO: wire peg-out config storage and implement peg-out configuration methods
+    error PegOutNotImplemented();
+
     /// @notice Sets the fixed and percentage fee components directly
     function setFee(uint256 fixedFee, uint256 percentageFee) external {
         _config.fixedFee = fixedFee;
@@ -79,6 +83,41 @@ contract FlyoverConfigurationsMock is IFlyoverConfigurations {
     /// @inheritdoc IFlyoverConfigurations
     function applyChange() external override {
         _config = _queued;
+    }
+
+    /// @inheritdoc IFlyoverConfigurations
+    function getPegOutConfiguration()
+        external
+        view
+        override
+        returns (PegOutConfiguration memory)
+    {
+        revert PegOutNotImplemented();
+    }
+
+    /// @inheritdoc IFlyoverConfigurations
+    function calculatePegOutFee(uint256) external view override returns (uint256) {
+        revert PegOutNotImplemented();
+    }
+
+    /// @inheritdoc IFlyoverConfigurations
+    function getRequiredPegOutBtcConfirmations(uint256)
+        external
+        view
+        override
+        returns (uint256)
+    {
+        revert PegOutNotImplemented();
+    }
+
+    /// @inheritdoc IFlyoverConfigurations
+    function queuePegOutChange(PegOutConfiguration calldata) external override {
+        revert PegOutNotImplemented();
+    }
+
+    /// @inheritdoc IFlyoverConfigurations
+    function applyPegOutChange() external override {
+        revert PegOutNotImplemented();
     }
 }
 /* solhint-enable comprehensive-interface */

--- a/test/pegin/FlyoverConfigurationsMock.sol
+++ b/test/pegin/FlyoverConfigurationsMock.sol
@@ -96,17 +96,16 @@ contract FlyoverConfigurationsMock is IFlyoverConfigurations {
     }
 
     /// @inheritdoc IFlyoverConfigurations
-    function calculatePegOutFee(uint256) external view override returns (uint256) {
+    function calculatePegOutFee(
+        uint256
+    ) external view override returns (uint256) {
         revert PegOutNotImplemented();
     }
 
     /// @inheritdoc IFlyoverConfigurations
-    function getRequiredPegOutBtcConfirmations(uint256)
-        external
-        view
-        override
-        returns (uint256)
-    {
+    function getRequiredPegOutBtcConfirmations(
+        uint256
+    ) external view override returns (uint256) {
         revert PegOutNotImplemented();
     }
 


### PR DESCRIPTION
## What

Freeze the commit-first peg-out ABI so downstream lanes can generate bindings:

- Add `IPegOutEscrow` (`requestPegOut`, `cancelPegOut`, `claimPegOut`, `getPegOutState`, refund path, and the event set).
- Extend `IFlyoverConfigurations` with `PegOutConfiguration`, `getPegOutConfiguration`, `calculatePegOutFee`, confirmation tiers, claim/fulfillment deadlines, and `maxMinerFee`.
- NatSpec on `IPegOutEscrow` records the two frozen decisions: request-id preimage (nonce to distinct ids) and the `msg.value` amount/fee split + dust overpayment rule. Configs points at that NatSpec.
- Minimal `PegOutNotImplemented` stubs on `FlyoverConfigurations` and `FlyoverConfigurationsMock` so the repo still compiles against the widened interface.

## Why

Same shape as the peg-in: lock the shared ABI before implementation lanes (escrow, S2 configs, SDK/LPS bindings).

## Type of Change

- [x] New feature (non-breaking change)

## Affected Areas

- [x] PegOut flow (`depositPegout`, `refundPegOut`, `refundUserPegOut`)

## Risk & Security Review

- [x] Access control and authorization paths reviewed
- [x] Reentrancy and external call paths reviewed
- [x] Storage layout / upgrade safety reviewed (if upgradeable code changed)
- [x] Time/block/confirmation assumptions reviewed
- [ ] BTC tx output/index assumptions reviewed (if pegout validation touched)
- [x] No secrets or sensitive values added

Peg-out methods on `FlyoverConfigurations` / the mock only `revert PegOutNotImplemented()` — no new storage, no deploy path changes.

## Test Plan

List what you ran locally and the outcome:

- [x] `npm run lint:sol`
- [x] `npm run lint:ts`
- [x] `npm run compile`
- [x] `npm test`

Additional notes on test coverage, edge cases, and any tests intentionally skipped:

Interface / stub-only change. Peg-in suites pass. No new escrow behavioral tests (implementation is out of scope). `test/tasks/PauseSystem.t.sol` can flake under parallel `vm.setEnv` pollution; unrelated to this PR.

## Jira Ticket

- Jira: [FLY-2541](https://rsklabs.atlassian.net/browse/FLY-2541)


## Reviewer Notes

- Treat `IPegOutEscrow` and the peg-out surface of `IFlyoverConfigurations` as frozen ABI after merge.
- Focus NatSpec decisions: id preimage includes `nonce` (`++requestCount`); amount/fee split derives `amount` from `msg.value` then `callFee = calculatePegOutFee(amount)` with dust-threshold overpayment.
- Stubs are intentional compile glue only — not the S2/S11 implementation.