### PR TITLE
Feat/fly 2545

### DIFF
--- a/src/CollateralManagement.sol
+++ b/src/CollateralManagement.sol
@@ -212,6 +212,13 @@ contract CollateralManagementContract is
     }
 
     /// @inheritdoc ICollateralManagement
+    /// @dev Stub until proportional global slash is implemented. Callers
+    ///      (e.g. PegOutEscrow.refundOnNoClaim) must not block user refunds on this reverting.
+    function globalSlash(uint256) external onlyRole(COLLATERAL_SLASHER) override {
+        revert GlobalSlashNotImplemented();
+    }
+
+    /// @inheritdoc ICollateralManagement
     function withdrawCollateral() external nonReentrant whenNotHardPaused override {
         _withdrawCollateralTo(payable(msg.sender));
     }

--- a/src/PegOutContract.sol
+++ b/src/PegOutContract.sol
@@ -309,9 +309,20 @@ contract PegOutContract is
 
     /// @inheritdoc IPegOut
     function refundUserPegOut(bytes32 quoteHash) external nonReentrant whenNotHardPaused override {
-        Quotes.PegOutQuote memory quote = _pegOutQuotes[quoteHash];
-
-        if (quote.lbcAddress == address(0)) revert Flyover.QuoteNotFound(quoteHash);
+        // TODO: after retiring depositPegOut, require escrow (revert PegOutEscrowNotSet) and drop the legacy branch.
+        Quotes.PegOutQuote memory quote;
+        if (address(_pegOutEscrow) == address(0)) {
+            // Legacy depositPegOut: replay after refund surfaces QuoteNotFound (quote body deleted).
+            quote = _pegOutQuotes[quoteHash];
+            if (quote.lbcAddress == address(0)) revert Flyover.QuoteNotFound(quoteHash);
+        } else {
+            // Commit-first: quote body lives on PegOutEscrow while CLAIMED.
+            if (_isQuoteCompleted(quoteHash)) revert QuoteAlreadyCompleted(quoteHash);
+            if (_pegOutEscrow.getPegOutState(quoteHash) != IPegOutEscrow.EscrowedPegOutState.CLAIMED) {
+                revert EscrowQuoteNotClaimed(quoteHash);
+            }
+            quote = _pegOutEscrow.getPegOutQuote(quoteHash);
+        }
 
         uint256 depositTs = _pegOutRegistry[quoteHash].depositTimestamp;
         uint256 depositBlock = _pegOutRegistry[quoteHash].depositBlock;
@@ -331,6 +342,7 @@ contract PegOutContract is
         _pegOutRegistry[quoteHash].completed = true;
 
         emit PegOutUserRefunded(quoteHash, addressToTransfer, valueToTransfer);
+        _notifyEscrowSettlement(quoteHash, IPegOutEscrow.EscrowedPegOutState.REFUNDED);
         _collateralManagement.slashPegOutCollateral(msg.sender, quote, quoteHash);
 
         (bool sent,) = addressToTransfer.call{value: valueToTransfer}("");
@@ -407,6 +419,22 @@ contract PegOutContract is
             revert EscrowQuoteNotClaimed(requestHash);
         }
         quote = _pegOutEscrow.getPegOutQuote(requestHash);
+    }
+
+    /// @notice Flip escrow CLAIMED → terminal when settlement finishes on this contract.
+    /// @dev Soft-skips when escrow is unset so legacy depositPegOut refunds still work.
+    /// TODO: after retiring depositPegOut, require escrow (PegOutEscrowNotSet) and
+    /// CLAIMED (EscrowQuoteNotClaimed) instead of early returns.
+    function _notifyEscrowSettlement(
+        bytes32 requestHash,
+        IPegOutEscrow.EscrowedPegOutState finalState
+    ) private {
+        if (address(_pegOutEscrow) == address(0)) return;
+        // Soft-skips non-CLAIMED ids (e.g. legacy depositPegOut refunds that never touched escrow).
+        if (_pegOutEscrow.getPegOutState(requestHash) != IPegOutEscrow.EscrowedPegOutState.CLAIMED) {
+            return;
+        }
+        _pegOutEscrow.onSettlement(requestHash, finalState);
     }
 
     /// @notice This function is used to hash a peg out quote

