### PR TITLE
Feat/fly 2544

### DIFF
--- a/src/PegOutContract.sol
+++ b/src/PegOutContract.sol
@@ -166,8 +166,11 @@ contract PegOutContract is
         }
 
         Quotes.PegOutQuote memory quote = _requireClaimedEscrowQuote(requestHash);
-        if (!_collateralManagement.isCollateralSufficient(_PEG_TYPE, quote.lpRskAddress)) {
+        if (!_collateralManagement.isRegistered(_PEG_TYPE, quote.lpRskAddress)) {
             revert Flyover.ProviderNotRegistered(quote.lpRskAddress);
+        }
+        if (!_collateralManagement.isCollateralSufficient(_PEG_TYPE, quote.lpRskAddress)) {
+            revert InsufficientCollateral(_collateralManagement.getPegOutCollateral(quote.lpRskAddress));
         }
         uint256 requiredAmount = quote.value + quote.callFee + quote.gasFee;
         if (msg.value != requiredAmount) {

--- a/src/PegOutContract.sol
+++ b/src/PegOutContract.sol
@@ -12,6 +12,7 @@ import {IBridge} from "./interfaces/IBridge.sol";
 import {ICollateralManagement, CollateralManagementSet} from "./interfaces/ICollateralManagement.sol";
 import {IPauseRegistry} from "./interfaces/IPauseRegistry.sol";
 import {IPegOut} from "./interfaces/IPegOut.sol";
+import {IPegOutEscrow} from "./interfaces/IPegOutEscrow.sol";
 import {Flyover} from "./libraries/Flyover.sol";
 import {Quotes} from "./libraries/Quotes.sol";
 import {SignatureValidator} from "./libraries/SignatureValidator.sol";
@@ -56,6 +57,7 @@ contract PegOutContract is
 
     IBridge private _bridge;
     ICollateralManagement private _collateralManagement;
+    IPegOutEscrow private _pegOutEscrow;
 
     mapping(bytes32 => Quotes.PegOutQuote) private _pegOutQuotes;
     mapping(bytes32 => PegOutRecord) private _pegOutRegistry;
@@ -76,6 +78,12 @@ contract PegOutContract is
     /// @param oldTime the old Bitcoin block time
     /// @param newTime the new Bitcoin block time
     event BtcBlockTimeSet(uint256 indexed oldTime, uint256 indexed newTime);
+    /// @notice Emitted when the commit-first PegOutEscrow is wired
+    event PegOutEscrowSet(address indexed oldAddress, address indexed newAddress);
+
+    error OnlyPegOutEscrow(address caller);
+    error PegOutEscrowNotSet();
+    error EscrowQuoteNotClaimed(bytes32 requestHash);
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -137,6 +145,60 @@ contract PegOutContract is
         if (!sent) {
             revert Flyover.PaymentFailed(quote.rskRefundAddress, change, reason);
         }
+    }
+
+    /// @inheritdoc IPegOut
+    function registerClaimedPegOut(
+        bytes32 requestHash,
+        bytes calldata signature
+    ) external payable override nonReentrant whenNotSoftPaused {
+        if (address(_pegOutEscrow) == address(0)) revert PegOutEscrowNotSet();
+        if (msg.sender != address(_pegOutEscrow)) {
+            revert OnlyPegOutEscrow(msg.sender);
+        }
+        // `depositTimestamp` is not cleared on settle, so the registered check alone would
+        // also block completed ids; keep `completed` first for a precise post-settlement revert.
+        if (_isQuoteCompleted(requestHash)) {
+            revert QuoteAlreadyCompleted(requestHash);
+        }
+        if (_pegOutRegistry[requestHash].depositTimestamp != 0) {
+            revert QuoteAlreadyRegistered(requestHash);
+        }
+
+        Quotes.PegOutQuote memory quote = _requireClaimedEscrowQuote(requestHash);
+        if (!_collateralManagement.isCollateralSufficient(_PEG_TYPE, quote.lpRskAddress)) {
+            revert Flyover.ProviderNotRegistered(quote.lpRskAddress);
+        }
+        uint256 requiredAmount = quote.value + quote.callFee + quote.gasFee;
+        if (msg.value != requiredAmount) {
+            revert Flyover.InsufficientAmount(msg.value, requiredAmount);
+        }
+        if (quote.depositDateLimit < block.timestamp || quote.expireDate < block.timestamp) {
+            revert QuoteExpiredByTime(quote.depositDateLimit, quote.expireDate);
+        }
+        if (quote.expireBlock < block.number) {
+            revert QuoteExpiredByBlocks(quote.expireBlock);
+        }
+
+        bytes32 eip712Hash = _hashPegOutQuoteEIP712(quote);
+        if (!SignatureValidator.verify(quote.lpRskAddress, eip712Hash, signature)) {
+            revert SignatureValidator.IncorrectSignature(quote.lpRskAddress, eip712Hash, signature);
+        }
+
+        _pegOutRegistry[requestHash].depositTimestamp = block.timestamp;
+        _pegOutRegistry[requestHash].depositBlock = block.number;
+
+        emit PegOutDeposit(requestHash, quote.lpRskAddress, block.timestamp, msg.value);
+    }
+
+    /// @notice Wires the commit-first PegOutEscrow (only that address may call registerClaimedPegOut)
+    // solhint-disable-next-line comprehensive-interface
+    function setPegOutEscrow(address pegOutEscrow_) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (pegOutEscrow_ != address(0) && pegOutEscrow_.code.length == 0) {
+            revert Flyover.NoContract(pegOutEscrow_);
+        }
+        emit PegOutEscrowSet(address(_pegOutEscrow), pegOutEscrow_);
+        _pegOutEscrow = IPegOutEscrow(pegOutEscrow_);
     }
 
     /// @notice This function is used to initialize the contract
