### PR TITLE
Feat/fly 2542

### DIFF
--- a/src/FlyoverConfigurations.sol
+++ b/src/FlyoverConfigurations.sol
@@ -13,17 +13,28 @@ import {Flyover} from "./libraries/Flyover.sol";
 /// serve decision, and the settlement path for its amount validation. Admin changes are
 /// time-locked in two steps (queue then apply) and re-validated at both steps against immutable
 /// bounds fixed at deployment, so an admin mistake cannot set absurd values even with the role.
-/// @dev Implements the frozen {IFlyoverConfigurations}. Peg-in is fully wired; peg-out interface
-/// methods stub with {PegOutNotImplemented} until the dedicated config storage lands (keeps this
-/// contract compiling against the frozen ABI). Upgradeable, ERC-7201 namespaced storage, deployed
-/// behind a TransparentUpgradeableProxy per repo pattern.
+/// @dev Implements the frozen {IFlyoverConfigurations}. Peg-out uses a separate ERC-7201 namespace.
+/// Upgradeable, ERC-7201 namespaced storage, deployed behind a TransparentUpgradeableProxy per
+/// repo pattern.
 /// @author Rootstock Labs
 contract FlyoverConfigurations is
     AccessControlDefaultAdminRulesUpgradeable,
     IFlyoverConfigurations
 {
     /// @notice Identifies the scalar field an out-of-bounds revert refers to.
-    enum Field { FixedFee, PercentageFee, MinAmount, MaxAmount }
+    enum Field {
+        FixedFee,
+        PercentageFee,
+        MinAmount,
+        MaxAmount,
+        PenaltyFee,
+        ClaimWindow,
+        ClaimWindowBlocks,
+        CallTime,
+        ExpireTime,
+        ExpireBlocks,
+        MaxMinerFee
+    }
 
     /// @custom:storage-location erc7201:rsk.flyover.FlyoverConfigurations
     struct FlyoverConfigurationsStorage {
@@ -40,6 +51,17 @@ contract FlyoverConfigurations is
         uint256 timelockDelay;
         PegConfiguration min;
         PegConfiguration max;
+    }
+
+    /// @custom:storage-location erc7201:rsk.flyover.FlyoverConfigurations.pegOut
+    /// @dev Separate namespace so peg-out never shifts peg-in storage.
+    struct PegOutConfigurationsStorage {
+        PegOutConfiguration active;
+        PegOutConfiguration pending;
+        uint256 pendingEta;
+        PegOutConfiguration minBound;
+        PegOutConfiguration maxBound;
+        bool initialized;
     }
 
     /// @notice The version of the contract
@@ -62,6 +84,11 @@ contract FlyoverConfigurations is
     bytes32 private constant _FLYOVER_CONFIGURATIONS_BOUNDS =
         0x62f8e0a1022a246e45081dab13f708870be3f38423627ed9d784f6bc5369e500;
 
+    // ERC-7201: keccak256(abi.encode(uint256(keccak256("rsk.flyover.FlyoverConfigurations.pegOut")) - 1)) &
+    // ~bytes32(uint256(0xff))
+    bytes32 private constant _FLYOVER_CONFIGURATIONS_PEGOUT =
+        0x15978da28ad46e9b891b8591ece2c0413e91c9a5c9c768c642316e015001be00;
+
     /// @notice Emitted when a configuration change is queued by the admin.
     /// @param newConfiguration The configuration that will activate once the time lock elapses
     /// @param eta The earliest timestamp `applyChange` may activate the queued configuration
@@ -70,6 +97,9 @@ contract FlyoverConfigurations is
     /// @notice Emitted when a queued configuration change is applied and becomes active.
     /// @param newConfiguration The now-active configuration
     event ChangeApplied(PegConfiguration newConfiguration);
+
+    event PegOutChangeQueued(PegOutConfiguration newConfiguration, uint256 eta);
+    event PegOutChangeApplied(PegOutConfiguration newConfiguration);
 
     /// @notice Raised when a scalar field falls outside its immutable deployment bound.
     error ConfigValueOutOfBounds(Field field, uint256 value, uint256 min, uint256 max);
@@ -85,9 +115,9 @@ contract FlyoverConfigurations is
     error TimelockNotElapsed(uint256 eta, uint256 nowTime);
     /// @notice Raised when applying while no change is queued.
     error NoQueuedChange();
-    /// @notice Peg-out config storage is not wired yet; interface methods stub until then.
-    /// @dev TODO: wire peg-out config storage and implement peg-out configuration methods
-    error PegOutNotImplemented();
+    error PegOutAlreadyInitialized();
+    error PegOutNotInitialized();
+    error InvalidPegOutDeadlines();
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -130,6 +160,27 @@ contract FlyoverConfigurations is
         _getStorage().activePegIn = pegInConfig;
     }
 
+    /// @notice One-time peg-out seed; call after {initialize}.
+    /// @dev TODO: consider folding peg-out seed/bounds into {initialize} on a greenfield deploy.
+    /// Kept separate so the existing peg-in initializer ABI, deploy calldata, and tests stay
+    /// unchanged, and so an already-initialized proxy can seed the peg-out ERC-7201 namespace
+    /// without re-running `initialize`.
+    // solhint-disable-next-line comprehensive-interface
+    function initializePegOut(
+        PegOutConfiguration calldata pegOutConfig,
+        PegOutConfiguration calldata pegOutMin,
+        PegOutConfiguration calldata pegOutMax
+    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        PegOutConfigurationsStorage storage pegOut = _getPegOutStorage();
+        if (pegOut.initialized) revert PegOutAlreadyInitialized();
+
+        pegOut.minBound = pegOutMin;
+        pegOut.maxBound = pegOutMax;
+        _validatePegOutConfig(pegOutConfig);
+        pegOut.active = pegOutConfig;
+        pegOut.initialized = true;
+    }
+
     /// @inheritdoc IFlyoverConfigurations
     function queueChange(PegConfiguration calldata newConfiguration) external override onlyRole(DEFAULT_ADMIN_ROLE) {
         _validateConfig(newConfiguration);
@@ -160,6 +211,41 @@ contract FlyoverConfigurations is
         emit ChangeApplied(pending);
     }
 
