### PR TITLE
Feat/fly 2543

### DIFF
--- a/src/PegOutEscrow.sol
+++ b/src/PegOutEscrow.sol
@@ -14,12 +14,6 @@ import {IPegOutEscrow} from "./interfaces/IPegOutEscrow.sol";
 import {Flyover} from "./libraries/Flyover.sol";
 import {Quotes} from "./libraries/Quotes.sol";
 
-/// @dev Narrow read of PegOutContract's public dust threshold (avoid concrete import).
-/// TODO: drop this if dustThreshold is added to {IPegOut} (or another shared interface).
-interface IDustThreshold {
-    function dustThreshold() external view returns (uint256);
-}
-
 /// @title PegOutEscrow
 /// @notice Commit-first peg-out escrow. User deposits RBTC first; LPs claim and settle via
 /// PegOutContract. Fee / deadline parameters come from {IFlyoverConfigurations}.
@@ -326,16 +320,12 @@ contract PegOutEscrow is
             revert Flyover.InsufficientAmount(value, amountPlusCallFee);
         }
         changeRefund = value - amountPlusCallFee;
-        uint256 dust = _dustThreshold(address($.pegOutContract));
+        uint256 dust = $.pegOutContract.dustThreshold();
         // solhint-disable-next-line gas-strict-inequalities
         if (dust > changeRefund) {
             callFee += changeRefund;
             changeRefund = 0;
         }
-    }
-
-    function _dustThreshold(address pegOutContract) private view returns (uint256) {
-        return IDustThreshold(pegOutContract).dustThreshold();
     }
 
     function _requireRequested(PegOutEscrowStorage storage $, bytes32 requestHash) private view {

--- a/src/PegOutEscrow.sol
+++ b/src/PegOutEscrow.sol
@@ -32,12 +32,19 @@ contract PegOutEscrow is
 {
     /// @custom:storage-location erc7201:rsk.flyover.PegOutEscrow
     struct PegOutEscrowStorage {
+        /// Settlement contract (claim forwards funds here; also supplies dustThreshold).
         IPegOut pegOutContract;
+        /// Collateral registry used by claim / no-claim slash (wired now; unused until those paths).
         ICollateralManagement collateralManagement;
+        /// Active peg-out fee, bounds, deadlines, and confirmation tiers.
         IFlyoverConfigurations configurations;
+        /// Quote-shaped terms snapshotted at request (deleted on cancel / terminal states).
         mapping(bytes32 => Quotes.PegOutQuote) quotes;
+        /// Lifecycle per requestHash (`NONE` if never requested).
         mapping(bytes32 => EscrowedPegOutState) state;
-        mapping(uint256 => bytes32) idByNonce;
+        /// requestHash for each 1-based nonce; LPS rebuild after missed events.
+        mapping(uint256 => bytes32) requestHashByNonce;
+        /// How many requests have been minted; next request uses `++requestCount`.
         uint256 requestCount;
     }
 
@@ -132,7 +139,7 @@ contract PegOutEscrow is
         if (address($.configurations) == address(0)) revert FlyoverConfigurationsNotSet();
 
         IFlyoverConfigurations.PegOutConfiguration memory cfg = $.configurations.getPegOutConfiguration();
-        (uint256 amount, uint256 callFee, uint256 change) = _splitValue($, msg.value, cfg);
+        (uint256 amount, uint256 callFee, uint256 changeRefund) = _splitValue($, msg.value, cfg);
         if (amount < cfg.minAmount || amount > cfg.maxAmount) {
             revert NotServiceable(amount, cfg.minAmount, cfg.maxAmount);
         }
@@ -141,7 +148,7 @@ contract PegOutEscrow is
         requestHash = _computeRequestHash(nonce, refundAddress, destinationAddress, amount, callFee);
 
         $.state[requestHash] = EscrowedPegOutState.REQUESTED;
-        $.idByNonce[nonce] = requestHash;
+        $.requestHashByNonce[nonce] = requestHash;
 
         uint256 confirmations = $.configurations.getRequiredPegOutBtcConfirmations(amount);
         $.quotes[requestHash] =
@@ -149,9 +156,9 @@ contract PegOutEscrow is
 
         emit PegOutRequested(requestHash, refundAddress, amount, destinationAddress);
 
-        if (change > 0) {
-            emit EscrowPegOutChangePaid(requestHash, refundAddress, change);
-            _payout(refundAddress, change);
+        if (changeRefund > 0) {
+            emit EscrowPegOutChangePaid(requestHash, refundAddress, changeRefund);
+            _payout(refundAddress, changeRefund);
         }
     }
 
@@ -209,7 +216,7 @@ contract PegOutEscrow is
 
     /// @inheritdoc IPegOutEscrow
     function requestIdAt(uint256 nonce) external view override returns (bytes32) {
-        return _getStorage().idByNonce[nonce];
+        return _getStorage().requestHashByNonce[nonce];
     }
 
     // solhint-disable-next-line comprehensive-interface
@@ -297,12 +304,15 @@ contract PegOutEscrow is
         });
     }
 