@@ -331,12 +393,25 @@ contract PegOutContract is
         }
     }
 
+    /// @notice Escrow CLAIMED quote required for {registerClaimedPegOut}.
+    function _requireClaimedEscrowQuote(bytes32 requestHash)
+        private
+        view
+        returns (Quotes.PegOutQuote memory quote)
+    {
+        if (address(_pegOutEscrow) == address(0)) revert PegOutEscrowNotSet();
+        if (_pegOutEscrow.getPegOutState(requestHash) != IPegOutEscrow.EscrowedPegOutState.CLAIMED) {
+            revert EscrowQuoteNotClaimed(requestHash);
+        }
+        quote = _pegOutEscrow.getPegOutQuote(requestHash);
+    }
+
     /// @notice This function is used to hash a peg out quote
     /// @dev The function also validates the quote belongs to this contract
     /// @param quote the peg out quote to hash
     /// @return quoteHash the hash of the peg out quote
     function _hashPegOutQuote(
-        Quotes.PegOutQuote calldata quote
+        Quotes.PegOutQuote memory quote
     ) private view returns (bytes32) {
         _validatePegOutQuote(quote);
         return keccak256(Quotes.encodePegOutQuote(quote));
@@ -346,14 +421,14 @@ contract PegOutContract is
     /// @dev The function also validates the quote belongs to this contract
     /// @param quote the peg out quote to hash
     /// @return quoteHash the hash of the peg out quote
-    function _hashPegOutQuoteEIP712(Quotes.PegOutQuote calldata quote) private view returns (bytes32) {
+    function _hashPegOutQuoteEIP712(Quotes.PegOutQuote memory quote) private view returns (bytes32) {
         _validatePegOutQuote(quote);
         return _hashTypedDataV4(Quotes.hashPegOutQuoteEIP712(quote));
     }
 
     /// @notice This function is used to validate a peg out quote before hashing it
     /// @param quote The peg out quote to validate
-    function _validatePegOutQuote(Quotes.PegOutQuote calldata quote) private view {
+    function _validatePegOutQuote(Quotes.PegOutQuote memory quote) private view {
         if (quote.chainId != block.chainid) {
             revert Flyover.InvalidChainId(block.chainid, quote.chainId);
         }

--- a/src/PegOutEscrow.sol
+++ b/src/PegOutEscrow.sol
@@ -13,6 +13,7 @@ import {IPegOut} from "./interfaces/IPegOut.sol";
 import {IPegOutEscrow} from "./interfaces/IPegOutEscrow.sol";
 import {Flyover} from "./libraries/Flyover.sol";
 import {Quotes} from "./libraries/Quotes.sol";
+import {SignatureValidator} from "./libraries/SignatureValidator.sol";
 
 /// @title PegOutEscrow
 /// @notice Commit-first peg-out escrow. User deposits RBTC first; LPs claim and settle via
@@ -172,9 +173,42 @@ contract PegOutEscrow is
     }
 
     /// @inheritdoc IPegOutEscrow
-    // TODO: implement claim path (LP signature, collateral check, registerClaimedPegOut)
-    function claimPegOut(bytes32, bytes calldata) external override {
-        revert PegOutPathNotImplemented();
+    function claimPegOut(bytes32 requestHash, bytes calldata signature)
+        external
+        override
+        nonReentrant
+        whenNotSoftPaused
+    {
+        PegOutEscrowStorage storage $ = _getStorage();
+        _requireRequested($, requestHash);
+
+        Quotes.PegOutQuote storage q = $.quotes[requestHash];
+        if (block.timestamp > q.depositDateLimit) {
+            revert ClaimWindowClosed(q.depositDateLimit);
+        }
+        if (address($.collateralManagement) == address(0)) revert CollateralManagementNotSet();
+        if (!$.collateralManagement.isRegistered(Flyover.ProviderType.PegOut, msg.sender)) {
+            revert Flyover.ProviderNotRegistered(msg.sender);
+        }
+        if (!$.collateralManagement.isCollateralSufficient(Flyover.ProviderType.PegOut, msg.sender)) {
+            revert IPegOut.InsufficientCollateral(
+                $.collateralManagement.getPegOutCollateral(msg.sender)
+            );
+        }
+
+        q.lpRskAddress = msg.sender;
+        Quotes.PegOutQuote memory signedQuote = q;
+        bytes32 eip712Hash = $.pegOutContract.hashPegOutQuoteEIP712(signedQuote);
+        if (!SignatureValidator.verify(msg.sender, eip712Hash, signature)) {
+            revert SignatureValidator.IncorrectSignature(msg.sender, eip712Hash, signature);
+        }
+
+        $.state[requestHash] = EscrowedPegOutState.CLAIMED;
+
+        uint256 valueToSend = q.value + q.callFee + q.gasFee;
+        emit PegOutClaimed(msg.sender, requestHash);
+
+        $.pegOutContract.registerClaimedPegOut{value: valueToSend}(requestHash, signature);
     }
 
     /// @inheritdoc IPegOutEscrow

--- a/src/interfaces/IPegOut.sol
+++ b/src/interfaces/IPegOut.sol
@@ -128,13 +128,19 @@ interface IPegOut is IPausable, IERC5267 {
     /// @param amount The amount of the withdrawal
     function withdraw(address payable addr, uint256 amount) external;
 
-    /// @notice This is the function used to pay for a peg out quote. This is the only correct function to execute
-    /// such payment, sending money directly to the contract does not work.
-    /// The user is expected to and is responsible for reviewing all fields of the quote, as they comprehend the terms
-    /// of the service agreed with the LP before paying.
+    /// @notice Legacy quote path: user pays a pre-signed peg-out quote
+    /// @dev Commit-first flow uses {registerClaimedPegOut} instead; this remains for existing LPS/SDK.
+    /// TODO: drop this when Commit-first flow is complete.
     /// @param quote The quote that is being paid
     /// @param signature The signature of the quote hash provided by the liquidity provider after the quote acceptance
     function depositPegOut(Quotes.PegOutQuote calldata quote, bytes calldata signature) external payable;
+
+    /// @notice Commit-first path: PegOutEscrow registers a claimed peg-out under the request hash
+    /// @dev Only callable by the wired PegOutEscrow. Quote terms stay on escrow; this contract records
+    /// claim timing / completion and holds the forwarded RBTC.
+    /// @param requestHash Escrow-minted request id
+    /// @param signature LP EIP-712 signature over the escrowed quote (with lpRskAddress set)
+    function registerClaimedPegOut(bytes32 requestHash, bytes calldata signature) external payable;
 
     /// @notice This function is used by the liquidity provider to recover the funds spent on the peg out service plus
     /// their fee for the service. It proves the inclusion of the transaction paying to the user in the Bitcoin network.

--- a/test/pegout-escrow/PegOutEscrow.t.sol
+++ b/test/pegout-escrow/PegOutEscrow.t.sol
@@ -4,32 +4,20 @@ pragma solidity 0.8.25;
 import {Test} from "forge-std/Test.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {PegOutEscrow} from "../../src/PegOutEscrow.sol";
+import {PegOutContract} from "../../src/PegOutContract.sol";
 import {PauseRegistry} from "../../src/PauseRegistry.sol";
+import {ICollateralManagement} from "../../src/interfaces/ICollateralManagement.sol";
+import {IPegOut} from "../../src/interfaces/IPegOut.sol";
 import {IPegOutEscrow} from "../../src/interfaces/IPegOutEscrow.sol";
 import {IFlyoverConfigurations} from "../../src/interfaces/IFlyoverConfigurations.sol";
 import {Flyover} from "../../src/libraries/Flyover.sol";
 import {Quotes} from "../../src/libraries/Quotes.sol";
+import {SignatureValidator} from "../../src/libraries/SignatureValidator.sol";
+import {BridgeMock} from "../../src/test-contracts/BridgeMock.sol";
+import {CollateralManagementMock} from "../../src/test-contracts/CollateralManagementMock.sol";
 import {FlyoverConfigurationsMock} from "../pegin/FlyoverConfigurationsMock.sol";
 
-/// @dev Minimal PegOut stand-in: only `dustThreshold` (public getter) is read by escrow.
-contract PegOutDustMock {
-    uint256 public dustThreshold;
-
-    constructor(uint256 dustThreshold_) {
-        dustThreshold = dustThreshold_;
-    }
-
-    function setDustThreshold(uint256 dustThreshold_) external {
-        dustThreshold = dustThreshold_;
-    }
-}
-
-/// @dev Satisfies initialize code.length checks; unused by request/cancel.
-contract CodeStub {
-
-}
-
-/// @title PegOutEscrow request + cancel
+/// @title PegOutEscrow request, cancel, and claimPegOut
 contract PegOutEscrowTest is Test {
     /// @dev Mirrors impl-only {PegOutEscrow.EscrowPegOutChangePaid} for expectEmit.
     event EscrowPegOutChangePaid(
@@ -51,18 +39,28 @@ contract PegOutEscrowTest is Test {
     uint256 internal constant PENALTY_FEE = 0.01 ether;
     uint256 internal constant TIER_CONFIRMATIONS = 6;
     uint256 internal constant BASIS = 10_000;
+    uint256 internal constant BTC_BLOCK_TIME = 3600;
 
     /// @dev msg.value that yields a serviceable principal near 1 ether under the seed config.
     uint256 internal constant DEFAULT_VALUE = 1.012 ether;
 
+    /// @dev ERC-7201 PegOutEscrow storage root (matches PegOutEscrow._PEGOUT_ESCROW_STORAGE).
+    bytes32 internal constant PEGOUT_ESCROW_STORAGE =
+        0xb99c8d82bac3ff4ec6a3e7ff5aa17dda321aa2a152ae7dc22fe007bc5dcb3000;
+
     PegOutEscrow internal escrow;
+    PegOutContract internal pegOut;
     FlyoverConfigurationsMock internal configurations;
-    PegOutDustMock internal pegOut;
+    CollateralManagementMock internal collateral;
     PauseRegistry internal pauseRegistry;
 
     address internal owner;
     address internal user;
     address internal other;
+    address internal lp;
+    uint256 internal lpKey;
+    address internal otherLp;
+    uint256 internal otherLpKey;
 
     bytes internal constant DEST =
         hex"0014deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
@@ -71,8 +69,12 @@ contract PegOutEscrowTest is Test {
         owner = makeAddr("owner");
         user = makeAddr("user");
         other = makeAddr("other");
+        (lp, lpKey) = makeAddrAndKey("lp");
+        (otherLp, otherLpKey) = makeAddrAndKey("otherLp");
         vm.deal(user, 100 ether);
         vm.deal(other, 100 ether);
+        vm.deal(lp, 100 ether);
+        vm.deal(otherLp, 100 ether);
 
         PauseRegistry prImpl = new PauseRegistry();
         pauseRegistry = PauseRegistry(
@@ -87,8 +89,31 @@ contract PegOutEscrowTest is Test {
         );
 
         configurations = new FlyoverConfigurationsMock();
-        pegOut = new PegOutDustMock(DUST);
-        CodeStub collateral = new CodeStub();
+        collateral = new CollateralManagementMock();
+
+        BridgeMock bridge = new BridgeMock();
+        PegOutContract pegOutImpl = new PegOutContract();
+        pegOut = PegOutContract(
+            payable(
+                address(
+                    new ERC1967Proxy(
+                        address(pegOutImpl),
+                        abi.encodeCall(
+                            pegOutImpl.initialize,
+                            (
+                                owner,
+                                payable(address(bridge)),
+                                DUST,
+                                address(collateral),
+                                false,
+                                BTC_BLOCK_TIME,
+                                pauseRegistry
+                            )
+                        )
+                    )
+                )
+            )
+        );
 
         PegOutEscrow impl = new PegOutEscrow();
         escrow = PegOutEscrow(
@@ -111,6 +136,9 @@ contract PegOutEscrowTest is Test {
                 )
             )
         );
+
+        vm.prank(owner);
+        pegOut.setPegOutEscrow(address(escrow));
 
         _seedPegOutConfig();
     }
@@ -236,6 +264,7 @@ contract PegOutEscrowTest is Test {
     }
 
     function test_requestPegOut_changeAtOrAboveDust_isRefunded() public {
+        vm.prank(owner);
         pegOut.setDustThreshold(1 wei);
 
         // Pick a value whose residual after split is clearly >= 1 wei.
@@ -269,6 +298,7 @@ contract PegOutEscrowTest is Test {
     }
 
     function test_requestPegOut_changeBelowDust_foldedIntoCallFee() public {
+        vm.prank(owner);
         pegOut.setDustThreshold(type(uint256).max);
 
         uint256 value = 2 ether;
@@ -380,13 +410,176 @@ contract PegOutEscrowTest is Test {
     }
 
     // -------------------------------------------------------------------------
+    // claimPegOut
+    // -------------------------------------------------------------------------
+
+    function test_claimPegOut_happyPath_lpAnchorFundsAndClaimed() public {
+        bytes32 requestHash = _requestDefault();
+        Quotes.PegOutQuote memory quote = escrow.getPegOutQuote(requestHash);
+        uint256 payout = quote.value + quote.callFee + quote.gasFee;
+        uint256 pegOutBefore = address(pegOut).balance;
+        uint256 escrowBefore = address(escrow).balance;
+
+        bytes memory signature = _signForLp(lpKey, quote, lp);
+        uint256 claimTs = block.timestamp;
+
+        vm.expectEmit(true, true, false, true, address(escrow));
+        emit IPegOutEscrow.PegOutClaimed(lp, requestHash);
+        // Claim timestamp is readable via PegOutDeposit (no public registry getter).
+        vm.expectEmit(true, true, true, true, address(pegOut));
+        emit IPegOut.PegOutDeposit(requestHash, lp, claimTs, payout);
+
+        vm.prank(lp);
+        escrow.claimPegOut(requestHash, signature);
+
+        assertEq(
+            uint256(escrow.getPegOutState(requestHash)),
+            uint256(IPegOutEscrow.EscrowedPegOutState.CLAIMED)
+        );
+        assertEq(escrow.getPegOutQuote(requestHash).lpRskAddress, lp);
+        assertEq(address(pegOut).balance, pegOutBefore + payout);
+        assertEq(address(escrow).balance, escrowBefore - payout);
+    }
+
+    function test_claimPegOut_secondClaim_revertsInvalidState() public {
+        bytes32 requestHash = _requestDefault();
+        Quotes.PegOutQuote memory quote = escrow.getPegOutQuote(requestHash);
+        bytes memory signature = _signForLp(lpKey, quote, lp);
+
+        vm.prank(lp);
+        escrow.claimPegOut(requestHash, signature);
+
+        bytes memory otherSig = _signForLp(otherLpKey, quote, otherLp);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegOutEscrow.InvalidState.selector,
+                requestHash,
+                IPegOutEscrow.EscrowedPegOutState.REQUESTED,
+                IPegOutEscrow.EscrowedPegOutState.CLAIMED
+            )
+        );
+        vm.prank(otherLp);
+        escrow.claimPegOut(requestHash, otherSig);
+    }
+
+    function test_claimPegOut_afterCancel_revertsInvalidState() public {
+        bytes32 requestHash = _requestDefault();
+        Quotes.PegOutQuote memory quote = escrow.getPegOutQuote(requestHash);
+        bytes memory signature = _signForLp(lpKey, quote, lp);
+
+        vm.prank(user);
+        escrow.cancelPegOut(requestHash);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegOutEscrow.InvalidState.selector,
+                requestHash,
+                IPegOutEscrow.EscrowedPegOutState.REQUESTED,
+                IPegOutEscrow.EscrowedPegOutState.CANCELLED
+            )
+        );
+        vm.prank(lp);
+        escrow.claimPegOut(requestHash, signature);
+    }
+
+    function test_claimPegOut_afterRefund_revertsInvalidState() public {
+        bytes32 requestHash = _requestDefault();
+        Quotes.PegOutQuote memory quote = escrow.getPegOutQuote(requestHash);
+        bytes memory signature = _signForLp(lpKey, quote, lp);
+
+        _forceEscrowState(
+            requestHash,
+            IPegOutEscrow.EscrowedPegOutState.REFUNDED
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegOutEscrow.InvalidState.selector,
+                requestHash,
+                IPegOutEscrow.EscrowedPegOutState.REQUESTED,
+                IPegOutEscrow.EscrowedPegOutState.REFUNDED
+            )
+        );
+        vm.prank(lp);
+        escrow.claimPegOut(requestHash, signature);
+    }
+
+    function test_claimPegOut_notRegistered_reverts() public {
+        bytes32 requestHash = _requestDefault();
+        Quotes.PegOutQuote memory quote = escrow.getPegOutQuote(requestHash);
+        bytes memory signature = _signForLp(lpKey, quote, lp);
+
+        vm.mockCall(
+            address(collateral),
+            abi.encodeCall(
+                ICollateralManagement.isRegistered,
+                (Flyover.ProviderType.PegOut, lp)
+            ),
+            abi.encode(false)
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(Flyover.ProviderNotRegistered.selector, lp)
+        );
+        vm.prank(lp);
+        escrow.claimPegOut(requestHash, signature);
+    }
+
+    function test_claimPegOut_underCollateralized_reverts() public {
+        bytes32 requestHash = _requestDefault();
+        Quotes.PegOutQuote memory quote = escrow.getPegOutQuote(requestHash);
+        bytes memory signature = _signForLp(lpKey, quote, lp);
+
+        uint256 lowCollateral = 0.1 ether;
+        vm.mockCall(
+            address(collateral),
+            abi.encodeCall(
+                ICollateralManagement.isCollateralSufficient,
+                (Flyover.ProviderType.PegOut, lp)
+            ),
+            abi.encode(false)
+        );
+        vm.mockCall(
+            address(collateral),
+            abi.encodeCall(ICollateralManagement.getPegOutCollateral, (lp)),
+            abi.encode(lowCollateral)
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegOut.InsufficientCollateral.selector,
+                lowCollateral
+            )
+        );
+        vm.prank(lp);
+        escrow.claimPegOut(requestHash, signature);
+    }
+
+    function test_claimPegOut_badSignature_reverts() public {
+        bytes32 requestHash = _requestDefault();
+        Quotes.PegOutQuote memory quote = escrow.getPegOutQuote(requestHash);
+        bytes memory badSignature = _signForLp(otherLpKey, quote, lp);
+
+        quote.lpRskAddress = lp;
+        bytes32 eip712Hash = pegOut.hashPegOutQuoteEIP712(quote);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                SignatureValidator.IncorrectSignature.selector,
+                lp,
+                eip712Hash,
+                badSignature
+            )
+        );
+        vm.prank(lp);
+        escrow.claimPegOut(requestHash, badSignature);
+    }
+
+    // -------------------------------------------------------------------------
     // stubs
     // -------------------------------------------------------------------------
 
     function test_stubs_revertNotImplemented() public {
-        vm.expectRevert(PegOutEscrow.PegOutPathNotImplemented.selector);
-        escrow.claimPegOut(bytes32(0), "");
-
         vm.expectRevert(PegOutEscrow.PegOutPathNotImplemented.selector);
         escrow.refundOnNoClaim(bytes32(0));
 
@@ -400,6 +593,32 @@ contract PegOutEscrowTest is Test {
     // -------------------------------------------------------------------------
     // helpers
     // -------------------------------------------------------------------------
+
+    function _requestDefault() internal returns (bytes32 requestHash) {
+        vm.prank(user);
+        requestHash = escrow.requestPegOut{value: DEFAULT_VALUE}(DEST, user);
+    }
+
+    function _signForLp(
+        uint256 privateKey,
+        Quotes.PegOutQuote memory quote,
+        address lpAddress
+    ) internal view returns (bytes memory) {
+        quote.lpRskAddress = lpAddress;
+        bytes32 eip712Hash = pegOut.hashPegOutQuoteEIP712(quote);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, eip712Hash);
+        return abi.encodePacked(r, s, v);
+    }
+
+    /// @dev `state` mapping is at struct offset 4 under the ERC-7201 root.
+    function _forceEscrowState(
+        bytes32 requestHash,
+        IPegOutEscrow.EscrowedPegOutState newState
+    ) internal {
+        bytes32 mappingSlot = bytes32(uint256(PEGOUT_ESCROW_STORAGE) + 4);
+        bytes32 loc = keccak256(abi.encode(requestHash, mappingSlot));
+        vm.store(address(escrow), loc, bytes32(uint256(uint8(newState))));
+    }
 
     function _seedPegOutConfig() internal {
         IFlyoverConfigurations.ConfirmationTier[]


### PR DESCRIPTION
## What

Implements `claimPegOut` on PegOutEscrow: an LP becomes responsible for delivery and the user's escrowed RBTC moves into PegOutContract in one transaction.

Adds a minimal settlement entry `registerClaimedPegOut` on PegOutContract (escrow-only), plus AC coverage in `test/pegout-escrow/PegOutEscrow.t.sol`.

Stacked on `feat/FLY-2543`.

## Why

Commit-first peg-out discovery is global, so claim is a race. The first check is state (`REQUESTED`), so a losing LP pays for a cheap revert. Claim is a hard commitment (no unclaim): collateral + signature bind the LP before funds leave escrow, and transfer + responsibility record must land atomically.

## Type of Change

- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Refactor (no intended behavior change)
- [ ] Security hardening
- [ ] Tests only
- [ ] Build/CI/Tooling
- [ ] Documentation

## Affected Areas

- [ ] PegIn flow (`registerPegIn`, `callForUser`, quote validation)
- [x] PegOut flow (`depositPegout`, `refundPegOut`, `refundUserPegOut`)
- [ ] Liquidity Provider lifecycle (register/update/status/resign/collateral/withdraw)
- [ ] Pause/operational controls
- [x] Quote hashing/signature logic
- [ ] Bitcoin tx / PMT / merkle validation
- [ ] Deployment or upgrade scripts / Makefile targets
- [ ] CI workflows (`ci`, `fuzz`, `formal`, `slither`, `codeql`)
- [ ] Docs

## Risk & Security Review

- [x] Access control and authorization paths reviewed
- [x] Reentrancy and external call paths reviewed
- [x] Storage layout / upgrade safety reviewed (if upgradeable code changed)
- [x] Time/block/confirmation assumptions reviewed
- [ ] BTC tx output/index assumptions reviewed (if pegout validation touched)
- [x] No secrets or sensitive values added

Notes:
- `PegOutContract` gains `_pegOutEscrow` storage before existing mappings (new wiring on this stack; review upgrade layout if this lands on already-deployed PegOut proxies).
- Legacy `depositPegOut` is left enabled (no `LegacyDepositDisabled` in this PR).

## Test Plan

List what you ran locally and the outcome:

- [ ] `npm run lint:sol`
- [ ] `npm run lint:ts`
- [ ] `npm run compile`
- [ ] `npm test`
- [ ] `npm run test:fuzz` (if logic/state transitions changed)
- [ ] `npm run test:invariant` (if invariant-sensitive logic changed)
- [ ] `npm run test:formal` (if formal-verification-sensitive logic changed)
- [ ] `npm run test:integration` (if integration paths changed)
- [ ] `npm run test:e2e` (if deployment/ownership flows changed)

Additional notes on test coverage, edge cases, and any tests intentionally skipped:

- Local: `forge test --match-path 'test/pegout-escrow/*'` (18 passed) and `forge test --match-path 'test/pegout/*'` during implementation.
- AC coverage for `claimPegOut`: second claim, claim after cancel, claim after refund (state forced to `REFUNDED` via storage write — `refundOnNoClaim` not in this PR), not registered / under-collateralized (`vm.mockCall` on `CollateralManagementMock`), bad signature, happy path (LP, funds, `PegOutDeposit` timestamp).
- `refundOnNoClaim` / `onSettlement` remain stubbed.

## Deployment & Ops Impact

- [ ] No deployment impact
- [x] Requires deployment
- [x] Requires upgrade
- [ ] Env/config changes required (`.env`, network RPCs, verification, etc.)
- [ ] Runbook/update instructions added to PR description

Requires PegOutEscrow + PegOutContract upgrades and admin `setPegOutEscrow(escrow)` on PegOutContract before claims can succeed.

## Related Issues

- Jira: [FLY-2544](https://rsklabs.atlassian.net/browse/FLY-2544)

## Reviewer Notes

**Claim order (escrow):** `REQUESTED` → registered → collateral sufficient → claim window → set `lpRskAddress` + EIP-712 verify → `CLAIMED` + `PegOutClaimed` → `registerClaimedPegOut{value}`.

**Minimal PegOut entry:** escrow-only `registerClaimedPegOut`; quote body stays on escrow; registry stores claim timestamp/block; emits `PegOutDeposit`.

**Intentional product notes (call out in review):**
1. **No public claim-anchor getter.** Anchors live in PegOutContract’s private registry. Claim timestamp is observable via `PegOutDeposit`; a view for block/timestamp can be added later if LPS/SDK need an on-chain read.
2. **Collateral gate split on the claim path** (`claimPegOut` and `registerClaimedPegOut`): `isRegistered` → `ProviderNotRegistered`, then `isCollateralSufficient` → `InsufficientCollateral`. Legacy `depositPegOut` still maps insufficient collateral to `ProviderNotRegistered`.
3. **`QuoteAlreadyCompleted` vs `QuoteAlreadyRegistered`:** `depositTimestamp` is not cleared on settle, so the registered check alone would also block completed ids; `completed` is checked first for a precise post-settlement revert (comment in code).
4. Out of scope: `refundOnNoClaim`, `onSettlement`, global slash, disabling legacy deposit, claim-fail discipline.