+    /// @inheritdoc IFlyoverConfigurations
+    function queuePegOutChange(PegOutConfiguration calldata newConfiguration)
+        external
+        override
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
+        _requirePegOutInitialized();
+        _validatePegOutConfig(newConfiguration);
+        PegOutConfigurationsStorage storage pegOut = _getPegOutStorage();
+        uint256 eta = block.timestamp + _getBounds().timelockDelay;
+        pegOut.pending = newConfiguration;
+        pegOut.pendingEta = eta;
+        emit PegOutChangeQueued(newConfiguration, eta);
+    }
+
+    /// @inheritdoc IFlyoverConfigurations
+    function applyPegOutChange() external override onlyRole(DEFAULT_ADMIN_ROLE) {
+        _requirePegOutInitialized();
+        PegOutConfigurationsStorage storage pegOut = _getPegOutStorage();
+        uint256 eta = pegOut.pendingEta;
+        if (eta == 0) revert NoQueuedChange();
+        if (block.timestamp < eta) revert TimelockNotElapsed(eta, block.timestamp);
+
+        PegOutConfiguration memory pending = pegOut.pending;
+        _validatePegOutConfig(pending);
+
+        pegOut.active = pegOut.pending;
+        delete pegOut.pending;
+        pegOut.pendingEta = 0;
+        emit PegOutChangeApplied(pending);
+    }
+
+    // TODO(nit): drop unused named returns on all view getters below (`configuration`, `fee`,
+    // `confirmations`, `min`/`max`, `pending`/`eta`) — peg-in and peg-out. Names mirror NatSpec
+    // but are unused when the body uses an explicit `return`.
     /// @inheritdoc IFlyoverConfigurations
     function getPegInConfiguration() external view override returns (PegConfiguration memory configuration) {
         return _getStorage().activePegIn;
@@ -209,38 +295,49 @@ contract FlyoverConfigurations is
     }
 
     /// @inheritdoc IFlyoverConfigurations
-    function getPegOutConfiguration()
+    function getPegOutConfiguration() external view override returns (PegOutConfiguration memory configuration) {
+        _requirePegOutInitialized();
+        return _getPegOutStorage().active;
+    }
+
+    /// @inheritdoc IFlyoverConfigurations
+    function calculatePegOutFee(uint256 amount) external view override returns (uint256 fee) {
+        _requirePegOutInitialized();
+        return _calculatePegOutFee(_getPegOutStorage().active, amount);
+    }
+
+    /// @inheritdoc IFlyoverConfigurations
+    function getRequiredPegOutBtcConfirmations(uint256 amount)
         external
         view
         override
-        returns (PegOutConfiguration memory)
+        returns (uint256 confirmations)
     {
-        revert PegOutNotImplemented();
+        _requirePegOutInitialized();
+        return _requiredPegOutConfirmations(_getPegOutStorage().active, amount);
     }
 
-    /// @inheritdoc IFlyoverConfigurations
-    function calculatePegOutFee(uint256) external view override returns (uint256) {
-        revert PegOutNotImplemented();
-    }
-
-    /// @inheritdoc IFlyoverConfigurations
-    function getRequiredPegOutBtcConfirmations(uint256)
+    /// @notice Immutable peg-out deployment bounds.
+    // solhint-disable-next-line comprehensive-interface
+    function getPegOutConfigurationBounds()
         external
         view
-        override
-        returns (uint256)
+        returns (PegOutConfiguration memory min, PegOutConfiguration memory max)
     {
-        revert PegOutNotImplemented();
+        _requirePegOutInitialized();
+        PegOutConfigurationsStorage storage pegOut = _getPegOutStorage();
+        return (pegOut.minBound, pegOut.maxBound);
     }
 
-    /// @inheritdoc IFlyoverConfigurations
-    function queuePegOutChange(PegOutConfiguration calldata) external override {
-        revert PegOutNotImplemented();
-    }
-
-    /// @inheritdoc IFlyoverConfigurations
-    function applyPegOutChange() external override {
-        revert PegOutNotImplemented();
+    /// @notice Queued peg-out change and eta (`0` if none).
+    // solhint-disable-next-line comprehensive-interface
+    function getPendingPegOutChange()
+        external
+        view
+        returns (PegOutConfiguration memory pending, uint256 eta)
+    {
+        PegOutConfigurationsStorage storage pegOut = _getPegOutStorage();
+        return (pegOut.pending, pegOut.pendingEta);
     }
 
     /// @dev fee = fixedFee + amount * percentageFee / 10_000, then rounded DOWN to a satoshi
@@ -253,10 +350,37 @@ contract FlyoverConfigurations is
         return fee;
     }
 