-    /// @dev Frozen inverse fee split + dust-change against PegOutContract.dustThreshold.
+    /// @dev Derives principal `amount` and `callFee` from `msg.value` (frozen inverse of
+    /// `callFee = fixedFee + percentageFee·amount / 10_000`), floors `amount` to a satoshi,
+    /// then applies dust-change: residual ≥ PegOutContract.dustThreshold is returned as
+    /// `changeRefund`; smaller residual is folded into `callFee` so escrow stays fully attributed.
     function _splitValue(
         PegOutEscrowStorage storage $,
         uint256 value,
         IFlyoverConfigurations.PegOutConfiguration memory cfg
-    ) private view returns (uint256 amount, uint256 callFee, uint256 change) {
+    ) private view returns (uint256 amount, uint256 callFee, uint256 changeRefund) {
         // solhint-disable-next-line gas-strict-inequalities
         if (value <= cfg.fixedFee) {
             revert Flyover.InsufficientAmount(value, cfg.fixedFee + 1);
@@ -311,16 +321,16 @@ contract PegOutEscrow is
             / (FEE_PERCENTAGE_DENOMINATOR + cfg.percentageFee);
         amount -= amount % Quotes.SAT_TO_WEI_CONVERSION;
         callFee = $.configurations.calculatePegOutFee(amount);
-        uint256 required = amount + callFee;
-        if (value < required) {
-            revert Flyover.InsufficientAmount(value, required);
+        uint256 amountPlusCallFee = amount + callFee;
+        if (value < amountPlusCallFee) {
+            revert Flyover.InsufficientAmount(value, amountPlusCallFee);
         }
-        change = value - required;
+        changeRefund = value - amountPlusCallFee;
         uint256 dust = _dustThreshold(address($.pegOutContract));
         // solhint-disable-next-line gas-strict-inequalities
-        if (dust > change) {
-            callFee += change;
-            change = 0;
+        if (dust > changeRefund) {
+            callFee += changeRefund;
+            changeRefund = 0;
         }
     }
 

--- a/src/PegOutEscrow.sol
+++ b/src/PegOutEscrow.sol
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {
+    AccessControlDefaultAdminRulesUpgradeable
+} from "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlDefaultAdminRulesUpgradeable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {EmergencyPause} from "./EmergencyPause/EmergencyPause.sol";
+import {ICollateralManagement, CollateralManagementSet} from "./interfaces/ICollateralManagement.sol";
+import {IFlyoverConfigurations} from "./interfaces/IFlyoverConfigurations.sol";
+import {IPauseRegistry} from "./interfaces/IPauseRegistry.sol";
+import {IPegOut} from "./interfaces/IPegOut.sol";
+import {IPegOutEscrow} from "./interfaces/IPegOutEscrow.sol";
+import {Flyover} from "./libraries/Flyover.sol";
+import {Quotes} from "./libraries/Quotes.sol";
+
+/// @dev Narrow read of PegOutContract's public dust threshold (avoid concrete import).
+/// TODO: drop this if dustThreshold is added to {IPegOut} (or another shared interface).
+interface IDustThreshold {
+    function dustThreshold() external view returns (uint256);
+}
+
+/// @title PegOutEscrow
+/// @notice Commit-first peg-out escrow. User deposits RBTC first; LPs claim and settle via
+/// PegOutContract. Fee / deadline parameters come from {IFlyoverConfigurations}.
+/// @author Rootstock Labs
+contract PegOutEscrow is
+    AccessControlDefaultAdminRulesUpgradeable,
+    EmergencyPause,
+    ReentrancyGuard,
+    IPegOutEscrow
+{
+    /// @custom:storage-location erc7201:rsk.flyover.PegOutEscrow
+    struct PegOutEscrowStorage {
+        IPegOut pegOutContract;
+        ICollateralManagement collateralManagement;
+        IFlyoverConfigurations configurations;
+        mapping(bytes32 => Quotes.PegOutQuote) quotes;
+        mapping(bytes32 => EscrowedPegOutState) state;
+        mapping(uint256 => bytes32) idByNonce;
+        uint256 requestCount;
+    }
+
+    string public constant VERSION = "1.0.0";
+
+    /// @notice Basis-point denominator for `percentageFee` (frozen on {IPegOutEscrow})
+    uint256 public constant FEE_PERCENTAGE_DENOMINATOR = 10_000;
+
+    // ERC-7201: keccak256(abi.encode(uint256(keccak256("rsk.flyover.PegOutEscrow")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant _PEGOUT_ESCROW_STORAGE =
+        0xb99c8d82bac3ff4ec6a3e7ff5aa17dda321aa2a152ae7dc22fe007bc5dcb3000;
+
+    event PegOutContractSet(address indexed oldAddress, address indexed newAddress);
+    event FlyoverConfigurationsSet(address indexed oldAddress, address indexed newAddress);
+
+    /// @notice Excess above `amount + callFee` returned when at/above dust (not on frozen ABI).
+    event EscrowPegOutChangePaid(bytes32 indexed requestHash, address indexed refundAddress, uint256 indexed change);
+
+    error FlyoverConfigurationsNotSet();
+    error PegOutPathNotImplemented();
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    // solhint-disable-next-line comprehensive-interface
+    receive() external payable {
+        revert Flyover.PaymentNotAllowed();
+    }
+
+    /// @notice Initializes the escrow and wires dependencies.
+    // solhint-disable-next-line comprehensive-interface
+    function initialize(
+        address defaultAdmin,
+        uint48 initialDelay,
+        IPauseRegistry pauseRegistry_,
+        address pegOutContract_,
+        address collateralManagement_,
+        address configurations_
+    ) external initializer {
+        if (address(pauseRegistry_).code.length == 0) revert Flyover.NoContract(address(pauseRegistry_));
+        if (pegOutContract_.code.length == 0) revert Flyover.NoContract(pegOutContract_);
+        if (collateralManagement_.code.length == 0) revert Flyover.NoContract(collateralManagement_);
+        if (configurations_.code.length == 0) revert Flyover.NoContract(configurations_);
+
+        __AccessControlDefaultAdminRules_init(initialDelay, defaultAdmin);
+        __EmergencyPause_init(pauseRegistry_);
+
+        PegOutEscrowStorage storage $ = _getStorage();
+        $.pegOutContract = IPegOut(pegOutContract_);
+        $.collateralManagement = ICollateralManagement(collateralManagement_);
+        $.configurations = IFlyoverConfigurations(payable(configurations_));
+    }
+
+    // solhint-disable-next-line comprehensive-interface
+    function setPegOutContract(address pegOutContract_) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (pegOutContract_.code.length == 0) revert Flyover.NoContract(pegOutContract_);
+        PegOutEscrowStorage storage $ = _getStorage();
+        emit PegOutContractSet(address($.pegOutContract), pegOutContract_);
+        $.pegOutContract = IPegOut(pegOutContract_);
+    }
+
+    // solhint-disable-next-line comprehensive-interface
+    function setCollateralManagement(address collateralManagement_) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (collateralManagement_.code.length == 0) revert Flyover.NoContract(collateralManagement_);
+        PegOutEscrowStorage storage $ = _getStorage();
+        emit CollateralManagementSet(address($.collateralManagement), collateralManagement_);
+        $.collateralManagement = ICollateralManagement(collateralManagement_);
+    }
+
+    // solhint-disable-next-line comprehensive-interface
+    function setFlyoverConfigurations(address configurations_) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (configurations_.code.length == 0) revert Flyover.NoContract(configurations_);
+        PegOutEscrowStorage storage $ = _getStorage();
+        emit FlyoverConfigurationsSet(address($.configurations), configurations_);
+        $.configurations = IFlyoverConfigurations(payable(configurations_));
+    }
+
+    /// @inheritdoc IPegOutEscrow
+    function requestPegOut(
+        bytes calldata destinationAddress,
+        address refundAddress
+    ) external payable override nonReentrant whenNotSoftPaused returns (bytes32 requestHash) {
+        if (destinationAddress.length == 0) revert InvalidDestination();
+        if (refundAddress == address(0)) {
+            refundAddress = msg.sender;
+        }
+
+        PegOutEscrowStorage storage $ = _getStorage();
+        if (address($.pegOutContract) == address(0)) revert PegOutContractNotSet();
+        if (address($.configurations) == address(0)) revert FlyoverConfigurationsNotSet();
+
+        IFlyoverConfigurations.PegOutConfiguration memory cfg = $.configurations.getPegOutConfiguration();
+        (uint256 amount, uint256 callFee, uint256 change) = _splitValue($, msg.value, cfg);
+        if (amount < cfg.minAmount || amount > cfg.maxAmount) {
+            revert NotServiceable(amount, cfg.minAmount, cfg.maxAmount);
+        }
+
+        uint256 nonce = ++$.requestCount;
+        requestHash = _computeRequestHash(nonce, refundAddress, destinationAddress, amount, callFee);
+
+        $.state[requestHash] = EscrowedPegOutState.REQUESTED;
+        $.idByNonce[nonce] = requestHash;
+
+        uint256 confirmations = $.configurations.getRequiredPegOutBtcConfirmations(amount);
+        $.quotes[requestHash] =
+            _buildQuote($, cfg, refundAddress, destinationAddress, amount, callFee, nonce, confirmations);
+
+        emit PegOutRequested(requestHash, refundAddress, amount, destinationAddress);
+
+        if (change > 0) {
+            emit EscrowPegOutChangePaid(requestHash, refundAddress, change);
+            _payout(refundAddress, change);
+        }
+    }
+
+    /// @inheritdoc IPegOutEscrow
+    function cancelPegOut(bytes32 requestHash) external override nonReentrant whenNotSoftPaused {
+        PegOutEscrowStorage storage $ = _getStorage();
+        _requireRequested($, requestHash);
+        Quotes.PegOutQuote memory q = $.quotes[requestHash];
+        if (msg.sender != q.rskRefundAddress) {
+            revert Flyover.InvalidSender(q.rskRefundAddress, msg.sender);
+        }
+
+        uint256 payout = q.value + q.callFee + q.gasFee;
+        _terminate($, requestHash, EscrowedPegOutState.CANCELLED);
+        emit PegOutCancelled(requestHash);
+        _payout(q.rskRefundAddress, payout);
+    }
+
+    /// @inheritdoc IPegOutEscrow
+    // TODO: implement claim path (LP signature, collateral check, registerClaimedPegOut)
+    function claimPegOut(bytes32, bytes calldata) external override {
+        revert PegOutPathNotImplemented();
+    }
+
+    /// @inheritdoc IPegOutEscrow
+    // TODO: implement no-claim refund after depositDateLimit (+ optional globalSlash)
+    function refundOnNoClaim(bytes32) external override {
+        revert PegOutPathNotImplemented();
+    }
+
+    /// @inheritdoc IPegOutEscrow
+    // TODO: implement PegOutContract settlement callback (CLAIMED → FULFILLED/REFUNDED)
+    function onSettlement(bytes32, EscrowedPegOutState) external override {
+        revert PegOutPathNotImplemented();
+    }
+
+    /// @inheritdoc IPegOutEscrow
+    function getPegOutState(bytes32 requestHash) external view override returns (EscrowedPegOutState) {
+        return _getStorage().state[requestHash];
+    }
+
+    /// @inheritdoc IPegOutEscrow
+    function getPegOutQuote(bytes32 requestHash) external view override returns (Quotes.PegOutQuote memory) {
+        PegOutEscrowStorage storage $ = _getStorage();
+        if ($.state[requestHash] == EscrowedPegOutState.NONE) {
+            revert Flyover.QuoteNotFound(requestHash);
+        }
+        return $.quotes[requestHash];
+    }
+
+    /// @inheritdoc IPegOutEscrow
+    function totalRequests() external view override returns (uint256) {
+        return _getStorage().requestCount;
+    }
+
+    /// @inheritdoc IPegOutEscrow
+    function requestIdAt(uint256 nonce) external view override returns (bytes32) {
+        return _getStorage().idByNonce[nonce];
+    }
+
+    // solhint-disable-next-line comprehensive-interface
+    function getPegOutContract() external view returns (address) {
+        return address(_getStorage().pegOutContract);
+    }
+
+    // solhint-disable-next-line comprehensive-interface
+    function getFlyoverConfigurations() external view returns (address) {
+        return address(_getStorage().configurations);
+    }
+
+    function _terminate(
+        PegOutEscrowStorage storage $,
+        bytes32 requestHash,
+        EscrowedPegOutState finalState
+    ) private {
+        $.state[requestHash] = finalState;
+        delete $.quotes[requestHash];
+    }
+
+    function _payout(address to, uint256 amount) private {
+        (bool sent, bytes memory reason) = to.call{value: amount}("");
+        if (!sent) {
+            revert Flyover.PaymentFailed(to, amount, reason);
+        }
+    }
+
+    function _computeRequestHash(
+        uint256 nonce,
+        address refundTo,
+        bytes calldata destinationAddress,
+        uint256 amount,
+        uint256 callFee
+    ) private view returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                block.chainid,
+                address(this),
+                nonce,
+                msg.sender,
+                refundTo,
+                keccak256(destinationAddress),
+                amount,
+                callFee,
+                block.timestamp
+            )
+        );
+    }
+
+    function _buildQuote(
+        PegOutEscrowStorage storage $,
+        IFlyoverConfigurations.PegOutConfiguration memory cfg,
+        address refundTo,
+        bytes calldata destinationAddress,
+        uint256 amount,
+        uint256 callFee,
+        uint256 nonce,
+        uint256 confirmations
+    ) private view returns (Quotes.PegOutQuote memory quote) {
+        uint256 latestClaim = block.timestamp + cfg.claimWindow;
+        uint256 latestClaimBlock = block.number + cfg.claimWindowBlocks;
+        quote = Quotes.PegOutQuote({
+            chainId: block.chainid,
+            callFee: callFee,
+            penaltyFee: cfg.penaltyFee,
+            value: amount,
+            // TODO: snapshot from config if frozen PegOutConfiguration regains gasFee
+            gasFee: 0,
+            lbcAddress: address($.pegOutContract),
+            lpRskAddress: address(0),
+            rskRefundAddress: refundTo,
+            nonce: int64(uint64(nonce)),
+            agreementTimestamp: uint32(block.timestamp),
+            depositDateLimit: uint32(latestClaim),
+            transferTime: uint32(cfg.callTime),
+            expireDate: uint32(latestClaim + cfg.expireTime),
+            expireBlock: uint32(latestClaimBlock + cfg.expireBlocks),
+            // TODO: snapshot from config if frozen PegOutConfiguration regains depositConfirmations
+            depositConfirmations: 0,
+            transferConfirmations: uint16(confirmations),
+            depositAddress: destinationAddress,
+            btcRefundAddress: "",
+            lpBtcAddress: ""
+        });
+    }
+
+    /// @dev Frozen inverse fee split + dust-change against PegOutContract.dustThreshold.
+    function _splitValue(
+        PegOutEscrowStorage storage $,
+        uint256 value,
+        IFlyoverConfigurations.PegOutConfiguration memory cfg
+    ) private view returns (uint256 amount, uint256 callFee, uint256 change) {
+        // solhint-disable-next-line gas-strict-inequalities
+        if (value <= cfg.fixedFee) {
+            revert Flyover.InsufficientAmount(value, cfg.fixedFee + 1);
+        }
+        amount = ((value - cfg.fixedFee) * FEE_PERCENTAGE_DENOMINATOR)
+            / (FEE_PERCENTAGE_DENOMINATOR + cfg.percentageFee);
+        amount -= amount % Quotes.SAT_TO_WEI_CONVERSION;
+        callFee = $.configurations.calculatePegOutFee(amount);
+        uint256 required = amount + callFee;
+        if (value < required) {
+            revert Flyover.InsufficientAmount(value, required);
+        }
+        change = value - required;
+        uint256 dust = _dustThreshold(address($.pegOutContract));
+        // solhint-disable-next-line gas-strict-inequalities
+        if (dust > change) {
+            callFee += change;
+            change = 0;
+        }
+    }
+
+    function _dustThreshold(address pegOutContract) private view returns (uint256) {
+        return IDustThreshold(pegOutContract).dustThreshold();
+    }
+
+    function _requireRequested(PegOutEscrowStorage storage $, bytes32 requestHash) private view {
+        EscrowedPegOutState actual = $.state[requestHash];
+        if (actual != EscrowedPegOutState.REQUESTED) {
+            revert InvalidState(requestHash, EscrowedPegOutState.REQUESTED, actual);
+        }
+    }
+
+    function _getStorage() private pure returns (PegOutEscrowStorage storage $) {
+        bytes32 slot = _PEGOUT_ESCROW_STORAGE;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            $.slot := slot
+        }
+    }
+}