--- a/src/PegOutEscrow.sol
+++ b/src/PegOutEscrow.sol
@@ -29,7 +29,7 @@ contract PegOutEscrow is
     struct PegOutEscrowStorage {
         /// Settlement contract (claim forwards funds here; also supplies dustThreshold).
         IPegOut pegOutContract;
-        /// Collateral registry used by claim / no-claim slash (wired now; unused until those paths).
+        /// Collateral registry used by claim / no-claim global slash.
         ICollateralManagement collateralManagement;
         /// Active peg-out fee, bounds, deadlines, and confirmation tiers.
         IFlyoverConfigurations configurations;
@@ -212,15 +212,42 @@ contract PegOutEscrow is
     }
 
     /// @inheritdoc IPegOutEscrow
-    // TODO: implement no-claim refund after depositDateLimit (+ optional globalSlash)
-    function refundOnNoClaim(bytes32) external override {
-        revert PegOutPathNotImplemented();
+    function refundOnNoClaim(bytes32 requestHash) external override nonReentrant whenNotSoftPaused {
+        PegOutEscrowStorage storage $ = _getStorage();
+        _requireRequested($, requestHash);
+        Quotes.PegOutQuote memory q = $.quotes[requestHash];
+        // solhint-disable-next-line gas-strict-inequalities
+        if (block.timestamp <= q.depositDateLimit) {
+            revert ClaimWindowOpen(q.depositDateLimit);
+        }
+
+        uint256 payout = q.value + q.callFee + q.gasFee;
+        _terminate($, requestHash, EscrowedPegOutState.REFUNDED);
+        emit PegOutRefundedOnNoClaim(requestHash, q.rskRefundAddress, payout);
+
+        // If globalSlash reverts (stub / missing role / no eligible LPs), user still refunded.
+        if (address($.collateralManagement) == address(0)) revert CollateralManagementNotSet();
+        try $.collateralManagement.globalSlash(q.penaltyFee) {}
+        catch {
+            emit GlobalSlashSkipped(requestHash);
+        }
+
+        _payout(q.rskRefundAddress, payout);
     }
 
     /// @inheritdoc IPegOutEscrow
-    // TODO: implement PegOutContract settlement callback (CLAIMED → FULFILLED/REFUNDED)
-    function onSettlement(bytes32, EscrowedPegOutState) external override {
-        revert PegOutPathNotImplemented();
+    function onSettlement(bytes32 requestHash, EscrowedPegOutState finalState) external override {
+        PegOutEscrowStorage storage $ = _getStorage();
+        if (msg.sender != address($.pegOutContract)) {
+            revert OnlyPegOutContract(msg.sender);
+        }
+        if ($.state[requestHash] != EscrowedPegOutState.CLAIMED) {
+            revert InvalidState(requestHash, EscrowedPegOutState.CLAIMED, $.state[requestHash]);
+        }
+        if (finalState != EscrowedPegOutState.FULFILLED && finalState != EscrowedPegOutState.REFUNDED) {
+            revert InvalidState(requestHash, EscrowedPegOutState.FULFILLED, finalState);
+        }
+        _terminate($, requestHash, finalState);
     }
 
     /// @inheritdoc IPegOutEscrow

--- a/src/interfaces/ICollateralManagement.sol
+++ b/src/interfaces/ICollateralManagement.sol
@@ -87,6 +87,9 @@ interface ICollateralManagement is IPausable {
     /// @param minCollateral The minimum collateral that was invalid
     error MinCollateralTooLow(uint256 minCollateral);
 
+    /// @notice Raised when {globalSlash} is called before it is implemented
+    error GlobalSlashNotImplemented();
+
     /// @notice Adds peg in collateral to an account
     /// @param addr The address of the account
     /// @dev This function requires the COLLATERAL_ADDER role
@@ -138,6 +141,15 @@ interface ICollateralManagement is IPausable {
         Quotes.PegOutQuote calldata quote,
         bytes32 quoteHash
     ) external;
+
+    /// @notice Slashes `total` proportionally across registered LPs past the grace window.
+    /// @dev Used when a serviceable request goes unclaimed (peg-in unclaimed settle;
+    /// peg-out {IPegOutEscrow-refundOnNoClaim}). Requires the COLLATERAL_SLASHER role.
+    /// Drains peg-in collateral first, then peg-out. Part of `total` may be paid as a
+    /// punisher reward using the same split as individual slashes. Until the proportional
+    /// slash is implemented, callers may see {GlobalSlashNotImplemented}.
+    /// @param total Aggregate penalty amount to distribute across eligible LPs
+    function globalSlash(uint256 total) external;
 
     /// @notice Withdraws rewards from the contract. Sends to the caller. Use withdrawRewards(address payable to)
     /// to send to a different address (e.g. if the caller cannot receive ETH).

--- a/src/test-contracts/CollateralManagementMock.sol
+++ b/src/test-contracts/CollateralManagementMock.sol
@@ -9,6 +9,15 @@ import {Quotes} from "../libraries/Quotes.sol";
 contract CollateralManagementMock is ICollateralManagement {
 
     uint256 private _balance;
+    /// @dev When true, {globalSlash} reverts so callers can exercise skip paths.
+    bool public globalSlashReverts = true;
+    /// @dev Incremented on each successful {globalSlash} call.
+    uint256 public globalSlashCalls;
+    uint256 public lastGlobalSlashTotal;
+
+    function setGlobalSlashReverts(bool reverts_) external {
+        globalSlashReverts = reverts_;
+    }
 
     function addPegInCollateralTo(address) external payable {
         _balance += msg.value;
@@ -32,6 +41,14 @@ contract CollateralManagementMock is ICollateralManagement {
 
     function slashPegOutCollateral(address, Quotes.PegOutQuote calldata, bytes32) external {
         emit Penalized(address(0), address(0), bytes32(0), Flyover.ProviderType.PegOut, 0, 0);
+    }
+
+    function globalSlash(uint256 total) external {
+        if (globalSlashReverts) {
+            revert GlobalSlashNotImplemented();
+        }
+        globalSlashCalls += 1;
+        lastGlobalSlashTotal = total;
     }
 
     function withdrawRewards() external {

--- a/test/pegout-escrow/PegOutEscrow.t.sol
+++ b/test/pegout-escrow/PegOutEscrow.t.sol
@@ -576,18 +576,117 @@ contract PegOutEscrowTest is Test {
     }
 
     // -------------------------------------------------------------------------
-    // stubs
+    // deadline refunds (acceptance)
     // -------------------------------------------------------------------------
 
-    function test_stubs_revertNotImplemented() public {
-        vm.expectRevert(PegOutEscrow.PegOutPathNotImplemented.selector);
-        escrow.refundOnNoClaim(bytes32(0));
+    function test_refundOnNoClaim_beforeDeadline_reverts() public {
+        bytes32 requestHash = _requestDefault();
+        uint256 depositDateLimit = escrow
+            .getPegOutQuote(requestHash)
+            .depositDateLimit;
 
-        vm.expectRevert(PegOutEscrow.PegOutPathNotImplemented.selector);
-        escrow.onSettlement(
-            bytes32(0),
-            IPegOutEscrow.EscrowedPegOutState.FULFILLED
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegOutEscrow.ClaimWindowOpen.selector,
+                depositDateLimit
+            )
         );
+        vm.prank(other);
+        escrow.refundOnNoClaim(requestHash);
+    }
+
+    function test_refundUserPegOut_beforeExpire_reverts() public {
+        bytes32 requestHash = _claimDefault();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegOut.QuoteNotExpired.selector,
+                requestHash
+            )
+        );
+        vm.prank(other);
+        pegOut.refundUserPegOut(requestHash);
+    }
+
+    function test_refundOnNoClaim_afterDeadline_anyoneRefundsAndAttemptsGlobalSlash()
+        public
+    {
+        bytes32 requestHash = _requestDefault();
+        Quotes.PegOutQuote memory q = escrow.getPegOutQuote(requestHash);
+        uint256 payout = q.value + q.callFee + q.gasFee;
+        uint256 userBefore = user.balance;
+
+        vm.warp(uint256(q.depositDateLimit) + 1);
+
+        vm.expectEmit(true, true, false, true, address(escrow));
+        emit IPegOutEscrow.PegOutRefundedOnNoClaim(requestHash, user, payout);
+        vm.expectEmit(true, false, false, true, address(escrow));
+        emit IPegOutEscrow.GlobalSlashSkipped(requestHash);
+
+        vm.prank(other);
+        escrow.refundOnNoClaim(requestHash);
+
+        assertEq(
+            uint256(escrow.getPegOutState(requestHash)),
+            uint256(IPegOutEscrow.EscrowedPegOutState.REFUNDED)
+        );
+        assertEq(user.balance, userBefore + payout);
+    }
+
+    function test_cancelPegOut_doesNotCallGlobalSlash() public {
+        collateral.setGlobalSlashReverts(false);
+
+        bytes32 requestHash = _requestDefault();
+        vm.prank(user);
+        escrow.cancelPegOut(requestHash);
+
+        assertEq(collateral.globalSlashCalls(), 0);
+        assertEq(
+            uint256(escrow.getPegOutState(requestHash)),
+            uint256(IPegOutEscrow.EscrowedPegOutState.CANCELLED)
+        );
+    }
+
+    function test_refundUserPegOut_afterExpire_anyoneRefundsIndividualSlashAndLateReverts()
+        public
+    {
+        bytes32 requestHash = _claimDefault();
+        Quotes.PegOutQuote memory q = escrow.getPegOutQuote(requestHash);
+        uint256 payout = q.value + q.callFee + q.gasFee;
+        uint256 userBefore = user.balance;
+
+        _warpPastFulfillment(q);
+
+        vm.expectEmit(true, true, false, true, address(pegOut));
+        emit IPegOut.PegOutUserRefunded(requestHash, user, payout);
+        vm.expectEmit(true, true, true, true, address(collateral));
+        emit ICollateralManagement.Penalized(
+            address(0),
+            address(0),
+            bytes32(0),
+            Flyover.ProviderType.PegOut,
+            0,
+            0
+        );
+
+        vm.prank(other);
+        pegOut.refundUserPegOut(requestHash);
+
+        assertEq(user.balance, userBefore + payout);
+        assertTrue(pegOut.isQuoteCompleted(requestHash));
+        assertEq(
+            uint256(escrow.getPegOutState(requestHash)),
+            uint256(IPegOutEscrow.EscrowedPegOutState.REFUNDED)
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegOut.QuoteAlreadyCompleted.selector,
+                requestHash
+            )
+        );
+        vm.prank(other);
+        pegOut.refundUserPegOut(requestHash);
     }
 
     // -------------------------------------------------------------------------
@@ -597,6 +696,19 @@ contract PegOutEscrowTest is Test {
     function _requestDefault() internal returns (bytes32 requestHash) {
         vm.prank(user);
         requestHash = escrow.requestPegOut{value: DEFAULT_VALUE}(DEST, user);
+    }
+
+    function _claimDefault() internal returns (bytes32 requestHash) {
+        requestHash = _requestDefault();
+        Quotes.PegOutQuote memory quote = escrow.getPegOutQuote(requestHash);
+        bytes memory signature = _signForLp(lpKey, quote, lp);
+        vm.prank(lp);
+        escrow.claimPegOut(requestHash, signature);
+    }
+
+    function _warpPastFulfillment(Quotes.PegOutQuote memory q) internal {
+        vm.warp(uint256(q.expireDate) + 1);
+        vm.roll(uint256(q.expireBlock) + 1);
     }
 
     function _signForLp(


### PR DESCRIPTION
## What

Adds the two deadline-driven refund exits on PegOutEscrow and wires them to slash hooks:

- **`refundOnNoClaim`**: after the claim window (`depositDateLimit`), anyone can refund the user from escrow, set `REFUNDED`, and attempt `globalSlash` (user payout does not depend on slash success; failures emit `GlobalSlashSkipped`).
- **`onSettlement`**: PegOutContract notifies escrow when a claimed peg-out finishes as `REFUNDED` (also accepts `FULFILLED` for later settlement wiring).
- **`refundUserPegOut`**: when PegOutEscrow is set, loads the `CLAIMED` quote from escrow, refunds the user, individual-slashes via existing `slashPegOutCollateral`, then calls `onSettlement(REFUNDED)`. Legacy `depositPegOut` path remains when escrow is unset (`QuoteNotFound` on replay).
- **`ICollateralManagement.globalSlash`**: role-gated stub that reverts `GlobalSlashNotImplemented` until the real proportional slash lands.

Acceptance-focused PegOutEscrow tests cover: blocked before deadline, permissionless refund after deadline + global slash attempt, cancel does not call global slash, claimed-unfulfilled refund + individual slash + late replay revert.

## Why

With commit-first peg-out, an unclaimed request past the claim deadline and a claimed-but-unfulfilled request past fulfillment expiry must refund the user without leaving funds stuck, while keeping cancellation (no slash) distinct from deadline refunds (network / LP fault → slash hooks).

## Type of Change

- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Refactor (no intended behavior change)
- [ ] Security hardening
- [ ] Tests only
- [ ] Build/CI/Tooling
- [ ] Documentation

## Affected Areas

- [ ] PegIn flow (`registerPegIn`, `callForUser`, quote validation)
- [x] PegOut flow (`depositPegout`, `refundPegOut`, `refundUserPegOut`)
- [ ] Liquidity Provider lifecycle (register/update/status/resign/collateral/withdraw)
- [ ] Pause/operational controls
- [ ] Quote hashing/signature logic
- [ ] Bitcoin tx / PMT / merkle validation
- [ ] Deployment or upgrade scripts / Makefile targets
- [ ] CI workflows (`ci`, `fuzz`, `formal`, `slither`, `codeql`)
- [ ] Docs

Also touches: `PegOutEscrow`, `ICollateralManagement` / `CollateralManagement` (globalSlash stub), collateral mock, PegOutEscrow unit tests.

## Risk & Security Review

- [x] Access control and authorization paths reviewed
- [x] Reentrancy and external call paths reviewed
- [x] Storage layout / upgrade safety reviewed (if upgradeable code changed)
- [x] Time/block/confirmation assumptions reviewed
- [ ] BTC tx output/index assumptions reviewed (if pegout validation touched)
- [x] No secrets or sensitive values added

Notes:
- `refundOnNoClaim` / `refundUserPegOut` are permissionless after their deadlines; payout goes to the snapshotted refund address.
- Global slash is try/catch’d so a stub/missing-role/revert cannot block the user refund.
- Escrow soft-skips in `_notifyEscrowSettlement` when unset or not `CLAIMED` (legacy coexistence); TODOs mark hardening after `depositPegOut` retirement.
- `globalSlash` body is intentionally unimplemented (stub only).

## Test Plan

List what you ran locally and the outcome:

- [x] `npm run lint:sol` (error fixed; remaining warnings pre-existing / non-blocking)
- [x] `npm run lint:ts`
- [ ] `npm run compile`
- [x] `npm test`
- [ ] `npm run test:fuzz` (if logic/state transitions changed)
- [ ] `npm run test:invariant` (if invariant-sensitive logic changed)
- [ ] `npm run test:formal` (if formal-verification-sensitive logic changed)
- [ ] `npm run test:integration` (if integration paths changed)
- [ ] `npm run test:e2e` (if deployment/ownership flows changed)

Additional notes on test coverage, edge cases, and any tests intentionally skipped:

```bash
forge test --match-path 'test/pegout-escrow/*'
forge test --match-path 'test/pegout/UserRefund.t.sol'
```

Both green. Coverage is acceptance-oriented for the two deadline exits + cancel vs global-slash distinction; full proportional `globalSlash` math and SPV `FULFILLED` notify are out of scope.

## Deployment & Ops Impact

- [ ] No deployment impact
- [x] Requires deployment
- [x] Requires upgrade
- [ ] Env/config changes required (`.env`, network RPCs, verification, etc.)
- [ ] Runbook/update instructions added to PR description

Upgradeable contracts touched: PegOutEscrow, PegOutContract, CollateralManagement. After deploy, PegOutEscrow must be wired (`setPegOutEscrow` / escrow deps) and should hold `COLLATERAL_SLASHER` before a real `globalSlash` body is enabled (today the stub reverts and is skipped).

## Related Issues

- Jira: [FLY-2545](https://rsklabs.atlassian.net/browse/FLY-2545)

## Reviewer Notes

- Focus on fund custody: no-claim refund pays from **escrow**; claimed-unfulfilled refund pays from **PegOutContract**.
- Three exits: cancel (no slash), no-claim refund (global slash attempt), claimed timeout (`slashPegOutCollateral` on responsible LP).
- `refundUserPegOut` branches on `address(_pegOutEscrow) == 0` (legacy) vs set (commit-first); `QuoteAlreadyCompleted` is only on the commit-first branch so legacy replay stays `QuoteNotFound`.
- Do not expect a working global slash distribution yet — interface + stub + try/catch wiring only.
- `onSettlement` accepts `FULFILLED` | `REFUNDED`, but this PR only notifies `REFUNDED` from `refundUserPegOut` (SPV path notify deferred).