+    function _calculatePegOutFee(PegOutConfiguration storage config, uint256 amount)
+        private
+        view
+        returns (uint256)
+    {
+        uint256 fee = config.fixedFee + (amount * config.percentageFee) / FEE_PERCENTAGE_DENOMINATOR;
+        if (fee > SAT_TO_WEI_CONVERSION && (fee % SAT_TO_WEI_CONVERSION) != 0) {
+            fee -= (fee % SAT_TO_WEI_CONVERSION);
+        }
+        return fee;
+    }
+
     /// @dev Returns the confirmations of the first tier whose maxAmount covers the amount. If the
     /// amount exceeds every tier, returns the highest (last) tier's confirmations, the most
     /// conservative answer. Tiers are kept strictly ascending, so the first match is the tightest.
     function _requiredConfirmations(PegConfiguration storage config, uint256 amount)
+        private
+        view
+        returns (uint256)
+    {
+        ConfirmationTier[] storage tiers = config.confirmationTiers;
+        uint256 length = tiers.length;
+        for (uint256 i = 0; i < length; ++i) {
+            if (amount <= tiers[i].maxAmount) {
+                return tiers[i].confirmations;
+            }
+        }
+        return tiers[length - 1].confirmations;
+    }
+
+    function _requiredPegOutConfirmations(PegOutConfiguration storage config, uint256 amount)
         private
         view
         returns (uint256)
@@ -313,6 +437,41 @@ contract FlyoverConfigurations is
         }
     }
 