--- a/src/PegOutEscrow.sol
+++ b/src/PegOutEscrow.sol
@@ -232,16 +232,18 @@ contract PegOutEscrow is
         delete $.quotes[requestHash];
     }
 
-    /// @dev ETH transfer that ignores returndata (refundAddress can be a contract).
     // slither-disable-next-line arbitrary-send-eth,low-level-calls
     function _payout(address to, uint256 amount) private {
-        bool sent;
+        address target = to;
+        uint256 value = amount;
+        uint256 gasLimit = gasleft();
+        bytes memory data = "";
+        bool success;
         // solhint-disable-next-line no-inline-assembly
-        assembly ("memory-safe") {
-            // out size 0: do not copy returndata (return-bomb safe)
-            sent := call(gas(), to, amount, 0, 0, 0, 0)
+        assembly {
+            success := call(gasLimit, target, value, add(data, 0x20), mload(data), 0, 0)
         }
-        if (!sent) {
+        if (!success) {
             revert Flyover.PaymentFailed(to, amount, hex"");
         }
     }

--- a/src/PegOutEscrow.sol
+++ b/src/PegOutEscrow.sol
@@ -232,10 +232,17 @@ contract PegOutEscrow is
         delete $.quotes[requestHash];
     }
 
+    /// @dev ETH transfer that ignores returndata (refundAddress can be a contract).
+    // slither-disable-next-line arbitrary-send-eth,low-level-calls
     function _payout(address to, uint256 amount) private {
-        (bool sent, bytes memory reason) = to.call{value: amount}("");
+        bool sent;
+        // solhint-disable-next-line no-inline-assembly
+        assembly ("memory-safe") {
+            // out size 0: do not copy returndata (return-bomb safe)
+            sent := call(gas(), to, amount, 0, 0, 0, 0)
+        }
         if (!sent) {
-            revert Flyover.PaymentFailed(to, amount, reason);
+            revert Flyover.PaymentFailed(to, amount, hex"");
         }
     }
 
@@ -321,6 +328,7 @@ contract PegOutEscrow is
         }
         changeRefund = value - amountPlusCallFee;
         uint256 dust = $.pegOutContract.dustThreshold();
