### PR TITLE
ci: integrate mutation testing

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,230 @@
+name: Mutation testing
+
+# Advisory only: this workflow reports surviving mutants but never fails a PR.
+# `mewt run` exits 0 even when mutants survive, so any gating would have to be
+# built on top of `mewt status --format json` deliberately.
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      targets:
+        description: "Space-separated contracts to mutate (defaults to the changed ones)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mutation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mutation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # Full history so the base ref is available to `git diff`.
+          fetch-depth: 0
+
+      # Drift guard. Advisory like the rest of the job: remove continue-on-error
+      # to make an unmapped contract block the PR.
+      - name: Check mutation scope
+        id: scope
+        continue-on-error: true
+        run: ./script/mutation/check-scope.sh
+
+      - name: Report scope drift
+        if: steps.scope.outcome == 'failure'
+        run: |
+          {
+            echo "### Mutation scope drift"
+            echo
+            echo "\`mewt.toml\` no longer matches the contracts under \`src/\`."
+            echo "Contracts without a \`[[per_target]]\` mapping are skipped by mutation testing."
+            echo
+            echo "Run \`make mutate-scope\` locally for details."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Resolve targets
+        id: targets
+        env:
+          # Passed through the environment rather than interpolated into the
+          # script, so neither input can inject shell.
+          INPUT_TARGETS: ${{ github.event.inputs.targets }}
+          # Empty on workflow_dispatch, where there is no PR to diff against.
+          HEAD_BASE_REF: ${{ github.base_ref }}
+        run: |
+          if [ -n "$INPUT_TARGETS" ]; then
+            # shellcheck disable=SC2086
+            targets="$(printf '%s\n' $INPUT_TARGETS | python3 script/mutation/scope.py filter)"
+          else
+            targets="$(./script/mutation/changed-contracts.sh "origin/${HEAD_BASE_REF:-master}")"
+          fi
+
+          {
+            echo "targets<<EOF"
+            echo "$targets"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ -z "$targets" ]; then
+            echo "has_targets=false" >> "$GITHUB_OUTPUT"
+            echo "No contracts in mutation scope changed; skipping." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "has_targets=true" >> "$GITHUB_OUTPUT"
+
+          # A single contract can produce a few hundred mutants, and every one
+          # of them recompiles. More than one contract does not fit in the job
+          # timeout, so drop to high severity (ER is the only high-severity
+          # Solidity mutation) and say so rather than running out the clock.
+          count="$(printf '%s\n' "$targets" | wc -l | tr -d ' ')"
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+
+          if [ "$count" -gt 1 ]; then
+            echo "mutations=ER" >> "$GITHUB_OUTPUT"
+            {
+              echo "### Mutation testing scope reduced"
+              echo
+              echo "This PR changes **$count** contracts in mutation scope."
+              echo "A full campaign on more than one contract does not fit in the job timeout,"
+              echo "so this run is limited to **high severity (ER) mutations only**."
+              echo
+              echo "For a full campaign on a single contract, run it locally:"
+              echo '```'
+              printf '%s\n' "$targets" | sed 's|^|make mutate-file FILE=|'
+              echo '```'
+              echo
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "mutations=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Use Node.js 20.15.1
+        if: steps.targets.outputs.has_targets == 'true'
+        uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
+        with:
+          node-version: "20.15.1"
+
+      - name: NPM Login
+        if: steps.targets.outputs.has_targets == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm config set //npm.pkg.github.com/:_authToken $GITHUB_TOKEN
+
+      # Required: foundry.toml remaps OpenZeppelin and @rsksmart into node_modules.
+      - name: Install dependencies
+        if: steps.targets.outputs.has_targets == 'true'
+        run: npm ci
+
+      - name: Install Foundry
+        if: steps.targets.outputs.has_targets == 'true'
+        uses: "foundry-rs/foundry-toolchain@50d5a8956f2e319df19e6b57539d7e2acb9f8c1e" # v1.5.0
+        with:
+          version: stable
+
+      - name: Resolve mewt version
+        if: steps.targets.outputs.has_targets == 'true'
+        id: mewt-version
+        run: |
+          tag="$(curl -sL https://api.github.com/repos/trailofbits/mewt/releases/latest | jq -r '.tag_name')"
+          # A rate-limited lookup must not cache an install under a bogus key.
+          if [ -z "$tag" ] || [ "$tag" = "null" ]; then
+            tag="unresolved-${{ github.run_id }}"
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Cache mewt
+        if: steps.targets.outputs.has_targets == 'true'
+        id: mewt-cache
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: ~/.local/bin/mewt
+          key: mewt-${{ runner.os }}-${{ steps.mewt-version.outputs.tag }}
+
+      - name: Install mewt
+        if: steps.targets.outputs.has_targets == 'true' && steps.mewt-cache.outputs.cache-hit != 'true'
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/trailofbits/mewt/releases/latest/download/mewt-installer.sh | sh
+
+      - name: Add mewt to PATH
+        if: steps.targets.outputs.has_targets == 'true'
+        run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      # Targets are always passed explicitly, which replaces [targets].include
+      # for this invocation. They are already intersected with the allowlist.
+      - name: Run mutation campaign
+        if: steps.targets.outputs.has_targets == 'true'
+        continue-on-error: true
+        env:
+          TARGETS: ${{ steps.targets.outputs.targets }}
+          MUTATIONS: ${{ steps.targets.outputs.mutations }}
+        run: |
+          if [ -n "$MUTATIONS" ]; then
+            set -- --mutations "$MUTATIONS"
+          else
+            set --
+          fi
+          # Word splitting is intended: TARGETS is a newline-separated path list.
+          # shellcheck disable=SC2086
+          mewt run "$@" $TARGETS
+
+      - name: Summarize results
+        if: steps.targets.outputs.has_targets == 'true'
+        env:
+          TARGETS: ${{ steps.targets.outputs.targets }}
+          MUTATIONS: ${{ steps.targets.outputs.mutations }}
+        run: |
+          mewt status --format json > mutation-status.json
+
+          {
+            echo "### Mutation testing"
+            echo
+            echo "**Contracts mutated:**"
+            printf '%s\n' "$TARGETS" | sed 's|^|- `|; s|$|`|'
+            echo
+            if [ -n "$MUTATIONS" ]; then
+              echo "**Mutations executed:** \`$MUTATIONS\` only (high severity). Medium/low rates below are \`n/a\` because those mutants were not run."
+            else
+              echo "**Mutations executed:** all severities (default mewt set for Solidity)."
+            fi
+            echo
+            echo "| Contract | Mutants | Tested | Caught | Uncaught | Timeout | High | Medium | Low |"
+            echo "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
+            jq -r '
+              def pct: if . == null then "n/a" else "\(. * 10 | round / 10)%" end;
+              .targets[]
+              | "| \(.path) | \(.total_mutants) | \(.tested) | \(.caught) | \(.uncaught) | \(.timeout) "
+                + "| \(.high_catch_rate | pct) | \(.medium_catch_rate | pct) | \(.low_catch_rate | pct) |"
+            ' mutation-status.json
+            echo
+            jq -r '
+              def pct: if . == null then "n/a" else "\(. * 10 | round / 10)%" end;
+              .campaign
+              | "Tested \(.tested) of \(.total_mutants) mutants: \(.caught) caught, "
+                + "\(.uncaught) uncaught, \(.timeout) timed out "
+                + "(catch rate high \(.high_catch_rate | pct), medium \(.medium_catch_rate | pct), "
+                + "low \(.low_catch_rate | pct))."
+            ' mutation-status.json
+            echo
+            echo "Advisory only: surviving mutants do not fail this job."
+            echo "Survivors are annotated on the PR via SARIF (Code Scanning)."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Generate SARIF
+        if: steps.targets.outputs.has_targets == 'true'
+        run: mewt results --format sarif > mutation.sarif
+
+      - name: Upload SARIF file
+        if: steps.targets.outputs.has_targets == 'true'
+        uses: github/codeql-action/upload-sarif@48ab28a6f5dbc2a99bf1e0131198dd8f1df78169 # v3.28.0
+        with:
+          sarif_file: mutation.sarif
+          category: mutation-testing

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -33,6 +33,11 @@ jobs:
           # Full history so the base ref is available to `git diff`.
           fetch-depth: 0
 
+      - name: Set up Python 3.12
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
       # Drift guard. Advisory like the rest of the job: remove continue-on-error
       # to make an unmapped contract block the PR.
       - name: Check mutation scope
@@ -107,6 +112,10 @@ jobs:
           else
             echo "mutations=" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Install jq
+        if: steps.targets.outputs.has_targets == 'true'
+        run: sudo apt-get update && sudo apt-get install -y jq
 
       - name: Use Node.js 20.15.1
         if: steps.targets.outputs.has_targets == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,12 @@ broadcast/**
 /coverage
 /coverage.json
 
-# Python virtualenv (created by `make python-setup`)
+# Python
 .venv/
+__pycache__/
+*.py[cod]
+
+# mewt (mutation testing)
+mewt.sqlite
+mutation-status.json
+*.sarif

--- a/Makefile
+++ b/Makefile
@@ -988,8 +988,19 @@ mutate-install:
 	@echo "Installing mewt..."
 	curl --proto '=https' --tlsv1.2 -LsSf https://github.com/trailofbits/mewt/releases/latest/download/mewt-installer.sh | sh
 	@echo ""
-	@echo "Installed: $$(command -v mewt || echo '~/.local/bin/mewt (ensure ~/.local/bin is on PATH)')"
-	@mewt --version
+	@mewt_bin="$$(command -v mewt || echo "$$HOME/.local/bin/mewt")"; \
+	if [ ! -x "$$mewt_bin" ]; then \
+		echo "Error: mewt was not found after installation."; \
+		exit 1; \
+	fi; \
+	echo "Installed: $$mewt_bin"; \
+	"$$mewt_bin" --version; \
+	if ! command -v mewt >/dev/null; then \
+		echo ""; \
+		echo "Note: $$(dirname "$$mewt_bin") is not on your PATH."; \
+		echo "Add it so the other mutate-* targets work:"; \
+		echo "  export PATH=\"$$(dirname "$$mewt_bin"):\$$PATH\""; \
+	fi
 
 # Show the mutation scope and check it against the contracts on disk
 .PHONY: mutate-scope

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,12 @@ PEGIN_QUOTE_FILE ?=
 PEGIN_SIGNATURE ?=
 PEGIN_TXID ?=
 
+# Mutation testing defaults
+BASE_REF ?= origin/master
+# Optional comma-separated mutation slugs, e.g. MUTATIONS=ER,CR,IF,IT,NR,RDV,RCI
+MUTATIONS ?=
+MEWT_FLAGS = $(if $(MUTATIONS),--mutations $(MUTATIONS))
+
 # Flyover library addresses are read from addresses.json at build time
 
 # Environment file
@@ -217,6 +223,15 @@ help:
 	@echo "  test-fuzz-pegout      - Run pegout fuzz tests"
 	@echo "  test-fuzz-libraries   - Run libraries fuzz tests"
 	@echo ""
+	@echo "Mutation Testing (mewt):"
+	@echo "  mutate-install    - Install mewt (trailofbits mutation testing tool)"
+	@echo "  mutate-scope      - Show the mutation allowlist and check it for drift"
+	@echo "  mutate-changed    - Mutate contracts changed against BASE_REF"
+	@echo "  mutate-file       - Mutate a single contract (FILE=...)"
+	@echo "  mutate-status     - Campaign overview with per-contract breakdown"
+	@echo "  mutate-results    - Show surviving mutants"
+	@echo "  mutate-clean      - Drop stale targets from the mewt database"
+	@echo ""
 	@echo "Deployment examples:"
 	@echo "  make deploy-libraries-broadcast NETWORK=rskTestnet      # Deploy libs, then update addresses.json"
 	@echo "  make deploy-flyover-fork NETWORK=rskTestnet             # Deploy full Flyover (libraries from addresses.json)"
@@ -275,6 +290,13 @@ help:
 	@echo "  make test-flyover                             # Run all Flyover system tests"
 	@echo "  make test-file FILE=test/tasks/HashQuote.t.sol  # Run specific test file"
 	@echo "  make test-func FUNC=test_HashPeginQuote       # Run specific test function"
+	@echo ""
+	@echo "Mutation testing examples:"
+	@echo "  make mutate-install                           # Install mewt"
+	@echo "  make mutate-scope                             # Inspect the mutation allowlist"
+	@echo "  make mutate-changed BASE_REF=origin/master    # Mutate changed contracts"
+	@echo "  make mutate-file FILE=src/PauseRegistry.sol   # Mutate one contract"
+	@echo "  make mutate-changed MUTATIONS=ER,CR,IF,IT,NR,RDV,RCI  # Faster high/medium-only pass"
 
 # =============================================================================
 # FLYOVER DEPLOYMENT SCRIPTS
@@ -953,6 +975,82 @@ test-fuzz-pegout:
 test-fuzz-libraries:
 	@echo "Running libraries fuzz tests..."
 	forge test --match-path "test/fuzz/libraries/*.sol" -vv
+
+# =============================================================================
+# MUTATION TESTING (mewt)
+# =============================================================================
+# Scope is the [[per_target]] allowlist in mewt.toml. Contracts outside it are
+# never mutated; script/mutation/check-scope.sh guards against drift.
+
+# Install mewt (same installer the CI workflow uses)
+.PHONY: mutate-install
+mutate-install:
+	@echo "Installing mewt..."
+	curl --proto '=https' --tlsv1.2 -LsSf https://github.com/trailofbits/mewt/releases/latest/download/mewt-installer.sh | sh
+	@echo ""
+	@echo "Installed: $$(command -v mewt || echo '~/.local/bin/mewt (ensure ~/.local/bin is on PATH)')"
+	@mewt --version
+
+# Show the mutation scope and check it against the contracts on disk
+.PHONY: mutate-scope
+mutate-scope:
+	@echo "Mutation allowlist:"
+	@python3 script/mutation/scope.py allowlist | sed 's/^/  /'
+	@echo ""
+	@./script/mutation/check-scope.sh
+
+# Mutate the contracts changed against BASE_REF
+.PHONY: mutate-changed
+mutate-changed:
+	@if ! git diff --quiet || ! git diff --cached --quiet; then \
+		echo "Error: working tree is dirty."; \
+		echo "mewt rewrites contracts in place, so commit or stash first."; \
+		exit 1; \
+	fi
+	@echo "Resolving contracts changed against $(BASE_REF)..."
+	@targets=$$(./script/mutation/changed-contracts.sh $(BASE_REF)); \
+	if [ -z "$$targets" ]; then \
+		echo "No contracts in mutation scope changed."; \
+		exit 0; \
+	fi; \
+	echo "Mutating:"; echo "$$targets" | sed 's/^/  /'; \
+	mewt run $(MEWT_FLAGS) $$targets
+
+# Mutate a single contract
+.PHONY: mutate-file
+mutate-file:
+	@if [ -z "$(FILE)" ]; then \
+		echo "Error: FILE is required"; \
+		echo "Usage: make mutate-file FILE=src/PegInContract.sol"; \
+		exit 1; \
+	fi
+	@if [ -z "$$(echo '$(FILE)' | python3 script/mutation/scope.py filter 2>/dev/null)" ]; then \
+		echo "Error: $(FILE) is not in the mutation allowlist."; \
+		echo "Run 'make mutate-scope' to see the eligible contracts."; \
+		exit 1; \
+	fi
+	@if ! git diff --quiet || ! git diff --cached --quiet; then \
+		echo "Error: working tree is dirty."; \
+		echo "mewt rewrites contracts in place, so commit or stash first."; \
+		exit 1; \
+	fi
+	@echo "Mutating $(FILE)..."
+	mewt run $(MEWT_FLAGS) $(FILE)
+
+# Campaign overview with per-contract breakdown
+.PHONY: mutate-status
+mutate-status:
+	@mewt status
+
+# Show surviving mutants
+.PHONY: mutate-results
+mutate-results:
+	@mewt results
+
+# Drop stale targets from the mewt database
+.PHONY: mutate-clean
+mutate-clean:
+	@mewt clean
 
 # Clean build artifacts
 .PHONY: clean

--- a/mewt.toml
+++ b/mewt.toml
@@ -1,0 +1,79 @@
+db = "mewt.sqlite"
+
+[log]
+level = "info"
+
+[targets]
+# Must stay in sync with the [[per_target]] globs below
+include = [
+  "src/PegInContract.sol",
+  "src/PegOutContract.sol",
+  "src/CollateralManagement.sol",
+  "src/FlyoverDiscovery.sol",
+  "src/FlyoverConfigurations.sol",
+  "src/PegInAddressRegistry.sol",
+  "src/PauseRegistry.sol",
+  "src/EmergencyPause/EmergencyPause.sol",
+  "src/libraries/PegInDerivation.sol",
+  "src/libraries/SignatureValidator.sol",
+  "src/libraries/Quotes.sol",
+  "src/libraries/FlyoverConfigurationsRegtest.sol",
+  "src/libraries/Flyover.sol",
+]
+ignore = ["src/interfaces/", "src/legacy/", "src/test-contracts/", "src/test/", "node_modules"]
+
+# no [test].cmd to avoid silently running the whole unit suite
+[test]
+timeout = 120
+
+[[per_target]]
+glob = "src/PegInContract.sol"
+test.cmd = "forge test --match-path \"test/pegin/*.t.sol\""
+
+[[per_target]]
+glob = "src/PegOutContract.sol"
+test.cmd = "forge test --match-path \"test/pegout/*.t.sol\""
+
+[[per_target]]
+glob = "src/CollateralManagement.sol"
+test.cmd = "forge test --match-path \"test/collateral/*.t.sol\""
+
+[[per_target]]
+glob = "src/FlyoverDiscovery.sol"
+test.cmd = "forge test --match-path \"test/discovery/*.t.sol\""
+
+[[per_target]]
+glob = "src/FlyoverConfigurations.sol"
+test.cmd = "forge test --match-path \"test/configurations/*.t.sol\""
+
+[[per_target]]
+glob = "src/PegInAddressRegistry.sol"
+test.cmd = "forge test --match-path \"test/pegin-registry/*.t.sol\""
+
+[[per_target]]
+glob = "src/PauseRegistry.sol"
+test.cmd = "forge test --match-path \"test/Pause.t.sol\""
+
+[[per_target]]
+glob = "src/EmergencyPause/EmergencyPause.sol"
+test.cmd = "forge test --match-path \"test/Pause.t.sol\""
+
+[[per_target]]
+glob = "src/libraries/PegInDerivation.sol"
+test.cmd = "forge test --match-path \"test/libraries/PegInDerivation.t.sol\""
+
+[[per_target]]
+glob = "src/libraries/SignatureValidator.sol"
+test.cmd = "forge test --match-path \"test/libraries/SignatureValidator*.t.sol\""
+
+[[per_target]]
+glob = "src/libraries/Quotes.sol"
+test.cmd = "forge test --match-path \"test/{pegin,pegout}/*.t.sol\""
+
+[[per_target]]
+glob = "src/libraries/FlyoverConfigurationsRegtest.sol"
+test.cmd = "forge test --match-path \"test/configurations/*.t.sol\""
+
+[[per_target]]
+glob = "src/libraries/Flyover.sol"
+test.cmd = "forge test --match-path \"test/{pegin,pegout,collateral,discovery}/*.t.sol\""

--- a/script/mutation/changed-contracts.sh
+++ b/script/mutation/changed-contracts.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Print the contracts changed against a base ref that are in the mutation
+# allowlist, one repo-relative path per line.
+#
+# The intersection with the allowlist happens here, before mewt is invoked, so
+# a contract without a [[per_target]] mapping can never be mutated. Paths are
+# emitted exactly as git reports them: mewt matches [[per_target]] globs against
+# the path as supplied, so canonicalizing or prefixing with ./ would silently
+# miss every rule.
+#
+# Usage:
+#   script/mutation/changed-contracts.sh [base-ref]
+#   BASE_REF=origin/master script/mutation/changed-contracts.sh
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+BASE="${1:-${BASE_REF:-origin/master}}"
+
+if ! git rev-parse --verify --quiet "$BASE" >/dev/null; then
+    echo "error: base ref '$BASE' not found." >&2
+    echo "Pass one explicitly: script/mutation/changed-contracts.sh <base-ref>" >&2
+    exit 1
+fi
+
+changed="$(git diff --name-only --diff-filter=ACMR "$BASE...HEAD")"
+contracts="$(printf '%s\n' "$changed" | grep -E '^src/.*\.sol$' || true)"
+
+if [ -z "$contracts" ]; then
+    exit 0
+fi
+
+printf '%s\n' "$contracts" | python3 script/mutation/scope.py filter

--- a/script/mutation/check-scope.sh
+++ b/script/mutation/check-scope.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# Fail when the mutation allowlist in mewt.toml has drifted from the contracts
+# on disk: an active contract with no [[per_target]] mapping would silently lose
+# mutation coverage, and a mapping pointing at a missing file is dead config.
+#
+# Usage:
+#   script/mutation/check-scope.sh
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+exec python3 script/mutation/scope.py check

--- a/script/mutation/scope.py
+++ b/script/mutation/scope.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Mutation scope helper.
+
+mewt.toml is the single source of truth for which contracts are eligible for
+mutation testing: the [[per_target]] globs are the allowlist. This module reads
+that allowlist back out so the shell entry points never restate it.
+
+Subcommands:
+  allowlist  Print the [[per_target]] globs, one per line.
+  active     Print the active contracts discovered under src/, one per line.
+  filter     Read candidate paths on stdin, print the allowlisted ones on stdout
+             and report the rest on stderr.
+  check      Fail when the allowlist has drifted from the contracts on disk.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+CONFIG = Path("mewt.toml")
+
+# Directories excluded from mutation testing. Kept in the same shape as the
+# [targets].ignore substrings in mewt.toml.
+EXCLUDED_PREFIXES = (
+    "src/interfaces/",
+    "src/legacy/",
+    "src/test-contracts/",
+    "src/test/",
+)
+
+
+def _load_config() -> dict:
+    if not CONFIG.is_file():
+        sys.exit(f"{CONFIG} not found; run from the repository root")
+    with CONFIG.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def allowlist() -> list[str]:
+    config = _load_config()
+    globs = [rule["glob"] for rule in config.get("per_target", []) if "glob" in rule]
+    if not globs:
+        sys.exit(f"{CONFIG} declares no [[per_target]] globs; mutation scope is empty")
+    return globs
+
+
+def include() -> list[str]:
+    return _load_config().get("targets", {}).get("include", [])
+
+
+def _glob_token(pattern: str, index: int) -> tuple[str, int]:
+    """Return (regex fragment, next index) for the glob token at pattern[index]."""
+    length = len(pattern)
+
+    if pattern.startswith("**", index):
+        next_index = index + 2
+        if next_index < length and pattern[next_index] == "/":
+            return "(?:.*/)?", next_index + 1
+        return ".*", next_index
+
+    char = pattern[index]
+    if char == "*":
+        return "[^/]*", index + 1
+    if char == "?":
+        return "[^/]", index + 1
+
+    if char == "[":
+        end = pattern.find("]", index)
+        if end != -1:
+            return pattern[index : end + 1], end + 1
+
+    return re.escape(char), index + 1
+
+
+def glob_to_regex(pattern: str) -> re.Pattern[str]:
+    """Translate a glob to a regex using globset's separator rules.
+
+    `*` and `?` never cross `/`, `**/` matches zero or more directories. Brace
+    alternation is rejected rather than silently mistranslated, since a wrong
+    translation here would widen the mutation scope.
+    """
+    if "{" in pattern or "}" in pattern:
+        sys.exit(
+            f"unsupported brace alternation in glob '{pattern}'; "
+            "use one [[per_target]] entry per contract"
+        )
+
+    parts = ["^"]
+    index = 0
+    while index < len(pattern):
+        fragment, index = _glob_token(pattern, index)
+        parts.append(fragment)
+    parts.append("$")
+    return re.compile("".join(parts))
+
+
+def matchers(patterns: list[str]) -> list[tuple[str, re.Pattern[str]]]:
+    return [(pattern, glob_to_regex(pattern)) for pattern in patterns]
+
+
+def is_allowed(path: str, compiled: list[tuple[str, re.Pattern[str]]]) -> bool:
+    return any(regex.match(path) for _, regex in compiled)
+
+
+def active_contracts() -> list[str]:
+    """Every contract under src/ that is eligible for mutation testing."""
+    paths = [path.as_posix() for path in sorted(Path("src").rglob("*.sol"))]
+    return [path for path in paths if not path.startswith(EXCLUDED_PREFIXES)]
+
+
+def cmd_filter() -> int:
+    compiled = matchers(allowlist())
+    candidates = [line.strip() for line in sys.stdin if line.strip()]
+    kept, dropped = [], []
+    for candidate in candidates:
+        (kept if is_allowed(candidate, compiled) else dropped).append(candidate)
+
+    for path in dropped:
+        print(f"out of mutation scope: {path}", file=sys.stderr)
+    for path in kept:
+        print(path)
+    return 0
+
+
+def cmd_check() -> int:
+    patterns = allowlist()
+    compiled = matchers(patterns)
+    contracts = active_contracts()
+    problems = []
+
+    unmapped = [path for path in contracts if not is_allowed(path, compiled)]
+    for path in unmapped:
+        problems.append(
+            f"no [[per_target]] mapping for {path} "
+            "(it would be skipped by mutation testing)"
+        )
+
+    for pattern, regex in compiled:
+        if not any(regex.match(path) for path in contracts):
+            problems.append(
+                f"[[per_target]] glob '{pattern}' matches no active contract "
+                "(stale mapping)"
+            )
+
+    include_patterns = include()
+    if not include_patterns:
+        problems.append("[targets].include is empty; a bare `mewt run` would fail")
+    else:
+        include_compiled = matchers(include_patterns)
+        allow_set = {path for path in contracts if is_allowed(path, compiled)}
+        include_set = {path for path in contracts if is_allowed(path, include_compiled)}
+        for path in sorted(include_set - allow_set):
+            problems.append(f"{path} is in [targets].include but has no [[per_target]] mapping")
+        for path in sorted(allow_set - include_set):
+            problems.append(f"{path} has a [[per_target]] mapping but is missing from [targets].include")
+
+    if problems:
+        print("Mutation scope drift detected:", file=sys.stderr)
+        for problem in problems:
+            print(f"  - {problem}", file=sys.stderr)
+        print(
+            "\nUpdate mewt.toml so [[per_target]] and [targets].include cover "
+            "exactly the active contracts under src/.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"Mutation scope OK: {len(contracts)} contracts mapped.")
+    return 0
+
+
+def main() -> int:
+    command = sys.argv[1] if len(sys.argv) > 1 else ""
+    if command == "allowlist":
+        print("\n".join(allowlist()))
+        return 0
+    if command == "active":
+        print("\n".join(active_contracts()))
+        return 0
+    if command == "filter":
+        return cmd_filter()
+    if command == "check":
+        return cmd_check()
+    sys.exit(f"usage: {Path(sys.argv[0]).name} (allowlist|active|filter|check)")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/script/mutation/scope.py
+++ b/script/mutation/scope.py
@@ -108,7 +108,8 @@ def is_allowed(path: str, compiled: list[tuple[str, re.Pattern[str]]]) -> bool:
 def active_contracts() -> list[str]:
     """Every contract under src/ that is eligible for mutation testing."""
     paths = [path.as_posix() for path in sorted(Path("src").rglob("*.sol"))]
-    return [path for path in paths if not path.startswith(EXCLUDED_PREFIXES)]
+    ignore = tuple(_load_config().get("targets", {}).get("ignore", [])) or EXCLUDED_PREFIXES
+    return [path for path in paths if not any(substr in path for substr in ignore)]
 
 
 def cmd_filter() -> int:


### PR DESCRIPTION
## What
Integrate [mewt](https://github.com/trailofbits/mewt) mutation testing for Solidity contracts.

- Add `mewt.toml` with an explicit allowlist (`[targets].include` + `[[per_target]]` test commands) and no global `[test].cmd`, so unmapped contracts are skipped rather than running the full suite
- Add `script/mutation/` helpers to resolve changed contracts against that allowlist and to detect allowlist drift
- Add an advisory GitHub Action (`.github/workflows/mutation.yml`) that mutates only changed allowlisted contracts on PRs, posts a job summary, and uploads surviving mutants as SARIF annotations
- Add local Makefile targets (`mutate-install`, `mutate-scope`, `mutate-changed`, `mutate-file`, etc.)
- On multi-contract PRs, warn in the summary and restrict the run to high-severity mutations (`ER`) so the job stays within the timeout

## Why
Unit coverage alone does not tell us whether the tests would catch real faults. Mutation testing measures that by introducing small code changes and checking whether the suite fails them. This is specialy important given the recent ai generated contributions.

Running the full suite on every contract is too expensive for CI, so we scope to changed allowlisted contracts and keep the job advisory. Local targets reuse the same config and scripts so developers can reproduce and deepen a campaign outside the PR timeout.

## Task
https://rsklabs.atlassian.net/browse/FLY-2506