+    function _validatePegOutConfig(PegOutConfiguration memory config) private view {
+        PegOutConfigurationsStorage storage pegOut = _getPegOutStorage();
+        PegOutConfiguration storage minB = pegOut.minBound;
+        PegOutConfiguration storage maxB = pegOut.maxBound;
+
+        _checkBound(Field.FixedFee, config.fixedFee, minB.fixedFee, maxB.fixedFee);
+        _checkBound(Field.PercentageFee, config.percentageFee, minB.percentageFee, maxB.percentageFee);
+        _checkBound(Field.MinAmount, config.minAmount, minB.minAmount, maxB.minAmount);
+        _checkBound(Field.MaxAmount, config.maxAmount, minB.maxAmount, maxB.maxAmount);
+        _checkBound(Field.PenaltyFee, config.penaltyFee, minB.penaltyFee, maxB.penaltyFee);
+        _checkBound(Field.ClaimWindow, config.claimWindow, minB.claimWindow, maxB.claimWindow);
+        _checkBound(
+            Field.ClaimWindowBlocks, config.claimWindowBlocks, minB.claimWindowBlocks, maxB.claimWindowBlocks
+        );
+        _checkBound(Field.CallTime, config.callTime, minB.callTime, maxB.callTime);
+        _checkBound(Field.ExpireTime, config.expireTime, minB.expireTime, maxB.expireTime);
+        _checkBound(Field.ExpireBlocks, config.expireBlocks, minB.expireBlocks, maxB.expireBlocks);
+        _checkBound(Field.MaxMinerFee, config.maxMinerFee, minB.maxMinerFee, maxB.maxMinerFee);
+
+        if (config.percentageFee > FEE_PERCENTAGE_DENOMINATOR) {
+            revert InvalidPercentageFee(config.percentageFee);
+        }
+        if (config.minAmount > config.maxAmount) {
+            revert InvalidAmountLimits(config.minAmount, config.maxAmount);
+        }
+        if (config.claimWindow == 0 || config.callTime == 0 || config.expireTime == 0) {
+            revert InvalidPegOutDeadlines();
+        }
+        _validateTiers(config.confirmationTiers);
+    }
+
+    function _requirePegOutInitialized() private view {
+        if (!_getPegOutStorage().initialized) revert PegOutNotInitialized();
+    }
+
     function _getStorage() private pure returns (FlyoverConfigurationsStorage storage $) {
         assembly {
             $.slot := _FLYOVER_CONFIGURATIONS_STORAGE
@@ -322,6 +481,12 @@ contract FlyoverConfigurations is
     function _getBounds() private pure returns (FlyoverConfigurationsBounds storage $) {
         assembly {
             $.slot := _FLYOVER_CONFIGURATIONS_BOUNDS
+        }
+    }
+
+    function _getPegOutStorage() private pure returns (PegOutConfigurationsStorage storage $) {
+        assembly {
+            $.slot := _FLYOVER_CONFIGURATIONS_PEGOUT
         }
     }
 }

--- a/src/libraries/FlyoverConfigurationsRegtest.sol
+++ b/src/libraries/FlyoverConfigurationsRegtest.sol
@@ -53,6 +53,64 @@ library FlyoverConfigurationsRegtest {
         bound.confirmationTiers = new IFlyoverConfigurations.ConfirmationTier[](0);
     }
 
+    function pegOutConfig()
+        internal
+        pure
+        returns (IFlyoverConfigurations.PegOutConfiguration memory config)
+    {
+        config.fixedFee = 0.0001 ether; // security floor (claim + proof gas)
+        config.percentageFee = 10;
+        config.minAmount = 0.005 ether;
+        config.maxAmount = 10 ether;
+        config.confirmationTiers = _tiers();
+        config.penaltyFee = 0.01 ether;
+        config.claimWindow = 30 minutes;
+        config.claimWindowBlocks = 600;
+        config.callTime = 2 hours;
+        config.expireTime = 4 hours;
+        // Keep claimWindowBlocks + expireBlocks ≤ PegOutContract's +4000 expireBlock cap.
+        config.expireBlocks = 3_300;
+        config.maxMinerFee = 0.0005 ether; // short-delivery floor cap
+    }
+
+    function pegOutMin()
+        internal
+        pure
+        returns (IFlyoverConfigurations.PegOutConfiguration memory bound)
+    {
+        bound.fixedFee = 0.0001 ether;
+        bound.percentageFee = 0;
+        bound.minAmount = 0.001 ether;
+        bound.maxAmount = 0.01 ether;
+        bound.confirmationTiers = new IFlyoverConfigurations.ConfirmationTier[](0);
+        bound.penaltyFee = 0.001 ether;
+        bound.claimWindow = 5 minutes;
+        bound.claimWindowBlocks = 1;
+        bound.callTime = 30 minutes;
+        bound.expireTime = 1 hours;
+        bound.expireBlocks = 1;
+        bound.maxMinerFee = 0;
+    }
+
+    function pegOutMax()
+        internal
+        pure
+        returns (IFlyoverConfigurations.PegOutConfiguration memory bound)
+    {
+        bound.fixedFee = 0.01 ether;
+        bound.percentageFee = 1_000;
+        bound.minAmount = 1 ether;
+        bound.maxAmount = 1_000 ether;
+        bound.confirmationTiers = new IFlyoverConfigurations.ConfirmationTier[](0);
+        bound.penaltyFee = 1 ether;
+        bound.claimWindow = 1 days;
+        bound.claimWindowBlocks = 50_000;
+        bound.callTime = 2 days;
+        bound.expireTime = 7 days;
+        bound.expireBlocks = 200_000;
+        bound.maxMinerFee = 0.1 ether;
+    }
+
     /// @dev Provisional confirmation tiers, strictly ascending by maxAmount. Larger deposits
     /// demand more BTC confirmations before an LP may claim; the last tier's confirmations answer
     /// any amount above the top bound.

--- a/test/configurations/ConfigurationsTestBase.sol
+++ b/test/configurations/ConfigurationsTestBase.sol
@@ -41,9 +41,37 @@ abstract contract ConfigurationsTestBase is Test {
     uint256 internal constant BOUND_MIN_MAX_AMOUNT = 0;
     uint256 internal constant BOUND_MAX_MAX_AMOUNT = 10_000 ether;
 
+    // --- peg-out seed / bounds ---
+    uint256 internal constant SEED_PENALTY_FEE = 0.01 ether;
+    uint256 internal constant SEED_CLAIM_WINDOW = 30 minutes;
+    uint256 internal constant SEED_CLAIM_WINDOW_BLOCKS = 600;
+    uint256 internal constant SEED_CALL_TIME = 2 hours;
+    uint256 internal constant SEED_EXPIRE_TIME = 4 hours;
+    uint256 internal constant SEED_EXPIRE_BLOCKS = 3_300;
+    uint256 internal constant SEED_MAX_MINER_FEE = 0.0005 ether;
+
+    uint256 internal constant BOUND_MIN_PENALTY_FEE = 0.001 ether;
+    uint256 internal constant BOUND_MAX_PENALTY_FEE = 1 ether;
+    uint256 internal constant BOUND_MIN_CLAIM_WINDOW = 5 minutes;
+    uint256 internal constant BOUND_MAX_CLAIM_WINDOW = 1 days;
+    uint256 internal constant BOUND_MIN_CLAIM_WINDOW_BLOCKS = 1;
+    uint256 internal constant BOUND_MAX_CLAIM_WINDOW_BLOCKS = 50_000;
+    uint256 internal constant BOUND_MIN_CALL_TIME = 30 minutes;
+    uint256 internal constant BOUND_MAX_CALL_TIME = 2 days;
+    uint256 internal constant BOUND_MIN_EXPIRE_TIME = 1 hours;
+    uint256 internal constant BOUND_MAX_EXPIRE_TIME = 7 days;
+    uint256 internal constant BOUND_MIN_EXPIRE_BLOCKS = 1;
+    uint256 internal constant BOUND_MAX_EXPIRE_BLOCKS = 200_000;
+    uint256 internal constant BOUND_MIN_MAX_MINER_FEE = 0;
+    uint256 internal constant BOUND_MAX_MAX_MINER_FEE = 0.1 ether;
+
     // ERC-7201 base slot of the mutable namespace `rsk.flyover.FlyoverConfigurations`.
     bytes32 internal constant STORAGE_SLOT =
         0x13aa2a37a5354fe7c5dcced2a6c33933ec66091f98f22792660cd2862f158700;
+
+    // ERC-7201 base slot of `rsk.flyover.FlyoverConfigurations.pegOut`.
+    bytes32 internal constant PEGOUT_STORAGE_SLOT =
+        0x15978da28ad46e9b891b8591ece2c0413e91c9a5c9c768c642316e015001be00;
 
     address internal owner = makeAddr("owner");
     address internal stranger = makeAddr("stranger");
@@ -65,6 +93,20 @@ abstract contract ConfigurationsTestBase is Test {
         );
         ERC1967Proxy proxy = new ERC1967Proxy(address(impl), initData);
         config = FlyoverConfigurations(payable(address(proxy)));
+    }
+
+    function _deployWithPegOut() internal {
+        _deploy();
+        _initPegOut();
+    }
+
+    function _initPegOut() internal {
+        vm.prank(owner);
+        config.initializePegOut(
+            _seedPegOutConfig(),
+            _pegOutBoundsMin(),
+            _pegOutBoundsMax()
+        );
     }
 
     /// @notice The seed peg-in configuration written at initialize time.
@@ -156,5 +198,98 @@ abstract contract ConfigurationsTestBase is Test {
         c = _altConfig();
         vm.prank(owner);
         config.queueChange(c);
+    }
+
+    function _seedPegOutConfig()
+        internal
+        pure
+        returns (IFlyoverConfigurations.PegOutConfiguration memory c)
+    {
+        c.fixedFee = SEED_FIXED_FEE;
+        c.percentageFee = SEED_PCT;
+        c.minAmount = SEED_MIN_AMOUNT;
+        c.maxAmount = SEED_MAX_AMOUNT;
+        c.confirmationTiers = _seedTiers();
+        c.penaltyFee = SEED_PENALTY_FEE;
+        c.claimWindow = SEED_CLAIM_WINDOW;
+        c.claimWindowBlocks = SEED_CLAIM_WINDOW_BLOCKS;
+        c.callTime = SEED_CALL_TIME;
+        c.expireTime = SEED_EXPIRE_TIME;
+        c.expireBlocks = SEED_EXPIRE_BLOCKS;
+        c.maxMinerFee = SEED_MAX_MINER_FEE;
+    }
+
+    function _pegOutBoundsMin()
+        internal
+        pure
+        returns (IFlyoverConfigurations.PegOutConfiguration memory c)
+    {
+        c.fixedFee = BOUND_MIN_FIXED_FEE;
+        c.percentageFee = BOUND_MIN_PCT;
+        c.minAmount = BOUND_MIN_MIN_AMOUNT;
+        c.maxAmount = BOUND_MIN_MAX_AMOUNT;
+        c.confirmationTiers = new IFlyoverConfigurations.ConfirmationTier[](0);
+        c.penaltyFee = BOUND_MIN_PENALTY_FEE;
+        c.claimWindow = BOUND_MIN_CLAIM_WINDOW;
+        c.claimWindowBlocks = BOUND_MIN_CLAIM_WINDOW_BLOCKS;
+        c.callTime = BOUND_MIN_CALL_TIME;
+        c.expireTime = BOUND_MIN_EXPIRE_TIME;
+        c.expireBlocks = BOUND_MIN_EXPIRE_BLOCKS;
+        c.maxMinerFee = BOUND_MIN_MAX_MINER_FEE;
+    }
+
+    function _pegOutBoundsMax()
+        internal
+        pure
+        returns (IFlyoverConfigurations.PegOutConfiguration memory c)
+    {
+        c.fixedFee = BOUND_MAX_FIXED_FEE;
+        c.percentageFee = BOUND_MAX_PCT;
+        c.minAmount = BOUND_MAX_MIN_AMOUNT;
+        c.maxAmount = BOUND_MAX_MAX_AMOUNT;
+        c.confirmationTiers = new IFlyoverConfigurations.ConfirmationTier[](0);
+        c.penaltyFee = BOUND_MAX_PENALTY_FEE;
+        c.claimWindow = BOUND_MAX_CLAIM_WINDOW;
+        c.claimWindowBlocks = BOUND_MAX_CLAIM_WINDOW_BLOCKS;
+        c.callTime = BOUND_MAX_CALL_TIME;
+        c.expireTime = BOUND_MAX_EXPIRE_TIME;
+        c.expireBlocks = BOUND_MAX_EXPIRE_BLOCKS;
+        c.maxMinerFee = BOUND_MAX_MAX_MINER_FEE;
+    }
+
+    function _altPegOutConfig()
+        internal
+        pure
+        returns (IFlyoverConfigurations.PegOutConfiguration memory c)
+    {
+        c.fixedFee = 2000 * SAT;
+        c.percentageFee = 20;
+        c.minAmount = 0.002 ether;
+        c.maxAmount = 200 ether;
+        c.confirmationTiers = new IFlyoverConfigurations.ConfirmationTier[](2);
+        c.confirmationTiers[0] = IFlyoverConfigurations.ConfirmationTier({
+            maxAmount: 2 ether,
+            confirmations: 2
+        });
+        c.confirmationTiers[1] = IFlyoverConfigurations.ConfirmationTier({
+            maxAmount: 20 ether,
+            confirmations: 5
+        });
+        c.penaltyFee = 0.02 ether;
+        c.claimWindow = 45 minutes;
+        c.claimWindowBlocks = 900;
+        c.callTime = 3 hours;
+        c.expireTime = 5 hours;
+        c.expireBlocks = 4_000;
+        c.maxMinerFee = 0.001 ether;
+    }
+
+    function _queueAltPegOut()
+        internal
+        returns (IFlyoverConfigurations.PegOutConfiguration memory c)
+    {
+        c = _altPegOutConfig();
+        vm.prank(owner);
+        config.queuePegOutChange(c);
     }
 }