+        // Match PegOutContract.depositPegOut: fold when dust > change (refund when change >= dust).
         // solhint-disable-next-line gas-strict-inequalities
         if (dust > changeRefund) {
             callFee += changeRefund;

--- a/src/interfaces/IPegOut.sol
+++ b/src/interfaces/IPegOut.sol
@@ -200,4 +200,8 @@ interface IPegOut is IPausable, IERC5267 {
     /// @param addr The address to get the balance of
     /// @return balance The balance of the address
     function getBalance(address addr) external view returns (uint256);
+
+    /// @notice Dust threshold for overpayment change refunds (wei)
+    /// @dev Used by depositPegOut and by PegOutEscrow request-time change handling.
+    function dustThreshold() external view returns (uint256);
 }

--- a/test/configurations/PegOut.t.sol
+++ b/test/configurations/PegOut.t.sol
@@ -24,7 +24,10 @@ contract PegOutConfigurationsTest is ConfigurationsTestBase {
         return fee;
     }
 
-    function test_calculatePegOutFee_fixedFloorAndSatoshiRounding() public view {
+    function test_calculatePegOutFee_fixedFloorAndSatoshiRounding()
+        public
+        view
+    {
         assertEq(config.calculatePegOutFee(0), SEED_FIXED_FEE);
 
         uint256 amount = 123_456_789_012_345;
@@ -47,7 +50,8 @@ contract PegOutConfigurationsTest is ConfigurationsTestBase {
     }
 
     function test_queueThenApplyPegOut_updatesActiveAndEmits() public {
-        IFlyoverConfigurations.PegOutConfiguration memory c = _altPegOutConfig();
+        IFlyoverConfigurations.PegOutConfiguration
+            memory c = _altPegOutConfig();
         uint256 expectedEta = block.timestamp + TIMELOCK_DELAY;
 
         vm.expectEmit(true, true, true, true, address(config));
@@ -63,7 +67,8 @@ contract PegOutConfigurationsTest is ConfigurationsTestBase {
         vm.prank(owner);
         config.applyPegOutChange();
 
-        IFlyoverConfigurations.PegOutConfiguration memory active = config.getPegOutConfiguration();
+        IFlyoverConfigurations.PegOutConfiguration memory active = config
+            .getPegOutConfiguration();
         assertEq(active.fixedFee, c.fixedFee);
         assertEq(active.claimWindow, c.claimWindow);
         assertEq(active.callTime, c.callTime);
@@ -81,7 +86,9 @@ contract PegOutConfigurationsTest is ConfigurationsTestBase {
         vm.prank(owner);
         vm.expectRevert(
             abi.encodeWithSelector(
-                FlyoverConfigurations.TimelockNotElapsed.selector, eta, eta - 1
+                FlyoverConfigurations.TimelockNotElapsed.selector,
+                eta,
+                eta - 1
             )
         );
         config.applyPegOutChange();
@@ -92,15 +99,18 @@ contract PegOutConfigurationsTest is ConfigurationsTestBase {
     /// and maxMinerFee (escrow should persist that snapshot at request time).
     function test_configChange_leavesPriorSnapshotUntouched() public {
         uint256 amount = 1 ether;
-        IFlyoverConfigurations.PegOutConfiguration memory snapshot = config.getPegOutConfiguration();
+        IFlyoverConfigurations.PegOutConfiguration memory snapshot = config
+            .getPegOutConfiguration();
         uint256 snapshottedFee = config.calculatePegOutFee(amount);
 
-        IFlyoverConfigurations.PegOutConfiguration memory next = _queueAltPegOut();
+        IFlyoverConfigurations.PegOutConfiguration
+            memory next = _queueAltPegOut();
         vm.warp(block.timestamp + TIMELOCK_DELAY);
         vm.prank(owner);
         config.applyPegOutChange();
 
-        IFlyoverConfigurations.PegOutConfiguration memory live = config.getPegOutConfiguration();
+        IFlyoverConfigurations.PegOutConfiguration memory live = config
+            .getPegOutConfiguration();
         assertEq(live.fixedFee, next.fixedFee);
         assertEq(live.claimWindow, next.claimWindow);
         assertEq(live.callTime, next.callTime);
@@ -116,7 +126,10 @@ contract PegOutConfigurationsTest is ConfigurationsTestBase {
         assertEq(snapshot.callTime, SEED_CALL_TIME);
         assertEq(snapshot.expireTime, SEED_EXPIRE_TIME);
         assertEq(snapshot.maxMinerFee, SEED_MAX_MINER_FEE);
-        assertEq(snapshottedFee, _expectedFee(SEED_FIXED_FEE, SEED_PCT, amount));
+        assertEq(
+            snapshottedFee,
+            _expectedFee(SEED_FIXED_FEE, SEED_PCT, amount)
+        );
         assertTrue(snapshot.fixedFee != live.fixedFee);
         assertTrue(snapshottedFee != config.calculatePegOutFee(amount));
     }

--- a/test/pegout-escrow/PegOutEscrow.t.sol
+++ b/test/pegout-escrow/PegOutEscrow.t.sol
@@ -1,0 +1,479 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {PegOutEscrow} from "../../src/PegOutEscrow.sol";
+import {PauseRegistry} from "../../src/PauseRegistry.sol";
+import {IPegOutEscrow} from "../../src/interfaces/IPegOutEscrow.sol";
+import {IFlyoverConfigurations} from "../../src/interfaces/IFlyoverConfigurations.sol";
+import {Flyover} from "../../src/libraries/Flyover.sol";
+import {Quotes} from "../../src/libraries/Quotes.sol";
+import {FlyoverConfigurationsMock} from "../pegin/FlyoverConfigurationsMock.sol";
+
+/// @dev Minimal PegOut stand-in: only `dustThreshold` (public getter) is read by escrow.
+contract PegOutDustMock {
+    uint256 public dustThreshold;
+
+    constructor(uint256 dustThreshold_) {
+        dustThreshold = dustThreshold_;
+    }
+
+    function setDustThreshold(uint256 dustThreshold_) external {
+        dustThreshold = dustThreshold_;
+    }
+}
+
+/// @dev Satisfies initialize code.length checks; unused by request/cancel.
+contract CodeStub {
+
+}
+
+/// @title PegOutEscrow request + cancel AC coverage (S12-A)
+contract PegOutEscrowTest is Test {
+    /// @dev Mirrors impl-only {PegOutEscrow.EscrowPegOutChangePaid} for expectEmit.
+    event EscrowPegOutChangePaid(
+        bytes32 indexed requestHash,
+        address indexed refundAddress,
+        uint256 indexed change
+    );
+
+    uint256 internal constant FIXED_FEE = 0.001 ether;
+    uint256 internal constant PERCENTAGE_FEE = 100; // 1%
+    uint256 internal constant MIN_AMOUNT = 0.01 ether;
+    uint256 internal constant MAX_AMOUNT = 50 ether;
+    uint256 internal constant DUST = 0.001 ether;
+    uint256 internal constant CLAIM_WINDOW = 1 hours;
+    uint256 internal constant CLAIM_WINDOW_BLOCKS = 100;
+    uint256 internal constant CALL_TIME = 2 hours;
+    uint256 internal constant EXPIRE_TIME = 1 hours;
+    uint256 internal constant EXPIRE_BLOCKS = 50;
+    uint256 internal constant PENALTY_FEE = 0.01 ether;
+    uint256 internal constant TIER_CONFIRMATIONS = 6;
+    uint256 internal constant BASIS = 10_000;
+
+    /// @dev msg.value that yields a serviceable principal near 1 ether under the seed config.
+    uint256 internal constant DEFAULT_VALUE = 1.012 ether;
+
+    PegOutEscrow internal escrow;
+    FlyoverConfigurationsMock internal configurations;
+    PegOutDustMock internal pegOut;
+    PauseRegistry internal pauseRegistry;
+
+    address internal owner;
+    address internal user;
+    address internal other;
+
+    bytes internal constant DEST =
+        hex"0014deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+
+    function setUp() public {
+        owner = makeAddr("owner");
+        user = makeAddr("user");
+        other = makeAddr("other");
+        vm.deal(user, 100 ether);
+        vm.deal(other, 100 ether);
+
+        PauseRegistry prImpl = new PauseRegistry();
+        pauseRegistry = PauseRegistry(
+            payable(
+                address(
+                    new ERC1967Proxy(
+                        address(prImpl),
+                        abi.encodeCall(prImpl.initialize, (0, owner))
+                    )
+                )
+            )
+        );
+
+        configurations = new FlyoverConfigurationsMock();
+        pegOut = new PegOutDustMock(DUST);
+        CodeStub collateral = new CodeStub();
+
+        PegOutEscrow impl = new PegOutEscrow();
+        escrow = PegOutEscrow(
+            payable(
+                address(
+                    new ERC1967Proxy(
+                        address(impl),
+                        abi.encodeCall(
+                            PegOutEscrow.initialize,
+                            (
+                                owner,
+                                uint48(0),
+                                pauseRegistry,
+                                address(pegOut),
+                                address(collateral),
+                                address(configurations)
+                            )
+                        )
+                    )
+                )
+            )
+        );
+
+        _seedPegOutConfig();
+    }
+
+    // -------------------------------------------------------------------------
+    // requestPegOut
+    // -------------------------------------------------------------------------
+
+    function test_requestPegOut_happyPath_stateQuoteGettersAndEvent() public {
+        (uint256 amount, uint256 callFee, uint256 change) = _expectedSplit(
+            DEFAULT_VALUE
+        );
+        assertGt(amount, 0);
+        assertEq(
+            amount % Quotes.SAT_TO_WEI_CONVERSION,
+            0,
+            "amount sat-floored"
+        );
+        assertTrue(amount >= MIN_AMOUNT && amount <= MAX_AMOUNT);
+
+        uint256 userBefore = user.balance;
+        uint256 nonce = 1;
+        bytes32 expectedHash = _expectedRequestHash(
+            nonce,
+            user,
+            DEST,
+            amount,
+            callFee
+        );
+
+        vm.expectEmit(true, true, true, true, address(escrow));
+        emit IPegOutEscrow.PegOutRequested(expectedHash, user, amount, DEST);
+
+        vm.prank(user);
+        bytes32 requestHash = escrow.requestPegOut{value: DEFAULT_VALUE}(
+            DEST,
+            user
+        );
+
+        assertEq(requestHash, expectedHash);
+        assertEq(
+            uint256(escrow.getPegOutState(requestHash)),
+            uint256(IPegOutEscrow.EscrowedPegOutState.REQUESTED)
+        );
+        assertEq(escrow.totalRequests(), 1);
+        assertEq(escrow.requestIdAt(1), requestHash);
+
+        Quotes.PegOutQuote memory q = escrow.getPegOutQuote(requestHash);
+        assertEq(q.value, amount);
+        assertEq(q.callFee, callFee);
+        assertEq(q.gasFee, 0);
+        assertEq(q.depositConfirmations, 0);
+        assertEq(q.penaltyFee, PENALTY_FEE);
+        assertEq(q.rskRefundAddress, user);
+        assertEq(q.lbcAddress, address(pegOut));
+        assertEq(q.lpRskAddress, address(0));
+        assertEq(q.nonce, int64(uint64(nonce)));
+        assertEq(q.depositDateLimit, uint32(block.timestamp + CLAIM_WINDOW));
+        assertEq(q.transferTime, uint32(CALL_TIME));
+        assertEq(
+            q.expireDate,
+            uint32(block.timestamp + CLAIM_WINDOW + EXPIRE_TIME)
+        );
+        assertEq(
+            q.expireBlock,
+            uint32(block.number + CLAIM_WINDOW_BLOCKS + EXPIRE_BLOCKS)
+        );
+        assertEq(q.transferConfirmations, uint16(TIER_CONFIRMATIONS));
+        assertEq(q.depositAddress, DEST);
+
+        // Change below dust is folded into callFee (DEFAULT_VALUE residual is small).
+        if (change == 0) {
+            assertEq(user.balance, userBefore - DEFAULT_VALUE);
+            assertEq(address(escrow).balance, amount + callFee);
+        } else {
+            assertEq(user.balance, userBefore - DEFAULT_VALUE + change);
+            assertEq(address(escrow).balance, DEFAULT_VALUE - change);
+        }
+    }
+
+    function test_requestPegOut_zeroRefundAddress_mapsToMsgSender() public {
+        (uint256 amount, uint256 callFee, ) = _expectedSplit(DEFAULT_VALUE);
+        bytes32 expectedHash = _expectedRequestHash(
+            1,
+            user,
+            DEST,
+            amount,
+            callFee
+        );
+
+        vm.prank(user);
+        bytes32 requestHash = escrow.requestPegOut{value: DEFAULT_VALUE}(
+            DEST,
+            address(0)
+        );
+
+        assertEq(requestHash, expectedHash);
+        assertEq(escrow.getPegOutQuote(requestHash).rskRefundAddress, user);
+    }
+
+    function test_requestPegOut_emptyDestination_reverts() public {
+        vm.prank(user);
+        vm.expectRevert(IPegOutEscrow.InvalidDestination.selector);
+        escrow.requestPegOut{value: DEFAULT_VALUE}("", user);
+    }
+
+    function test_requestPegOut_amountBelowMin_revertsNotServiceable() public {
+        // Tiny payment → principal below MIN_AMOUNT after fee split.
+        uint256 tiny = FIXED_FEE + 0.001 ether;
+        (uint256 amount, , ) = _expectedSplit(tiny);
+        assertLt(amount, MIN_AMOUNT);
+
+        vm.prank(user);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegOutEscrow.NotServiceable.selector,
+                amount,
+                MIN_AMOUNT,
+                MAX_AMOUNT
+            )
+        );
+        escrow.requestPegOut{value: tiny}(DEST, user);
+    }
+
+    function test_requestPegOut_changeAtOrAboveDust_isRefunded() public {
+        pegOut.setDustThreshold(1 wei);
+
+        // Pick a value whose residual after split is clearly >= 1 wei.
+        uint256 value = 2 ether;
+        (uint256 amount, uint256 callFee, uint256 change) = _expectedSplit(
+            value
+        );
+        // With dust=1, residual above required is returned (not folded).
+        assertGt(change, 0);
+
+        uint256 userBefore = user.balance;
+        bytes32 expectedHash = _expectedRequestHash(
+            1,
+            user,
+            DEST,
+            amount,
+            callFee
+        );
+
+        vm.expectEmit(true, true, true, true, address(escrow));
+        emit IPegOutEscrow.PegOutRequested(expectedHash, user, amount, DEST);
+        vm.expectEmit(true, true, true, true, address(escrow));
+        emit EscrowPegOutChangePaid(expectedHash, user, change);
+
+        vm.prank(user);
+        bytes32 requestHash = escrow.requestPegOut{value: value}(DEST, user);
+
+        assertEq(user.balance, userBefore - value + change);
+        assertEq(address(escrow).balance, amount + callFee);
+        assertEq(escrow.getPegOutQuote(requestHash).callFee, callFee);
+    }
+
+    function test_requestPegOut_changeBelowDust_foldedIntoCallFee() public {
+        pegOut.setDustThreshold(type(uint256).max);
+
+        uint256 value = 2 ether;
+        (
+            uint256 amount,
+            uint256 baseCallFee,
+            uint256 residual
+        ) = _expectedSplitBeforeDust(value);
+        assertGt(residual, 0);
+
+        uint256 userBefore = user.balance;
+
+        vm.prank(user);
+        bytes32 requestHash = escrow.requestPegOut{value: value}(DEST, user);
+
+        // No change refunded; residual absorbed into callFee.
+        assertEq(user.balance, userBefore - value);
+        assertEq(address(escrow).balance, value);
+
+        Quotes.PegOutQuote memory q = escrow.getPegOutQuote(requestHash);
+        assertEq(q.value, amount);
+        assertEq(q.callFee, baseCallFee + residual);
+    }
+
+    // -------------------------------------------------------------------------
+    // cancelPegOut
+    // -------------------------------------------------------------------------
+
+    function test_cancelPegOut_refundsAndTerminates() public {
+        vm.prank(user);
+        bytes32 requestHash = escrow.requestPegOut{value: DEFAULT_VALUE}(
+            DEST,
+            user
+        );
+
+        Quotes.PegOutQuote memory q = escrow.getPegOutQuote(requestHash);
+        uint256 payout = q.value + q.callFee + q.gasFee;
+        uint256 userBefore = user.balance;
+        uint256 escrowBefore = address(escrow).balance;
+
+        vm.expectEmit(true, false, false, true, address(escrow));
+        emit IPegOutEscrow.PegOutCancelled(requestHash);
+
+        vm.prank(user);
+        escrow.cancelPegOut(requestHash);
+
+        assertEq(
+            uint256(escrow.getPegOutState(requestHash)),
+            uint256(IPegOutEscrow.EscrowedPegOutState.CANCELLED)
+        );
+        assertEq(user.balance, userBefore + payout);
+        assertEq(address(escrow).balance, escrowBefore - payout);
+
+        // Quote storage is cleared; state is CANCELLED (not NONE), so getter still returns.
+        Quotes.PegOutQuote memory cleared = escrow.getPegOutQuote(requestHash);
+        assertEq(cleared.value, 0);
+        assertEq(cleared.callFee, 0);
+        assertEq(cleared.rskRefundAddress, address(0));
+    }
+
+    function test_cancelPegOut_wrongCaller_reverts() public {
+        vm.prank(user);
+        bytes32 requestHash = escrow.requestPegOut{value: DEFAULT_VALUE}(
+            DEST,
+            user
+        );
+
+        vm.prank(other);
+        vm.expectRevert(
+            abi.encodeWithSelector(Flyover.InvalidSender.selector, user, other)
+        );
+        escrow.cancelPegOut(requestHash);
+    }
+
+    function test_cancelPegOut_notRequested_reverts() public {
+        bytes32 missing = keccak256("missing");
+        vm.prank(user);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegOutEscrow.InvalidState.selector,
+                missing,
+                IPegOutEscrow.EscrowedPegOutState.REQUESTED,
+                IPegOutEscrow.EscrowedPegOutState.NONE
+            )
+        );
+        escrow.cancelPegOut(missing);
+    }
+
+    function test_cancelPegOut_twice_reverts() public {
+        vm.prank(user);
+        bytes32 requestHash = escrow.requestPegOut{value: DEFAULT_VALUE}(
+            DEST,
+            user
+        );
+
+        vm.prank(user);
+        escrow.cancelPegOut(requestHash);
+
+        vm.prank(user);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegOutEscrow.InvalidState.selector,
+                requestHash,
+                IPegOutEscrow.EscrowedPegOutState.REQUESTED,
+                IPegOutEscrow.EscrowedPegOutState.CANCELLED
+            )
+        );
+        escrow.cancelPegOut(requestHash);
+    }
+
+    // -------------------------------------------------------------------------
+    // stubs
+    // -------------------------------------------------------------------------
+
+    function test_stubs_revertNotImplemented() public {
+        vm.expectRevert(PegOutEscrow.PegOutPathNotImplemented.selector);
+        escrow.claimPegOut(bytes32(0), "");
+
+        vm.expectRevert(PegOutEscrow.PegOutPathNotImplemented.selector);
+        escrow.refundOnNoClaim(bytes32(0));
+
+        vm.expectRevert(PegOutEscrow.PegOutPathNotImplemented.selector);
+        escrow.onSettlement(
+            bytes32(0),
+            IPegOutEscrow.EscrowedPegOutState.FULFILLED
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // helpers
+    // -------------------------------------------------------------------------
+
+    function _seedPegOutConfig() internal {
+        IFlyoverConfigurations.ConfirmationTier[]
+            memory tiers = new IFlyoverConfigurations.ConfirmationTier[](1);
+        tiers[0] = IFlyoverConfigurations.ConfirmationTier({
+            maxAmount: type(uint256).max,
+            confirmations: TIER_CONFIRMATIONS
+        });
+
+        configurations.setPegOutConfiguration(
+            IFlyoverConfigurations.PegOutConfiguration({
+                fixedFee: FIXED_FEE,
+                percentageFee: PERCENTAGE_FEE,
+                minAmount: MIN_AMOUNT,
+                maxAmount: MAX_AMOUNT,
+                confirmationTiers: tiers,
+                penaltyFee: PENALTY_FEE,
+                claimWindow: CLAIM_WINDOW,
+                claimWindowBlocks: CLAIM_WINDOW_BLOCKS,
+                callTime: CALL_TIME,
+                expireTime: EXPIRE_TIME,
+                expireBlocks: EXPIRE_BLOCKS,
+                maxMinerFee: 0.001 ether
+            })
+        );
+    }
+
+    function _expectedSplitBeforeDust(
+        uint256 value
+    )
+        internal
+        view
+        returns (uint256 amount, uint256 callFee, uint256 residual)
+    {
+        amount = ((value - FIXED_FEE) * BASIS) / (BASIS + PERCENTAGE_FEE);
+        amount -= amount % Quotes.SAT_TO_WEI_CONVERSION;
+        callFee = configurations.calculatePegOutFee(amount);
+        residual = value - (amount + callFee);
+    }
+
+    function _expectedSplit(
+        uint256 value
+    ) internal view returns (uint256 amount, uint256 callFee, uint256 change) {
+        uint256 residual;
+        (amount, callFee, residual) = _expectedSplitBeforeDust(value);
+        uint256 dust = pegOut.dustThreshold();
+        if (dust > residual) {
+            callFee += residual;
+            change = 0;
+        } else {
+            change = residual;
+        }
+    }
+
+    function _expectedRequestHash(
+        uint256 nonce,
+        address refundTo,
+        bytes memory destination,
+        uint256 amount,
+        uint256 callFee
+    ) internal view returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(
+                    block.chainid,
+                    address(escrow),
+                    nonce,
+                    user,
+                    refundTo,
+                    keccak256(destination),
+                    amount,
+                    callFee,
+                    block.timestamp
+                )
+            );
+    }
+}

--- a/test/pegout-escrow/PegOutEscrow.t.sol
+++ b/test/pegout-escrow/PegOutEscrow.t.sol
@@ -29,7 +29,7 @@ contract CodeStub {
 
 }
 
-/// @title PegOutEscrow request + cancel AC coverage (S12-A)
+/// @title PegOutEscrow request + cancel
 contract PegOutEscrowTest is Test {
     /// @dev Mirrors impl-only {PegOutEscrow.EscrowPegOutChangePaid} for expectEmit.
     event EscrowPegOutChangePaid(


### PR DESCRIPTION
## What

Add `PegOutEscrow` implementing the frozen `IPegOutEscrow` request/cancel path and getters against `FlyoverConfigurations`: fee split (no `gasFee`), dust change vs PegOut `dustThreshold`, `refundAddress(0)` → `msg.sender`, quote snapshot at request, and cancel refund while `REQUESTED`. Stub `claimPegOut` / `refundOnNoClaim` / `onSettlement`. No interface changes.

## Why

Commit-first peg-out needs an on-chain escrow so the user’s RBTC deposit is the only commitment before an LP claims. This PR lands request + cancel (and discovery getters) on top of FLY-2542 configs; claim/settlement stay stubbed for a follow-up.

## Type of Change

- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Refactor (no intended behavior change)
- [ ] Security hardening
- [ ] Tests only
- [ ] Build/CI/Tooling
- [ ] Documentation

## Affected Areas

- [ ] PegIn flow (`registerPegIn`, `callForUser`, quote validation)
- [x] PegOut flow (`depositPegout`, `refundPegOut`, `refundUserPegOut`)
- [ ] Liquidity Provider lifecycle (register/update/status/resign/collateral/withdraw)
- [ ] Pause/operational controls
- [ ] Quote hashing/signature logic
- [ ] Bitcoin tx / PMT / merkle validation
- [ ] Deployment or upgrade scripts / Makefile targets
- [ ] CI workflows (`ci`, `fuzz`, `formal`, `slither`, `codeql`)
- [ ] Docs

## Risk & Security Review

- [x] Access control and authorization paths reviewed
- [x] Reentrancy and external call paths reviewed
- [x] Storage layout / upgrade safety reviewed (if upgradeable code changed)
- [x] Time/block/confirmation assumptions reviewed
- [ ] BTC tx output/index assumptions reviewed (if pegout validation touched)
- [x] No secrets or sensitive values added

## Test Plan

List what you ran locally and the outcome:

- [x] `npm run lint:sol` (solhint on `src/PegOutEscrow.sol`)
- [ ] `npm run lint:ts`
- [x] `npm run compile` / `forge build`
- [x] `forge test --match-path 'test/pegout-escrow/*'`
- [ ] `npm test`
- [ ] `npm run test:fuzz` (if logic/state transitions changed)
- [ ] `npm run test:invariant` (if invariant-sensitive logic changed)
- [ ] `npm run test:formal` (if formal-verification-sensitive logic changed)
- [ ] `npm run test:integration` (if integration paths changed)
- [ ] `npm run test:e2e` (if deployment/ownership flows changed)

Additional notes on test coverage, edge cases, and any tests intentionally skipped:

Unit coverage in `test/pegout-escrow/PegOutEscrow.t.sol` for request/cancel AC (happy path, zero-refund mapping, serviceability, dust refund vs fold, cancel auth/state, stubs). Claim/settlement intentionally not implemented.

## Deployment & Ops Impact

- [ ] No deployment impact
- [x] Requires deployment
- [ ] Requires upgrade
- [ ] Env/config changes required (`.env`, network RPCs, verification, etc.)
- [ ] Runbook/update instructions added to PR description

New upgradeable escrow contract; wire `initialize(admin, delay, pauseRegistry, pegOut, collateral, configurations)` after configs are live. Deploy scripts not included in this PR.

## Related Issues

- Jira: [FLY-2543](https://rsklabs.atlassian.net/browse/FLY-2543)
- Depends on: feat/FLY-2542 (peg-out FlyoverConfigurations impl)

## Reviewer Notes

- Frozen rules vs PoC: no `gasFee` in fee split; `refundAddress(0)` → `msg.sender`; quote `gasFee` / `depositConfirmations` snapshotted as `0` (not on frozen config).
- Dust read via narrow `IDustThreshold` (not on `IPegOut`); change emit is impl-only `EscrowPegOutChangePaid` (not on frozen escrow ABI).
- `claimPegOut` / `refundOnNoClaim` / `onSettlement` revert `PegOutPathNotImplemented` (TODOs marked).

## Screenshots / Logs (if applicable)

N/A