--- a/test/configurations/PegOut.t.sol
+++ b/test/configurations/PegOut.t.sol
@@ -24,7 +24,10 @@ contract PegOutConfigurationsTest is ConfigurationsTestBase {
         return fee;
     }
 
-    function test_calculatePegOutFee_fixedFloorAndSatoshiRounding() public view {
+    function test_calculatePegOutFee_fixedFloorAndSatoshiRounding()
+        public
+        view
+    {
         assertEq(config.calculatePegOutFee(0), SEED_FIXED_FEE);
 
         uint256 amount = 123_456_789_012_345;
@@ -47,7 +50,8 @@ contract PegOutConfigurationsTest is ConfigurationsTestBase {
     }
 
     function test_queueThenApplyPegOut_updatesActiveAndEmits() public {
-        IFlyoverConfigurations.PegOutConfiguration memory c = _altPegOutConfig();
+        IFlyoverConfigurations.PegOutConfiguration
+            memory c = _altPegOutConfig();
         uint256 expectedEta = block.timestamp + TIMELOCK_DELAY;
 
         vm.expectEmit(true, true, true, true, address(config));
@@ -63,7 +67,8 @@ contract PegOutConfigurationsTest is ConfigurationsTestBase {
         vm.prank(owner);
         config.applyPegOutChange();
 
-        IFlyoverConfigurations.PegOutConfiguration memory active = config.getPegOutConfiguration();
+        IFlyoverConfigurations.PegOutConfiguration memory active = config
+            .getPegOutConfiguration();
         assertEq(active.fixedFee, c.fixedFee);
         assertEq(active.claimWindow, c.claimWindow);
         assertEq(active.callTime, c.callTime);
@@ -81,7 +86,9 @@ contract PegOutConfigurationsTest is ConfigurationsTestBase {
         vm.prank(owner);
         vm.expectRevert(
             abi.encodeWithSelector(
-                FlyoverConfigurations.TimelockNotElapsed.selector, eta, eta - 1
+                FlyoverConfigurations.TimelockNotElapsed.selector,
+                eta,
+                eta - 1
             )
         );
         config.applyPegOutChange();
@@ -92,15 +99,18 @@ contract PegOutConfigurationsTest is ConfigurationsTestBase {
     /// and maxMinerFee (escrow should persist that snapshot at request time).
     function test_configChange_leavesPriorSnapshotUntouched() public {
         uint256 amount = 1 ether;
-        IFlyoverConfigurations.PegOutConfiguration memory snapshot = config.getPegOutConfiguration();
+        IFlyoverConfigurations.PegOutConfiguration memory snapshot = config
+            .getPegOutConfiguration();
         uint256 snapshottedFee = config.calculatePegOutFee(amount);
 
-        IFlyoverConfigurations.PegOutConfiguration memory next = _queueAltPegOut();
+        IFlyoverConfigurations.PegOutConfiguration
+            memory next = _queueAltPegOut();
         vm.warp(block.timestamp + TIMELOCK_DELAY);
         vm.prank(owner);
         config.applyPegOutChange();
 
-        IFlyoverConfigurations.PegOutConfiguration memory live = config.getPegOutConfiguration();
+        IFlyoverConfigurations.PegOutConfiguration memory live = config
+            .getPegOutConfiguration();
         assertEq(live.fixedFee, next.fixedFee);
         assertEq(live.claimWindow, next.claimWindow);
         assertEq(live.callTime, next.callTime);
@@ -116,7 +126,10 @@ contract PegOutConfigurationsTest is ConfigurationsTestBase {
         assertEq(snapshot.callTime, SEED_CALL_TIME);
         assertEq(snapshot.expireTime, SEED_EXPIRE_TIME);
         assertEq(snapshot.maxMinerFee, SEED_MAX_MINER_FEE);
-        assertEq(snapshottedFee, _expectedFee(SEED_FIXED_FEE, SEED_PCT, amount));
+        assertEq(
+            snapshottedFee,
+            _expectedFee(SEED_FIXED_FEE, SEED_PCT, amount)
+        );
         assertTrue(snapshot.fixedFee != live.fixedFee);
         assertTrue(snapshottedFee != config.calculatePegOutFee(amount));
     }

--- a/test/configurations/PegOut.t.sol
+++ b/test/configurations/PegOut.t.sol
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {ConfigurationsTestBase} from "./ConfigurationsTestBase.sol";
+import {FlyoverConfigurations} from "../../src/FlyoverConfigurations.sol";
+import {IFlyoverConfigurations} from "../../src/interfaces/IFlyoverConfigurations.sol";
+
+/// @title PegOutConfigurationsTest
+/// @notice AC coverage for peg-out FlyoverConfigurations: fee, tiers, queue/apply, snapshot.
+contract PegOutConfigurationsTest is ConfigurationsTestBase {
+    function setUp() public {
+        _deployWithPegOut();
+    }
+
+    function _expectedFee(
+        uint256 fixedFee,
+        uint256 pct,
+        uint256 amount
+    ) private pure returns (uint256) {
+        uint256 fee = fixedFee + (amount * pct) / PCT_DENOMINATOR;
+        if (fee > SAT && (fee % SAT) != 0) {
+            fee -= (fee % SAT);
+        }
+        return fee;
+    }
+
+    function test_calculatePegOutFee_fixedFloorAndSatoshiRounding() public view {
+        assertEq(config.calculatePegOutFee(0), SEED_FIXED_FEE);
+
+        uint256 amount = 123_456_789_012_345;
+        uint256 rawFee = SEED_FIXED_FEE + (amount * SEED_PCT) / PCT_DENOMINATOR;
+        assertTrue(rawFee % SAT != 0, "test setup: sub-satoshi remainder");
+
+        uint256 got = config.calculatePegOutFee(amount);
+        assertEq(got, rawFee - (rawFee % SAT));
+        assertEq(got % SAT, 0);
+        assertEq(got, _expectedFee(SEED_FIXED_FEE, SEED_PCT, amount));
+    }
+
+    function test_getRequiredPegOutBtcConfirmations_tiers() public view {
+        assertEq(config.getRequiredPegOutBtcConfirmations(0.5 ether), 1);
+        assertEq(config.getRequiredPegOutBtcConfirmations(1 ether), 1);
+        assertEq(config.getRequiredPegOutBtcConfirmations(5 ether), 3);
+        assertEq(config.getRequiredPegOutBtcConfirmations(10 ether), 3);
+        assertEq(config.getRequiredPegOutBtcConfirmations(50 ether), 6);
+        assertEq(config.getRequiredPegOutBtcConfirmations(1000 ether), 6);
+    }
+
+    function test_queueThenApplyPegOut_updatesActiveAndEmits() public {
+        IFlyoverConfigurations.PegOutConfiguration memory c = _altPegOutConfig();
+        uint256 expectedEta = block.timestamp + TIMELOCK_DELAY;
+
+        vm.expectEmit(true, true, true, true, address(config));
+        emit FlyoverConfigurations.PegOutChangeQueued(c, expectedEta);
+        vm.prank(owner);
+        config.queuePegOutChange(c);
+
+        assertEq(config.getPegOutConfiguration().fixedFee, SEED_FIXED_FEE);
+
+        vm.warp(expectedEta);
+        vm.expectEmit(true, true, true, true, address(config));
+        emit FlyoverConfigurations.PegOutChangeApplied(c);
+        vm.prank(owner);
+        config.applyPegOutChange();
+
+        IFlyoverConfigurations.PegOutConfiguration memory active = config.getPegOutConfiguration();
+        assertEq(active.fixedFee, c.fixedFee);
+        assertEq(active.claimWindow, c.claimWindow);
+        assertEq(active.callTime, c.callTime);
+        assertEq(active.expireTime, c.expireTime);
+        assertEq(active.maxMinerFee, c.maxMinerFee);
+        assertEq(config.calculatePegOutFee(0), c.fixedFee);
+        assertEq(config.getRequiredPegOutBtcConfirmations(1 ether), 2);
+    }
+
+    function test_applyPegOut_beforeDelay_reverts() public {
+        _queueAltPegOut();
+        (, uint256 eta) = config.getPendingPegOutChange();
+
+        vm.warp(eta - 1);
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FlyoverConfigurations.TimelockNotElapsed.selector, eta, eta - 1
+            )
+        );
+        config.applyPegOutChange();
+        assertEq(config.getPegOutConfiguration().fixedFee, SEED_FIXED_FEE);
+    }
+
+    /// @notice A later queue/apply must not change a prior in-memory snapshot of fee, deadlines,
+    /// and maxMinerFee (escrow should persist that snapshot at request time).
+    function test_configChange_leavesPriorSnapshotUntouched() public {
+        uint256 amount = 1 ether;
+        IFlyoverConfigurations.PegOutConfiguration memory snapshot = config.getPegOutConfiguration();
+        uint256 snapshottedFee = config.calculatePegOutFee(amount);
+
+        IFlyoverConfigurations.PegOutConfiguration memory next = _queueAltPegOut();
+        vm.warp(block.timestamp + TIMELOCK_DELAY);
+        vm.prank(owner);
+        config.applyPegOutChange();
+
+        IFlyoverConfigurations.PegOutConfiguration memory live = config.getPegOutConfiguration();
+        assertEq(live.fixedFee, next.fixedFee);
+        assertEq(live.claimWindow, next.claimWindow);
+        assertEq(live.callTime, next.callTime);
+        assertEq(live.maxMinerFee, next.maxMinerFee);
+        assertEq(
+            config.calculatePegOutFee(amount),
+            _expectedFee(next.fixedFee, next.percentageFee, amount)
+        );
+
+        assertEq(snapshot.fixedFee, SEED_FIXED_FEE);
+        assertEq(snapshot.percentageFee, SEED_PCT);
+        assertEq(snapshot.claimWindow, SEED_CLAIM_WINDOW);
+        assertEq(snapshot.callTime, SEED_CALL_TIME);
+        assertEq(snapshot.expireTime, SEED_EXPIRE_TIME);
+        assertEq(snapshot.maxMinerFee, SEED_MAX_MINER_FEE);
+        assertEq(snapshottedFee, _expectedFee(SEED_FIXED_FEE, SEED_PCT, amount));
+        assertTrue(snapshot.fixedFee != live.fixedFee);
+        assertTrue(snapshottedFee != config.calculatePegOutFee(amount));
+    }
+}

--- a/test/pegin/FlyoverConfigurationsMock.sol
+++ b/test/pegin/FlyoverConfigurationsMock.sol
@@ -14,10 +14,8 @@ contract FlyoverConfigurationsMock is IFlyoverConfigurations {
 
     PegConfiguration private _config;
     PegConfiguration private _queued;
-
-    /// @notice Peg-out stubs only; real mock wiring lands with peg-out config tests.
-    /// @dev TODO: wire peg-out config storage and implement peg-out configuration methods
-    error PegOutNotImplemented();
+    PegOutConfiguration private _pegOutConfig;
+    PegOutConfiguration private _pegOutQueued;
 
     /// @notice Sets the fixed and percentage fee components directly
     function setFee(uint256 fixedFee, uint256 percentageFee) external {
@@ -85,38 +83,58 @@ contract FlyoverConfigurationsMock is IFlyoverConfigurations {
         _config = _queued;
     }
 
+    function setPegOutConfiguration(
+        PegOutConfiguration calldata configuration
+    ) external {
+        _pegOutConfig = configuration;
+    }
+
     /// @inheritdoc IFlyoverConfigurations
     function getPegOutConfiguration()
         external
         view
         override
-        returns (PegOutConfiguration memory)
+        returns (PegOutConfiguration memory configuration)
     {
-        revert PegOutNotImplemented();
+        return _pegOutConfig;
     }
 
     /// @inheritdoc IFlyoverConfigurations
     function calculatePegOutFee(
-        uint256
-    ) external view override returns (uint256) {
-        revert PegOutNotImplemented();
+        uint256 amount
+    ) external view override returns (uint256 fee) {
+        return
+            _pegOutConfig.fixedFee +
+            (amount * _pegOutConfig.percentageFee) /
+            _BASIS_POINTS;
     }
 
     /// @inheritdoc IFlyoverConfigurations
     function getRequiredPegOutBtcConfirmations(
-        uint256
-    ) external view override returns (uint256) {
-        revert PegOutNotImplemented();
+        uint256 amount
+    ) external view override returns (uint256 confirmations) {
+        uint256 tierCount = _pegOutConfig.confirmationTiers.length;
+        for (uint256 i = 0; i < tierCount; i++) {
+            if (amount <= _pegOutConfig.confirmationTiers[i].maxAmount) {
+                return _pegOutConfig.confirmationTiers[i].confirmations;
+            }
+        }
+        if (tierCount > 0) {
+            return _pegOutConfig.confirmationTiers[tierCount - 1].confirmations;
+        }
+        return 0;
     }
 
     /// @inheritdoc IFlyoverConfigurations
-    function queuePegOutChange(PegOutConfiguration calldata) external override {
-        revert PegOutNotImplemented();
+    function queuePegOutChange(
+        PegOutConfiguration calldata newConfiguration
+    ) external override {
+        _pegOutQueued = newConfiguration;
     }
 
     /// @inheritdoc IFlyoverConfigurations
     function applyPegOutChange() external override {
-        revert PegOutNotImplemented();
+        _pegOutConfig = _pegOutQueued;
     }
 }
 /* solhint-enable comprehensive-interface */


### PR DESCRIPTION
## What

Implement the frozen peg-out side of `FlyoverConfigurations`: active config reads, satoshi-floored `calculatePegOutFee`, confirmation-tier lookup, and time-locked `queuePegOutChange` / `applyPegOutChange`, with peg-out storage in a separate ERC-7201 namespace and one-shot `initializePegOut`. Wire provisional regtest seeds and update the test mock. No interface changes.

## Why

Peg-out protocol parameters need the same on-chain, time-locked source as peg-in so SDK/LPS/escrow all read one set of numbers. This PR replaces the `PegOutNotImplemented` stubs left by FLY-2541 without touching the frozen ABI.

## Type of Change

- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Refactor (no intended behavior change)
- [ ] Security hardening
- [ ] Tests only
- [ ] Build/CI/Tooling
- [ ] Documentation

## Affected Areas

- [ ] PegIn flow (`registerPegIn`, `callForUser`, quote validation)
- [x] PegOut flow (`depositPegout`, `refundPegOut`, `refundUserPegOut`)
- [ ] Liquidity Provider lifecycle (register/update/status/resign/collateral/withdraw)
- [ ] Pause/operational controls
- [ ] Quote hashing/signature logic
- [ ] Bitcoin tx / PMT / merkle validation
- [ ] Deployment or upgrade scripts / Makefile targets
- [ ] CI workflows (`ci`, `fuzz`, `formal`, `slither`, `codeql`)
- [ ] Docs

## Risk & Security Review

- [x] Access control and authorization paths reviewed
- [ ] Reentrancy and external call paths reviewed
- [x] Storage layout / upgrade safety reviewed (if upgradeable code changed)
- [x] Time/block/confirmation assumptions reviewed
- [ ] BTC tx output/index assumptions reviewed (if pegout validation touched)
- [x] No secrets or sensitive values added

## Test Plan

List what you ran locally and the outcome:

- [ ] `npm run lint:sol`
- [ ] `npm run lint:ts`
- [ ] `npm run compile`
- [ ] `npm test`
- [ ] `npm run test:fuzz` (if logic/state transitions changed)
- [ ] `npm run test:invariant` (if invariant-sensitive logic changed)
- [ ] `npm run test:formal` (if formal-verification-sensitive logic changed)
- [ ] `npm run test:integration` (if integration paths changed)
- [ ] `npm run test:e2e` (if deployment/ownership flows changed)

Additional notes on test coverage, edge cases, and any tests intentionally skipped:

No new unit tests in this PR. Relies on existing configurations/pegin suites staying green and CI. Escrow snapshot economics will be covered when PegOutEscrow lands.

## Deployment & Ops Impact

- [ ] No deployment impact
- [x] Requires deployment
- [x] Requires upgrade
- [ ] Env/config changes required (`.env`, network RPCs, verification, etc.)
- [ ] Runbook/update instructions added to PR description

After peg-in `initialize`, admin must call `initializePegOut(config, min, max)` once to seed peg-out storage. Shared timelock delay is unchanged.

## Related Issues

- Jira: [FLY-2542](https://rsklabs.atlassian.net/browse/FLY-2542)
- Depends on: feat/FLY-2541 (frozen peg-out ABI + stubs)
- GitHub Issue: #(if applicable)

## Reviewer Notes

- Base this PR on `feat/FLY-2541` so interface edits stay out of this PR. To be merged with v3.0.0 once approved and after this [PR](https://github.com/rsksmart/liquidity-bridge-contract/pull/523) has been merged
- Peg-out lives under ERC-7201 `rsk.flyover.FlyoverConfigurations.pegOut` so peg-in slots are untouched.
- `initializePegOut` is intentionally separate from `initialize` (see TODO on that function).
- PoC fields `gasFee` / `depositConfirmations` are intentionally omitted (frozen 12-field struct).

## Screenshots / Logs (if applicable)

N/A