### PR TITLE
Feat/fly 2546

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,10 @@ help:
 	@echo "  deploy-pegin-broadcast   - Deploy PegInContract (actual deployment)"
 	@echo "  deploy-pegout-fork       - Deploy PegOutContract (fork simulation)"
 	@echo "  deploy-pegout-broadcast  - Deploy PegOutContract (actual deployment)"
+	@echo "  deploy-flyover-configurations-fork - Deploy FlyoverConfigurations (fork simulation)"
+	@echo "  deploy-flyover-configurations-broadcast - Deploy FlyoverConfigurations (actual deployment)"
+	@echo "  deploy-pegout-escrow-fork - Deploy PegOutEscrow (fork simulation)"
+	@echo "  deploy-pegout-escrow-broadcast - Deploy PegOutEscrow (actual deployment)"
 	@echo ""
 	@echo "Legacy LBC Deployment:"
 	@echo "  deploy-lbc-fork        - Deploy LiquidityBridgeContract (fork simulation)"
@@ -439,6 +443,62 @@ deploy-pegout-broadcast:
 	@echo "RPC URL: $(call get_network_config,$(NETWORK))"
 	@export NETWORK=$(NETWORK); \
 	$(FORGE) script/deployment/DeployPegOut.s.sol:DeployPegOut \
+		$(RPC_OPTS) \
+		$(PRIVATE_KEY_OPTS) \
+		$(call get_library_flags,$(NETWORK)) \
+		--gas-limit $(GAS_LIMIT) \
+		--legacy \
+		--broadcast
+
+# Deploy FlyoverConfigurations (fork simulation)
+.PHONY: deploy-flyover-configurations-fork
+deploy-flyover-configurations-fork:
+	@echo "Deploying FlyoverConfigurations on $(NETWORK) (FORK SIMULATION)..."
+	@echo "RPC URL: $(call get_network_config,$(NETWORK))"
+	@export NETWORK=$(NETWORK); \
+	$(FORGE) script/deployment/DeployFlyoverConfigurations.s.sol:DeployFlyoverConfigurations \
+		$(FORK_OPTS) \
+		$(PRIVATE_KEY_OPTS) \
+		$(call get_library_flags,$(NETWORK)) \
+		--gas-limit $(GAS_LIMIT) \
+		--legacy
+
+# Deploy FlyoverConfigurations (actual deployment)
+.PHONY: deploy-flyover-configurations-broadcast
+deploy-flyover-configurations-broadcast:
+	@echo "Deploying FlyoverConfigurations on $(NETWORK) (ACTUAL DEPLOYMENT)..."
+	@echo "RPC URL: $(call get_network_config,$(NETWORK))"
+	@export NETWORK=$(NETWORK); \
+	$(FORGE) script/deployment/DeployFlyoverConfigurations.s.sol:DeployFlyoverConfigurations \
+		$(RPC_OPTS) \
+		$(PRIVATE_KEY_OPTS) \
+		$(call get_library_flags,$(NETWORK)) \
+		--gas-limit $(GAS_LIMIT) \
+		--legacy \
+		--broadcast
+
+# Deploy PegOutEscrow (fork simulation)
+# Requires PAUSE_REGISTRY_PROXY, PEGOUT_PROXY, COLLATERAL_MANAGEMENT_PROXY, FLYOVER_CONFIGURATIONS_PROXY
+.PHONY: deploy-pegout-escrow-fork
+deploy-pegout-escrow-fork:
+	@echo "Deploying PegOutEscrow on $(NETWORK) (FORK SIMULATION)..."
+	@echo "RPC URL: $(call get_network_config,$(NETWORK))"
+	@export NETWORK=$(NETWORK); \
+	$(FORGE) script/deployment/DeployPegOutEscrow.s.sol:DeployPegOutEscrow \
+		$(FORK_OPTS) \
+		$(PRIVATE_KEY_OPTS) \
+		$(call get_library_flags,$(NETWORK)) \
+		--gas-limit $(GAS_LIMIT) \
+		--legacy
+
+# Deploy PegOutEscrow (actual deployment)
+# Requires PAUSE_REGISTRY_PROXY, PEGOUT_PROXY, COLLATERAL_MANAGEMENT_PROXY, FLYOVER_CONFIGURATIONS_PROXY
+.PHONY: deploy-pegout-escrow-broadcast
+deploy-pegout-escrow-broadcast:
+	@echo "Deploying PegOutEscrow on $(NETWORK) (ACTUAL DEPLOYMENT)..."
+	@echo "RPC URL: $(call get_network_config,$(NETWORK))"
+	@export NETWORK=$(NETWORK); \
+	$(FORGE) script/deployment/DeployPegOutEscrow.s.sol:DeployPegOutEscrow \
 		$(RPC_OPTS) \
 		$(PRIVATE_KEY_OPTS) \
 		$(call get_library_flags,$(NETWORK)) \

--- a/script/deployment/DeployFlyover.s.sol
+++ b/script/deployment/DeployFlyover.s.sol
@@ -10,12 +10,15 @@ import {HelperConfig} from "../HelperConfig.s.sol";
 import {ProxyReader} from "../helpers/ProxyReader.sol";
 
 import {CollateralManagementContract} from "../../src/CollateralManagement.sol";
+import {FlyoverConfigurations} from "../../src/FlyoverConfigurations.sol";
 import {FlyoverDiscovery} from "../../src/FlyoverDiscovery.sol";
 import {PauseRegistry} from "../../src/PauseRegistry.sol";
 import {PegInAddressRegistry} from "../../src/PegInAddressRegistry.sol";
 import {PegInContract} from "../../src/PegInContract.sol";
 import {PegOutContract} from "../../src/PegOutContract.sol";
+import {PegOutEscrow} from "../../src/PegOutEscrow.sol";
 import {IPauseRegistry} from "../../src/interfaces/IPauseRegistry.sol";
+import {FlyoverConfigurationsRegtest} from "../../src/libraries/FlyoverConfigurationsRegtest.sol";
 
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
@@ -41,6 +44,12 @@ contract DeployFlyover is Script {
         address pegInAddressRegistryImpl;
         address pegInAddressRegistryProxy;
         address pegInAddressRegistryProxyAdmin;
+        address flyoverConfigurationsImpl;
+        address flyoverConfigurationsProxy;
+        address flyoverConfigurationsProxyAdmin;
+        address pegOutEscrowImpl;
+        address pegOutEscrowProxy;
+        address pegOutEscrowProxyAdmin;
     }
 
     function run() external returns (FlyoverDeployment memory) {
@@ -243,6 +252,68 @@ contract DeployFlyover is Script {
         );
         PegInAddressRegistry(payable(pegInAddressRegistryProxy))
             .setPegInContract(d.pegInProxy);
+
+        _deployConfigurationsAndEscrow(d, defaultAdmin, cfg, opts);
+    }
+
+    /// @dev Separate stack frame avoids "stack too deep" in {_deployAll}.
+    function _deployConfigurationsAndEscrow(
+        FlyoverDeployment memory d,
+        address defaultAdmin,
+        HelperConfig.FlyoverConfig memory cfg,
+        Options memory opts
+    ) private {
+        address configsProxy = Upgrades.deployTransparentProxy(
+            "FlyoverConfigurations.sol",
+            defaultAdmin,
+            abi.encodeCall(
+                FlyoverConfigurations.initialize,
+                (
+                    defaultAdmin,
+                    cfg.adminDelay,
+                    FlyoverConfigurationsRegtest.TIMELOCK_DELAY,
+                    FlyoverConfigurationsRegtest.pegInConfig(),
+                    FlyoverConfigurationsRegtest.pegInMin(),
+                    FlyoverConfigurationsRegtest.pegInMax()
+                )
+            ),
+            opts
+        );
+        d.flyoverConfigurationsProxy = configsProxy;
+        d.flyoverConfigurationsImpl = ProxyReader.readImplementation(
+            vm,
+            configsProxy
+        );
+        d.flyoverConfigurationsProxyAdmin = ProxyReader.readAdmin(
+            vm,
+            configsProxy
+        );
+        FlyoverConfigurations(payable(configsProxy)).initializePegOut(
+            FlyoverConfigurationsRegtest.pegOutConfig(),
+            FlyoverConfigurationsRegtest.pegOutMin(),
+            FlyoverConfigurationsRegtest.pegOutMax()
+        );
+
+        address escrowProxy = Upgrades.deployTransparentProxy(
+            "PegOutEscrow.sol",
+            defaultAdmin,
+            abi.encodeCall(
+                PegOutEscrow.initialize,
+                (
+                    defaultAdmin,
+                    cfg.adminDelay,
+                    IPauseRegistry(d.pauseRegistryProxy),
+                    d.pegOutProxy,
+                    d.collateralManagementProxy,
+                    configsProxy
+                )
+            ),
+            opts
+        );
+        d.pegOutEscrowProxy = escrowProxy;
+        d.pegOutEscrowImpl = ProxyReader.readImplementation(vm, escrowProxy);
+        d.pegOutEscrowProxyAdmin = ProxyReader.readAdmin(vm, escrowProxy);
+        PegOutContract(payable(d.pegOutProxy)).setPegOutEscrow(escrowProxy);
     }
 
     function _setupRoles(FlyoverDeployment memory d) private {
@@ -255,6 +326,7 @@ contract DeployFlyover is Script {
         cm.grantRole(adder, d.flyoverDiscoveryProxy);
         cm.grantRole(slasher, d.pegInProxy);
         cm.grantRole(slasher, d.pegOutProxy);
+        cm.grantRole(slasher, d.pegOutEscrowProxy);
     }
 
     function _log(FlyoverDeployment memory d) private pure {
@@ -285,5 +357,20 @@ contract DeployFlyover is Script {
             "PegInAddressRegistry ProxyAdmin:",
             d.pegInAddressRegistryProxyAdmin
         );
+        console.log(
+            "FlyoverConfigurations impl:",
+            d.flyoverConfigurationsImpl
+        );
+        console.log(
+            "FlyoverConfigurations proxy:",
+            d.flyoverConfigurationsProxy
+        );
+        console.log(
+            "FlyoverConfigurations ProxyAdmin:",
+            d.flyoverConfigurationsProxyAdmin
+        );
+        console.log("PegOutEscrow impl:", d.pegOutEscrowImpl);
+        console.log("PegOutEscrow proxy:", d.pegOutEscrowProxy);
+        console.log("PegOutEscrow ProxyAdmin:", d.pegOutEscrowProxyAdmin);
     }
 }

--- a/script/deployment/DeployFlyover.s.sol
+++ b/script/deployment/DeployFlyover.s.sol
@@ -357,10 +357,7 @@ contract DeployFlyover is Script {
             "PegInAddressRegistry ProxyAdmin:",
             d.pegInAddressRegistryProxyAdmin
         );
-        console.log(
-            "FlyoverConfigurations impl:",
-            d.flyoverConfigurationsImpl
-        );
+        console.log("FlyoverConfigurations impl:", d.flyoverConfigurationsImpl);
         console.log(
             "FlyoverConfigurations proxy:",
             d.flyoverConfigurationsProxy

--- a/script/deployment/DeployFlyoverConfigurations.s.sol
+++ b/script/deployment/DeployFlyoverConfigurations.s.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {Options} from "openzeppelin-foundry-upgrades/Options.sol";
+import {Upgrades} from "openzeppelin-foundry-upgrades/Upgrades.sol";
+
+import {Script, console} from "lib/forge-std/src/Script.sol";
+
+import {HelperConfig} from "../HelperConfig.s.sol";
+import {ProxyReader} from "../helpers/ProxyReader.sol";
+
+import {FlyoverConfigurations} from "../../src/FlyoverConfigurations.sol";
+import {FlyoverConfigurationsRegtest} from "../../src/libraries/FlyoverConfigurationsRegtest.sol";
+
+/// @title DeployFlyoverConfigurations
+/// @notice Deploys FlyoverConfigurations with provisional regtest seed values (S12.1).
+contract DeployFlyoverConfigurations is Script {
+    struct DeploymentResult {
+        address implementation;
+        address proxy;
+        address admin;
+    }
+
+    function run() external returns (DeploymentResult memory result) {
+        HelperConfig helper = new HelperConfig();
+        HelperConfig.FlyoverConfig memory cfg = helper.getFlyoverConfig();
+        uint256 deployerKey = helper.getDeployerPrivateKey();
+        address deployer = vm.rememberKey(deployerKey);
+
+        vm.startBroadcast(deployerKey);
+        result = _deploy(deployer, cfg.adminDelay, helper.getOptions());
+        vm.stopBroadcast();
+
+        _log(result);
+    }
+
+    /// @notice Test-only helper to deploy without broadcast/env key lookup.
+    function deployForTesting(
+        address defaultAdmin,
+        uint48 adminDelay,
+        Options memory opts
+    ) external returns (DeploymentResult memory) {
+        return _deploy(defaultAdmin, adminDelay, opts);
+    }
+
+    function _deploy(
+        address defaultAdmin,
+        uint48 adminDelay,
+        Options memory opts
+    ) private returns (DeploymentResult memory result) {
+        address proxy = Upgrades.deployTransparentProxy(
+            "FlyoverConfigurations.sol",
+            defaultAdmin,
+            abi.encodeCall(
+                FlyoverConfigurations.initialize,
+                (
+                    defaultAdmin,
+                    adminDelay,
+                    FlyoverConfigurationsRegtest.TIMELOCK_DELAY,
+                    FlyoverConfigurationsRegtest.pegInConfig(),
+                    FlyoverConfigurationsRegtest.pegInMin(),
+                    FlyoverConfigurationsRegtest.pegInMax()
+                )
+            ),
+            opts
+        );
+
+        FlyoverConfigurations(payable(proxy)).initializePegOut(
+            FlyoverConfigurationsRegtest.pegOutConfig(),
+            FlyoverConfigurationsRegtest.pegOutMin(),
+            FlyoverConfigurationsRegtest.pegOutMax()
+        );
+
+        result.proxy = proxy;
+        result.implementation = ProxyReader.readImplementation(vm, proxy);
+        result.admin = ProxyReader.readAdmin(vm, proxy);
+    }
+
+    function _log(DeploymentResult memory r) private pure {
+        console.log("=== FlyoverConfigurations Deployed ===");
+        console.log("Implementation:", r.implementation);
+        console.log("Proxy:", r.proxy);
+        console.log("ProxyAdmin:", r.admin);
+    }
+}

--- a/script/deployment/DeployPegOutEscrow.s.sol
+++ b/script/deployment/DeployPegOutEscrow.s.sol
@@ -39,7 +39,10 @@ contract DeployPegOutEscrow is Script {
         address configurationsProxy = vm.envAddress(
             "FLYOVER_CONFIGURATIONS_PROXY"
         );
-        require(pauseRegistryProxy != address(0), "PAUSE_REGISTRY_PROXY required");
+        require(
+            pauseRegistryProxy != address(0),
+            "PAUSE_REGISTRY_PROXY required"
+        );
         require(pegOutProxy != address(0), "PEGOUT_PROXY required");
         require(
             collateralManagementProxy != address(0),
@@ -75,15 +78,16 @@ contract DeployPegOutEscrow is Script {
         address configurationsProxy,
         Options memory opts
     ) external returns (DeploymentResult memory) {
-        return _deploy(
-            defaultAdmin,
-            adminDelay,
-            pauseRegistryProxy,
-            pegOutProxy,
-            collateralManagementProxy,
-            configurationsProxy,
-            opts
-        );
+        return
+            _deploy(
+                defaultAdmin,
+                adminDelay,
+                pauseRegistryProxy,
+                pegOutProxy,
+                collateralManagementProxy,
+                configurationsProxy,
+                opts
+            );
     }
 
     function _deploy(

--- a/script/deployment/DeployPegOutEscrow.s.sol
+++ b/script/deployment/DeployPegOutEscrow.s.sol
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {Options} from "openzeppelin-foundry-upgrades/Options.sol";
+import {Upgrades} from "openzeppelin-foundry-upgrades/Upgrades.sol";
+
+import {Script, console} from "lib/forge-std/src/Script.sol";
+
+import {HelperConfig} from "../HelperConfig.s.sol";
+import {ProxyReader} from "../helpers/ProxyReader.sol";
+
+import {CollateralManagementContract} from "../../src/CollateralManagement.sol";
+import {IPauseRegistry} from "../../src/interfaces/IPauseRegistry.sol";
+import {PegOutContract} from "../../src/PegOutContract.sol";
+import {PegOutEscrow} from "../../src/PegOutEscrow.sol";
+
+/// @title DeployPegOutEscrow
+/// @notice Deploys PegOutEscrow with the S5 transparent-proxy pattern and wires PegOut + slash role.
+/// @dev Requires PAUSE_REGISTRY_PROXY, PEGOUT_PROXY, COLLATERAL_MANAGEMENT_PROXY,
+///      and FLYOVER_CONFIGURATIONS_PROXY env vars.
+contract DeployPegOutEscrow is Script {
+    struct DeploymentResult {
+        address implementation;
+        address proxy;
+        address admin;
+    }
+
+    function run() external returns (DeploymentResult memory result) {
+        HelperConfig helper = new HelperConfig();
+        HelperConfig.FlyoverConfig memory cfg = helper.getFlyoverConfig();
+        uint256 deployerKey = helper.getDeployerPrivateKey();
+        address deployer = vm.rememberKey(deployerKey);
+
+        address pauseRegistryProxy = vm.envAddress("PAUSE_REGISTRY_PROXY");
+        address pegOutProxy = vm.envAddress("PEGOUT_PROXY");
+        address collateralManagementProxy = vm.envAddress(
+            "COLLATERAL_MANAGEMENT_PROXY"
+        );
+        address configurationsProxy = vm.envAddress(
+            "FLYOVER_CONFIGURATIONS_PROXY"
+        );
+        require(pauseRegistryProxy != address(0), "PAUSE_REGISTRY_PROXY required");
+        require(pegOutProxy != address(0), "PEGOUT_PROXY required");
+        require(
+            collateralManagementProxy != address(0),
+            "COLLATERAL_MANAGEMENT_PROXY required"
+        );
+        require(
+            configurationsProxy != address(0),
+            "FLYOVER_CONFIGURATIONS_PROXY required"
+        );
+
+        vm.startBroadcast(deployerKey);
+        result = _deploy(
+            deployer,
+            cfg.adminDelay,
+            pauseRegistryProxy,
+            pegOutProxy,
+            collateralManagementProxy,
+            configurationsProxy,
+            helper.getOptions()
+        );
+        vm.stopBroadcast();
+
+        _log(result);
+    }
+
+    /// @notice Test-only helper to deploy without broadcast/env key lookup.
+    function deployForTesting(
+        address defaultAdmin,
+        uint48 adminDelay,
+        address pauseRegistryProxy,
+        address pegOutProxy,
+        address collateralManagementProxy,
+        address configurationsProxy,
+        Options memory opts
+    ) external returns (DeploymentResult memory) {
+        return _deploy(
+            defaultAdmin,
+            adminDelay,
+            pauseRegistryProxy,
+            pegOutProxy,
+            collateralManagementProxy,
+            configurationsProxy,
+            opts
+        );
+    }
+
+    function _deploy(
+        address defaultAdmin,
+        uint48 adminDelay,
+        address pauseRegistryProxy,
+        address pegOutProxy,
+        address collateralManagementProxy,
+        address configurationsProxy,
+        Options memory opts
+    ) private returns (DeploymentResult memory result) {
+        address escrowProxy = Upgrades.deployTransparentProxy(
+            "PegOutEscrow.sol",
+            defaultAdmin,
+            abi.encodeCall(
+                PegOutEscrow.initialize,
+                (
+                    defaultAdmin,
+                    adminDelay,
+                    IPauseRegistry(pauseRegistryProxy),
+                    pegOutProxy,
+                    collateralManagementProxy,
+                    configurationsProxy
+                )
+            ),
+            opts
+        );
+
+        PegOutContract(payable(pegOutProxy)).setPegOutEscrow(escrowProxy);
+
+        CollateralManagementContract cm = CollateralManagementContract(
+            payable(collateralManagementProxy)
+        );
+        cm.grantRole(cm.COLLATERAL_SLASHER(), escrowProxy);
+
+        result.proxy = escrowProxy;
+        result.implementation = ProxyReader.readImplementation(vm, escrowProxy);
+        result.admin = ProxyReader.readAdmin(vm, escrowProxy);
+    }
+
+    function _log(DeploymentResult memory r) private pure {
+        console.log("=== PegOutEscrow Deployed ===");
+        console.log("Implementation:", r.implementation);
+        console.log("Proxy:", r.proxy);
+        console.log("ProxyAdmin:", r.admin);
+    }
+}

--- a/test/deployment/DeployFlyover.t.sol
+++ b/test/deployment/DeployFlyover.t.sol
@@ -6,11 +6,15 @@ import "lib/forge-std/src/console.sol";
 import {HelperConfig} from "../../script/HelperConfig.s.sol";
 import {ProxyReader} from "../../script/helpers/ProxyReader.sol";
 import {CollateralManagementContract} from "../../src/CollateralManagement.sol";
+import {FlyoverConfigurations} from "../../src/FlyoverConfigurations.sol";
 import {FlyoverDiscovery} from "../../src/FlyoverDiscovery.sol";
 import {PauseRegistry} from "../../src/PauseRegistry.sol";
 import {PegInContract} from "../../src/PegInContract.sol";
 import {PegOutContract} from "../../src/PegOutContract.sol";
+import {PegOutEscrow} from "../../src/PegOutEscrow.sol";
+import {IPauseRegistry} from "../../src/interfaces/IPauseRegistry.sol";
 import {Flyover} from "../../src/libraries/Flyover.sol";
+import {FlyoverConfigurationsRegtest} from "../../src/libraries/FlyoverConfigurationsRegtest.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {TransparentUpgradeableProxy, ITransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
@@ -36,6 +40,8 @@ contract DeployFlyoverTest is Test {
     FlyoverDiscovery public discovery;
     PegInContract public pegInContract;
     PegOutContract public pegOutContract;
+    FlyoverConfigurations public flyoverConfigurations;
+    PegOutEscrow public pegOutEscrow;
 
     function setUp() public {
         helperConfig = new HelperConfig();
@@ -61,6 +67,8 @@ contract DeployFlyoverTest is Test {
         _assertTransparentProxyAdmin(address(discovery), deployer_);
         _assertTransparentProxyAdmin(address(pegInContract), deployer_);
         _assertTransparentProxyAdmin(address(pegOutContract), deployer_);
+        _assertTransparentProxyAdmin(address(flyoverConfigurations), deployer_);
+        _assertTransparentProxyAdmin(address(pegOutEscrow), deployer_);
     }
 
     /// @notice Deploy all contracts inline (mirrors DeployFlyover script)
@@ -79,6 +87,12 @@ contract DeployFlyoverTest is Test {
 
         // 4) PegOutContract
         _deployPegOut(deployer, cfg);
+
+        // 5) FlyoverConfigurations
+        _deployFlyoverConfigurations(deployer, cfg);
+
+        // 6) PegOutEscrow (+ wire + slash role)
+        _deployPegOutEscrow(deployer, cfg);
     }
 
     function _deployCollateralManagement(
@@ -182,6 +196,66 @@ contract DeployFlyoverTest is Test {
         pegOutContract = PegOutContract(payable(proxy));
     }
 
+    function _deployFlyoverConfigurations(
+        address deployer,
+        HelperConfig.FlyoverConfig memory cfg
+    ) private {
+        address impl = address(new FlyoverConfigurations());
+        address proxy = address(
+            new TransparentUpgradeableProxy(
+                impl,
+                deployer,
+                abi.encodeCall(
+                    FlyoverConfigurations.initialize,
+                    (
+                        deployer,
+                        cfg.adminDelay,
+                        FlyoverConfigurationsRegtest.TIMELOCK_DELAY,
+                        FlyoverConfigurationsRegtest.pegInConfig(),
+                        FlyoverConfigurationsRegtest.pegInMin(),
+                        FlyoverConfigurationsRegtest.pegInMax()
+                    )
+                )
+            )
+        );
+        flyoverConfigurations = FlyoverConfigurations(payable(proxy));
+        flyoverConfigurations.initializePegOut(
+            FlyoverConfigurationsRegtest.pegOutConfig(),
+            FlyoverConfigurationsRegtest.pegOutMin(),
+            FlyoverConfigurationsRegtest.pegOutMax()
+        );
+    }
+
+    function _deployPegOutEscrow(
+        address deployer,
+        HelperConfig.FlyoverConfig memory cfg
+    ) private {
+        address impl = address(new PegOutEscrow());
+        address proxy = address(
+            new TransparentUpgradeableProxy(
+                impl,
+                deployer,
+                abi.encodeCall(
+                    PegOutEscrow.initialize,
+                    (
+                        deployer,
+                        cfg.adminDelay,
+                        IPauseRegistry(pauseRegistryProxy),
+                        address(pegOutContract),
+                        address(collateralManagement),
+                        address(flyoverConfigurations)
+                    )
+                )
+            )
+        );
+        pegOutEscrow = PegOutEscrow(payable(proxy));
+        pegOutContract.setPegOutEscrow(proxy);
+        collateralManagement.grantRole(
+            collateralManagement.COLLATERAL_SLASHER(),
+            proxy
+        );
+    }
+
     function test_FullDeploymentFlow() public {
         console.log("\n=== TEST FULL FLYOVER DEPLOYMENT ===\n");
 
@@ -218,6 +292,21 @@ contract DeployFlyoverTest is Test {
         );
         console.log("   Proxy:", address(pegOutContract));
 
+        console.log("\n5. Verifying FlyoverConfigurations...");
+        assertTrue(
+            address(flyoverConfigurations) != address(0),
+            "Configs should not be zero"
+        );
+        console.log("   Proxy:", address(flyoverConfigurations));
+
+        console.log("\n6. Verifying PegOutEscrow...");
+        assertTrue(
+            address(pegOutEscrow) != address(0),
+            "Escrow should not be zero"
+        );
+        assertEq(pegOutEscrow.getPegOutContract(), address(pegOutContract));
+        console.log("   Proxy:", address(pegOutEscrow));
+
         console.log("\n[PASS] All contracts deployed successfully!");
     }
 
@@ -245,6 +334,7 @@ contract DeployFlyoverTest is Test {
             collateralSlasherRole,
             address(pegOutContract)
         );
+        // Escrow slash role is granted inside _deployPegOutEscrow.
 
         // Verify FlyoverDiscovery has COLLATERAL_ADDER
         console.log("1. Checking FlyoverDiscovery has COLLATERAL_ADDER...");
@@ -278,6 +368,16 @@ contract DeployFlyoverTest is Test {
             "PegOutContract should have COLLATERAL_SLASHER"
         );
         console.log("   PegOutContract has COLLATERAL_SLASHER: true");
+
+        console.log("\n4. Checking PegOutEscrow has COLLATERAL_SLASHER...");
+        assertTrue(
+            collateralManagement.hasRole(
+                collateralSlasherRole,
+                address(pegOutEscrow)
+            ),
+            "PegOutEscrow should have COLLATERAL_SLASHER"
+        );
+        console.log("   PegOutEscrow has COLLATERAL_SLASHER: true");
 
         console.log("\n[PASS] All roles set up correctly!");
     }

--- a/test/deployment/DeployPegOutEscrow.t.sol
+++ b/test/deployment/DeployPegOutEscrow.t.sol
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import "lib/forge-std/src/Test.sol";
+import "lib/forge-std/src/console.sol";
+import {HelperConfig} from "../../script/HelperConfig.s.sol";
+import {ProxyReader} from "../../script/helpers/ProxyReader.sol";
+import {CollateralManagementContract} from "../../src/CollateralManagement.sol";
+import {FlyoverConfigurations} from "../../src/FlyoverConfigurations.sol";
+import {PauseRegistry} from "../../src/PauseRegistry.sol";
+import {PegOutContract} from "../../src/PegOutContract.sol";
+import {PegOutEscrow} from "../../src/PegOutEscrow.sol";
+import {IPauseRegistry} from "../../src/interfaces/IPauseRegistry.sol";
+import {FlyoverConfigurationsRegtest} from "../../src/libraries/FlyoverConfigurationsRegtest.sol";
+import {BridgeMock} from "../../src/test-contracts/BridgeMock.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {
+    TransparentUpgradeableProxy,
+    ITransparentUpgradeableProxy
+} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+
+/**
+ * @title DeployPegOutEscrowTest
+ * @notice Test for PegOutEscrow deployment and PegOut / slash-role wiring
+ */
+contract DeployPegOutEscrowTest is Test {
+    HelperConfig public helperConfig;
+    BridgeMock public bridgeMock;
+    address public collateralManagementProxy;
+    address public pauseRegistryProxy;
+    address public pegOutProxy;
+    address public configurationsProxy;
+
+    function setUp() public {
+        helperConfig = new HelperConfig();
+        bridgeMock = new BridgeMock();
+
+        HelperConfig.FlyoverConfig memory cfg = helperConfig.getFlyoverConfig();
+        address deployer = address(this);
+
+        PauseRegistry prImpl = new PauseRegistry();
+        pauseRegistryProxy = address(
+            new TransparentUpgradeableProxy(
+                address(prImpl),
+                deployer,
+                abi.encodeCall(prImpl.initialize, (0, deployer))
+            )
+        );
+
+        address cmImpl = address(new CollateralManagementContract());
+        collateralManagementProxy = address(
+            new TransparentUpgradeableProxy(
+                cmImpl,
+                deployer,
+                abi.encodeCall(
+                    CollateralManagementContract.initialize,
+                    (
+                        deployer,
+                        cfg.adminDelay,
+                        cfg.minimumCollateral,
+                        cfg.resignDelayBlocks,
+                        cfg.rewardPercentage,
+                        PauseRegistry(pauseRegistryProxy)
+                    )
+                )
+            )
+        );
+
+        address pegOutImpl = address(new PegOutContract());
+        pegOutProxy = address(
+            new TransparentUpgradeableProxy(
+                pegOutImpl,
+                deployer,
+                abi.encodeCall(
+                    PegOutContract.initialize,
+                    (
+                        deployer,
+                        payable(address(bridgeMock)),
+                        cfg.dustThreshold,
+                        collateralManagementProxy,
+                        cfg.mainnet,
+                        cfg.btcBlockTime,
+                        PauseRegistry(pauseRegistryProxy)
+                    )
+                )
+            )
+        );
+
+        address configsImpl = address(new FlyoverConfigurations());
+        configurationsProxy = address(
+            new TransparentUpgradeableProxy(
+                configsImpl,
+                deployer,
+                abi.encodeCall(
+                    FlyoverConfigurations.initialize,
+                    (
+                        deployer,
+                        cfg.adminDelay,
+                        FlyoverConfigurationsRegtest.TIMELOCK_DELAY,
+                        FlyoverConfigurationsRegtest.pegInConfig(),
+                        FlyoverConfigurationsRegtest.pegInMin(),
+                        FlyoverConfigurationsRegtest.pegInMax()
+                    )
+                )
+            )
+        );
+        FlyoverConfigurations(payable(configurationsProxy)).initializePegOut(
+            FlyoverConfigurationsRegtest.pegOutConfig(),
+            FlyoverConfigurationsRegtest.pegOutMin(),
+            FlyoverConfigurationsRegtest.pegOutMax()
+        );
+    }
+
+    function _deployEscrow(address deployer, uint48 adminDelay)
+        internal
+        returns (address proxy)
+    {
+        address impl = address(new PegOutEscrow());
+        proxy = address(
+            new TransparentUpgradeableProxy(
+                impl,
+                deployer,
+                abi.encodeCall(
+                    PegOutEscrow.initialize,
+                    (
+                        deployer,
+                        adminDelay,
+                        IPauseRegistry(pauseRegistryProxy),
+                        pegOutProxy,
+                        collateralManagementProxy,
+                        configurationsProxy
+                    )
+                )
+            )
+        );
+
+        PegOutContract(payable(pegOutProxy)).setPegOutEscrow(proxy);
+        CollateralManagementContract cm = CollateralManagementContract(
+            payable(collateralManagementProxy)
+        );
+        cm.grantRole(cm.COLLATERAL_SLASHER(), proxy);
+    }
+
+    function test_DeployPegOutEscrow_WiresPegOutAndSlasher() public {
+        HelperConfig.FlyoverConfig memory cfg = helperConfig.getFlyoverConfig();
+        address deployer = address(this);
+
+        address proxy = _deployEscrow(deployer, cfg.adminDelay);
+        PegOutEscrow escrow = PegOutEscrow(payable(proxy));
+
+        assertEq(escrow.getPegOutContract(), pegOutProxy);
+        assertEq(escrow.getFlyoverConfigurations(), configurationsProxy);
+        assertEq(
+            Ownable(ProxyReader.readAdmin(vm, proxy)).owner(),
+            deployer,
+            "PegOutEscrow ProxyAdmin owner mismatch"
+        );
+
+        CollateralManagementContract cm = CollateralManagementContract(
+            payable(collateralManagementProxy)
+        );
+        assertTrue(
+            cm.hasRole(cm.COLLATERAL_SLASHER(), proxy),
+            "Escrow should have COLLATERAL_SLASHER"
+        );
+
+        // Escrow is wired: non-escrow callers hit OnlyPegOutEscrow (not PegOutEscrowNotSet).
+        PegOutContract pegOut = PegOutContract(payable(pegOutProxy));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                PegOutContract.OnlyPegOutEscrow.selector,
+                address(this)
+            )
+        );
+        pegOut.registerClaimedPegOut(bytes32(uint256(1)), "");
+    }
+
+    function test_DeployPegOutEscrow_SeedsRegtestPegOutConfig() public {
+        HelperConfig.FlyoverConfig memory cfg = helperConfig.getFlyoverConfig();
+        _deployEscrow(address(this), cfg.adminDelay);
+
+        FlyoverConfigurations configs = FlyoverConfigurations(
+            payable(configurationsProxy)
+        );
+        assertEq(
+            configs.getPegOutConfiguration().fixedFee,
+            FlyoverConfigurationsRegtest.pegOutConfig().fixedFee
+        );
+        assertEq(
+            configs.getPegOutConfiguration().claimWindow,
+            FlyoverConfigurationsRegtest.pegOutConfig().claimWindow
+        );
+    }
+
+    function test_DeployPegOutEscrow_IsUpgradeable() public {
+        HelperConfig.FlyoverConfig memory cfg = helperConfig.getFlyoverConfig();
+        address deployer = address(this);
+        address proxy = _deployEscrow(deployer, cfg.adminDelay);
+
+        ProxyAdmin proxyAdmin = ProxyAdmin(ProxyReader.readAdmin(vm, proxy));
+        address oldImpl = ProxyReader.readImplementation(vm, proxy);
+        address newImpl = address(new PegOutEscrow());
+        proxyAdmin.upgradeAndCall(
+            ITransparentUpgradeableProxy(proxy),
+            newImpl,
+            ""
+        );
+        assertEq(ProxyReader.readImplementation(vm, proxy), newImpl);
+        assertTrue(oldImpl != newImpl);
+    }
+}

--- a/test/deployment/DeployPegOutEscrow.t.sol
+++ b/test/deployment/DeployPegOutEscrow.t.sol
@@ -14,10 +14,7 @@ import {IPauseRegistry} from "../../src/interfaces/IPauseRegistry.sol";
 import {FlyoverConfigurationsRegtest} from "../../src/libraries/FlyoverConfigurationsRegtest.sol";
 import {BridgeMock} from "../../src/test-contracts/BridgeMock.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
-import {
-    TransparentUpgradeableProxy,
-    ITransparentUpgradeableProxy
-} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {TransparentUpgradeableProxy, ITransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 
 /**
@@ -112,10 +109,10 @@ contract DeployPegOutEscrowTest is Test {
         );
     }
 
-    function _deployEscrow(address deployer, uint48 adminDelay)
-        internal
-        returns (address proxy)
-    {
+    function _deployEscrow(
+        address deployer,
+        uint48 adminDelay
+    ) internal returns (address proxy) {
         address impl = address(new PegOutEscrow());
         proxy = address(
             new TransparentUpgradeableProxy(

--- a/test/pegout-escrow/PegOutEscrow.t.sol
+++ b/test/pegout-escrow/PegOutEscrow.t.sol
@@ -721,9 +721,13 @@ contract PegOutEscrowTest is Test {
         );
     }
 
-    function test_R2_RefundOnNoClaimAtExactLimit_RevertsClaimWindowOpen() public {
+    function test_R2_RefundOnNoClaimAtExactLimit_RevertsClaimWindowOpen()
+        public
+    {
         bytes32 requestHash = _requestDefault();
-        uint256 depositDateLimit = escrow.getPegOutQuote(requestHash).depositDateLimit;
+        uint256 depositDateLimit = escrow
+            .getPegOutQuote(requestHash)
+            .depositDateLimit;
 
         vm.warp(depositDateLimit);
 
@@ -872,7 +876,9 @@ contract PegOutEscrowTest is Test {
         );
     }
 
-    function test_FeeSnapshot_ConfigChangeMidFlight_UnchangedEconomics() public {
+    function test_FeeSnapshot_ConfigChangeMidFlight_UnchangedEconomics()
+        public
+    {
         bytes32 requestHash = _requestDefault();
         Quotes.PegOutQuote memory before = escrow.getPegOutQuote(requestHash);
 
@@ -911,7 +917,10 @@ contract PegOutEscrowTest is Test {
         escrow.claimPegOut(requestHash, signature);
 
         assertEq(escrow.getPegOutQuote(requestHash).callFee, before.callFee);
-        assertEq(escrow.getPegOutQuote(requestHash).penaltyFee, before.penaltyFee);
+        assertEq(
+            escrow.getPegOutQuote(requestHash).penaltyFee,
+            before.penaltyFee
+        );
         assertEq(
             uint256(escrow.getPegOutState(requestHash)),
             uint256(IPegOutEscrow.EscrowedPegOutState.CLAIMED)

--- a/test/pegout-escrow/PegOutEscrow.t.sol
+++ b/test/pegout-escrow/PegOutEscrow.t.sol
@@ -17,7 +17,8 @@ import {BridgeMock} from "../../src/test-contracts/BridgeMock.sol";
 import {CollateralManagementMock} from "../../src/test-contracts/CollateralManagementMock.sol";
 import {FlyoverConfigurationsMock} from "../pegin/FlyoverConfigurationsMock.sol";
 
-/// @title PegOutEscrow request, cancel, and claimPegOut
+/// @title PegOutEscrow S11.1 state machine + claim gates
+/// @dev Test names map to S11.1 transition / race / B-scenario ids where applicable.
 contract PegOutEscrowTest is Test {
     /// @dev Mirrors impl-only {PegOutEscrow.EscrowPegOutChangePaid} for expectEmit.
     event EscrowPegOutChangePaid(
@@ -144,10 +145,10 @@ contract PegOutEscrowTest is Test {
     }
 
     // -------------------------------------------------------------------------
-    // requestPegOut
+    // T0 — requestPegOut
     // -------------------------------------------------------------------------
 
-    function test_requestPegOut_happyPath_stateQuoteGettersAndEvent() public {
+    function test_T0_Request_NoneToRequested() public {
         (uint256 amount, uint256 callFee, uint256 change) = _expectedSplit(
             DEFAULT_VALUE
         );
@@ -239,13 +240,13 @@ contract PegOutEscrowTest is Test {
         assertEq(escrow.getPegOutQuote(requestHash).rskRefundAddress, user);
     }
 
-    function test_requestPegOut_emptyDestination_reverts() public {
+    function test_B7_Unserviceable_EmptyDestination_StaysNone() public {
         vm.prank(user);
         vm.expectRevert(IPegOutEscrow.InvalidDestination.selector);
         escrow.requestPegOut{value: DEFAULT_VALUE}("", user);
     }
 
-    function test_requestPegOut_amountBelowMin_revertsNotServiceable() public {
+    function test_B7_Unserviceable_AmountBelowMin_StaysNone() public {
         // Tiny payment → principal below MIN_AMOUNT after fee split.
         uint256 tiny = FIXED_FEE + 0.001 ether;
         (uint256 amount, , ) = _expectedSplit(tiny);
@@ -324,10 +325,10 @@ contract PegOutEscrowTest is Test {
     }
 
     // -------------------------------------------------------------------------
-    // cancelPegOut
+    // T1 / B6 — cancelPegOut
     // -------------------------------------------------------------------------
 
-    function test_cancelPegOut_refundsAndTerminates() public {
+    function test_T1_Cancel_RequestedToCancelled() public {
         vm.prank(user);
         bytes32 requestHash = escrow.requestPegOut{value: DEFAULT_VALUE}(
             DEST,
@@ -387,7 +388,7 @@ contract PegOutEscrowTest is Test {
         escrow.cancelPegOut(missing);
     }
 
-    function test_cancelPegOut_twice_reverts() public {
+    function test_Forbidden_CancelTwice_Reverts() public {
         vm.prank(user);
         bytes32 requestHash = escrow.requestPegOut{value: DEFAULT_VALUE}(
             DEST,
@@ -410,10 +411,10 @@ contract PegOutEscrowTest is Test {
     }
 
     // -------------------------------------------------------------------------
-    // claimPegOut
+    // T2 — claimPegOut
     // -------------------------------------------------------------------------
 
-    function test_claimPegOut_happyPath_lpAnchorFundsAndClaimed() public {
+    function test_T2_Claim_RequestedToClaimed() public {
         bytes32 requestHash = _requestDefault();
         Quotes.PegOutQuote memory quote = escrow.getPegOutQuote(requestHash);
         uint256 payout = quote.value + quote.callFee + quote.gasFee;
@@ -441,7 +442,7 @@ contract PegOutEscrowTest is Test {
         assertEq(address(escrow).balance, escrowBefore - payout);
     }
 
-    function test_claimPegOut_secondClaim_revertsInvalidState() public {
+    function test_R4_B1_SecondClaim_RevertsInvalidState() public {
         bytes32 requestHash = _requestDefault();
         Quotes.PegOutQuote memory quote = escrow.getPegOutQuote(requestHash);
         bytes memory signature = _signForLp(lpKey, quote, lp);
@@ -462,7 +463,7 @@ contract PegOutEscrowTest is Test {
         escrow.claimPegOut(requestHash, otherSig);
     }
 
-    function test_claimPegOut_afterCancel_revertsInvalidState() public {
+    function test_R1_CancelVsClaim_CancelFirst_ClaimReverts() public {
         bytes32 requestHash = _requestDefault();
         Quotes.PegOutQuote memory quote = escrow.getPegOutQuote(requestHash);
         bytes memory signature = _signForLp(lpKey, quote, lp);
@@ -482,7 +483,7 @@ contract PegOutEscrowTest is Test {
         escrow.claimPegOut(requestHash, signature);
     }
 
-    function test_claimPegOut_afterRefund_revertsInvalidState() public {
+    function test_Forbidden_ClaimAfterRefunded_Reverts() public {
         bytes32 requestHash = _requestDefault();
         Quotes.PegOutQuote memory quote = escrow.getPegOutQuote(requestHash);
         bytes memory signature = _signForLp(lpKey, quote, lp);
@@ -576,10 +577,10 @@ contract PegOutEscrowTest is Test {
     }
 
     // -------------------------------------------------------------------------
-    // deadline refunds (acceptance)
+    // T3 / T5 / R2 — deadline refunds
     // -------------------------------------------------------------------------
 
-    function test_refundOnNoClaim_beforeDeadline_reverts() public {
+    function test_R2_RefundOnNoClaimWhileWindowOpen_Reverts() public {
         bytes32 requestHash = _requestDefault();
         uint256 depositDateLimit = escrow
             .getPegOutQuote(requestHash)
@@ -608,9 +609,7 @@ contract PegOutEscrowTest is Test {
         pegOut.refundUserPegOut(requestHash);
     }
 
-    function test_refundOnNoClaim_afterDeadline_anyoneRefundsAndAttemptsGlobalSlash()
-        public
-    {
+    function test_T3_B2_RefundOnNoClaim_RequestedToRefunded() public {
         bytes32 requestHash = _requestDefault();
         Quotes.PegOutQuote memory q = escrow.getPegOutQuote(requestHash);
         uint256 payout = q.value + q.callFee + q.gasFee;
@@ -633,7 +632,7 @@ contract PegOutEscrowTest is Test {
         assertEq(user.balance, userBefore + payout);
     }
 
-    function test_cancelPegOut_doesNotCallGlobalSlash() public {
+    function test_B6_Cancel_DoesNotCallGlobalSlash() public {
         collateral.setGlobalSlashReverts(false);
 
         bytes32 requestHash = _requestDefault();
@@ -647,9 +646,7 @@ contract PegOutEscrowTest is Test {
         );
     }
 
-    function test_refundUserPegOut_afterExpire_anyoneRefundsIndividualSlashAndLateReverts()
-        public
-    {
+    function test_T5_B3_RefundUser_ClaimedToRefunded() public {
         bytes32 requestHash = _claimDefault();
         Quotes.PegOutQuote memory q = escrow.getPegOutQuote(requestHash);
         uint256 payout = q.value + q.callFee + q.gasFee;
@@ -687,6 +684,259 @@ contract PegOutEscrowTest is Test {
         );
         vm.prank(other);
         pegOut.refundUserPegOut(requestHash);
+    }
+
+    // -------------------------------------------------------------------------
+    // S11.1 gaps — races, T4, forbidden CLAIMED exits, fee snapshot, B8
+    // -------------------------------------------------------------------------
+
+    function test_R1_CancelVsClaim_ClaimFirst_CancelReverts() public {
+        bytes32 requestHash = _claimDefault();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegOutEscrow.InvalidState.selector,
+                requestHash,
+                IPegOutEscrow.EscrowedPegOutState.REQUESTED,
+                IPegOutEscrow.EscrowedPegOutState.CLAIMED
+            )
+        );
+        vm.prank(user);
+        escrow.cancelPegOut(requestHash);
+    }
+
+    function test_R2_ClaimAtExactDepositDateLimit_Succeeds() public {
+        bytes32 requestHash = _requestDefault();
+        Quotes.PegOutQuote memory quote = escrow.getPegOutQuote(requestHash);
+        bytes memory signature = _signForLp(lpKey, quote, lp);
+
+        vm.warp(uint256(quote.depositDateLimit));
+
+        vm.prank(lp);
+        escrow.claimPegOut(requestHash, signature);
+
+        assertEq(
+            uint256(escrow.getPegOutState(requestHash)),
+            uint256(IPegOutEscrow.EscrowedPegOutState.CLAIMED)
+        );
+    }
+
+    function test_R2_RefundOnNoClaimAtExactLimit_RevertsClaimWindowOpen() public {
+        bytes32 requestHash = _requestDefault();
+        uint256 depositDateLimit = escrow.getPegOutQuote(requestHash).depositDateLimit;
+
+        vm.warp(depositDateLimit);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegOutEscrow.ClaimWindowOpen.selector,
+                depositDateLimit
+            )
+        );
+        vm.prank(other);
+        escrow.refundOnNoClaim(requestHash);
+    }
+
+    function test_R2_ClaimAfterDeadline_RevertsClaimWindowClosed() public {
+        bytes32 requestHash = _requestDefault();
+        Quotes.PegOutQuote memory quote = escrow.getPegOutQuote(requestHash);
+        bytes memory signature = _signForLp(lpKey, quote, lp);
+
+        vm.warp(uint256(quote.depositDateLimit) + 1);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegOutEscrow.ClaimWindowClosed.selector,
+                quote.depositDateLimit
+            )
+        );
+        vm.prank(lp);
+        escrow.claimPegOut(requestHash, signature);
+    }
+
+    /// @dev T4 product path (refundPegOut → onSettlement(FULFILLED)) is an S13 gap;
+    /// this asserts the escrow transition via the PegOut-only notify surface.
+    function test_T4_OnSettlement_ClaimedToFulfilled() public {
+        bytes32 requestHash = _claimDefault();
+
+        vm.prank(address(pegOut));
+        escrow.onSettlement(
+            requestHash,
+            IPegOutEscrow.EscrowedPegOutState.FULFILLED
+        );
+
+        assertEq(
+            uint256(escrow.getPegOutState(requestHash)),
+            uint256(IPegOutEscrow.EscrowedPegOutState.FULFILLED)
+        );
+        Quotes.PegOutQuote memory cleared = escrow.getPegOutQuote(requestHash);
+        assertEq(cleared.value, 0);
+        assertEq(cleared.lpRskAddress, address(0));
+    }
+
+    function test_Forbidden_CancelFromClaimed_Reverts() public {
+        bytes32 requestHash = _claimDefault();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegOutEscrow.InvalidState.selector,
+                requestHash,
+                IPegOutEscrow.EscrowedPegOutState.REQUESTED,
+                IPegOutEscrow.EscrowedPegOutState.CLAIMED
+            )
+        );
+        vm.prank(user);
+        escrow.cancelPegOut(requestHash);
+    }
+
+    function test_Forbidden_RefundOnNoClaimFromClaimed_Reverts() public {
+        bytes32 requestHash = _claimDefault();
+        Quotes.PegOutQuote memory q = escrow.getPegOutQuote(requestHash);
+        vm.warp(uint256(q.depositDateLimit) + 1);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegOutEscrow.InvalidState.selector,
+                requestHash,
+                IPegOutEscrow.EscrowedPegOutState.REQUESTED,
+                IPegOutEscrow.EscrowedPegOutState.CLAIMED
+            )
+        );
+        vm.prank(other);
+        escrow.refundOnNoClaim(requestHash);
+    }
+
+    function test_Forbidden_OnSettlement_NotClaimed_Reverts() public {
+        bytes32 requestHash = _requestDefault();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegOutEscrow.InvalidState.selector,
+                requestHash,
+                IPegOutEscrow.EscrowedPegOutState.CLAIMED,
+                IPegOutEscrow.EscrowedPegOutState.REQUESTED
+            )
+        );
+        vm.prank(address(pegOut));
+        escrow.onSettlement(
+            requestHash,
+            IPegOutEscrow.EscrowedPegOutState.FULFILLED
+        );
+    }
+
+    /// @dev R3 / B5 — late but valid fulfillment stays FULFILLED (not REFUNDED).
+    function test_R3_B5_LateProof_FulfilledViaOnSettlement() public {
+        bytes32 requestHash = _claimDefault();
+        Quotes.PegOutQuote memory q = escrow.getPegOutQuote(requestHash);
+        // Past call window but before user-refund expiry is the late-delivery window;
+        // escrow notify does not re-check time — settlement race is owned by PegOut.
+        vm.warp(uint256(q.depositDateLimit) + uint256(q.transferTime) + 1);
+
+        vm.prank(address(pegOut));
+        escrow.onSettlement(
+            requestHash,
+            IPegOutEscrow.EscrowedPegOutState.FULFILLED
+        );
+
+        assertEq(
+            uint256(escrow.getPegOutState(requestHash)),
+            uint256(IPegOutEscrow.EscrowedPegOutState.FULFILLED)
+        );
+    }
+
+    function test_R3_UserRefundWins_ThenOnSettlementReverts() public {
+        bytes32 requestHash = _claimDefault();
+        Quotes.PegOutQuote memory q = escrow.getPegOutQuote(requestHash);
+        _warpPastFulfillment(q);
+
+        vm.prank(other);
+        pegOut.refundUserPegOut(requestHash);
+
+        assertEq(
+            uint256(escrow.getPegOutState(requestHash)),
+            uint256(IPegOutEscrow.EscrowedPegOutState.REFUNDED)
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegOutEscrow.InvalidState.selector,
+                requestHash,
+                IPegOutEscrow.EscrowedPegOutState.CLAIMED,
+                IPegOutEscrow.EscrowedPegOutState.REFUNDED
+            )
+        );
+        vm.prank(address(pegOut));
+        escrow.onSettlement(
+            requestHash,
+            IPegOutEscrow.EscrowedPegOutState.FULFILLED
+        );
+    }
+
+    function test_FeeSnapshot_ConfigChangeMidFlight_UnchangedEconomics() public {
+        bytes32 requestHash = _requestDefault();
+        Quotes.PegOutQuote memory before = escrow.getPegOutQuote(requestHash);
+
+        IFlyoverConfigurations.ConfirmationTier[]
+            memory tiers = new IFlyoverConfigurations.ConfirmationTier[](1);
+        tiers[0] = IFlyoverConfigurations.ConfirmationTier({
+            maxAmount: type(uint256).max,
+            confirmations: TIER_CONFIRMATIONS
+        });
+        configurations.setPegOutConfiguration(
+            IFlyoverConfigurations.PegOutConfiguration({
+                fixedFee: FIXED_FEE * 5,
+                percentageFee: PERCENTAGE_FEE * 2,
+                minAmount: MIN_AMOUNT,
+                maxAmount: MAX_AMOUNT,
+                confirmationTiers: tiers,
+                penaltyFee: PENALTY_FEE * 3,
+                claimWindow: CLAIM_WINDOW / 2,
+                claimWindowBlocks: CLAIM_WINDOW_BLOCKS,
+                callTime: CALL_TIME,
+                expireTime: EXPIRE_TIME,
+                expireBlocks: EXPIRE_BLOCKS,
+                maxMinerFee: 0.001 ether
+            })
+        );
+
+        Quotes.PegOutQuote memory afterCfg = escrow.getPegOutQuote(requestHash);
+        assertEq(afterCfg.callFee, before.callFee);
+        assertEq(afterCfg.penaltyFee, before.penaltyFee);
+        assertEq(afterCfg.value, before.value);
+        assertEq(afterCfg.depositDateLimit, before.depositDateLimit);
+        assertEq(afterCfg.expireDate, before.expireDate);
+
+        bytes memory signature = _signForLp(lpKey, afterCfg, lp);
+        vm.prank(lp);
+        escrow.claimPegOut(requestHash, signature);
+
+        assertEq(escrow.getPegOutQuote(requestHash).callFee, before.callFee);
+        assertEq(escrow.getPegOutQuote(requestHash).penaltyFee, before.penaltyFee);
+        assertEq(
+            uint256(escrow.getPegOutState(requestHash)),
+            uint256(IPegOutEscrow.EscrowedPegOutState.CLAIMED)
+        );
+    }
+
+    /// @dev B8 is reserved in S11.1; PoC still rejects under-value at validation (no new state).
+    function test_B8_BelowFloor_ReservedPoCGap() public {
+        // Tiny payment cannot clear min after fee split — never leaves NONE (same gate as B7 today).
+        uint256 tiny = FIXED_FEE + 0.001 ether;
+        (uint256 amount, , ) = _expectedSplit(tiny);
+        assertLt(amount, MIN_AMOUNT);
+
+        vm.prank(user);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPegOutEscrow.NotServiceable.selector,
+                amount,
+                MIN_AMOUNT,
+                MAX_AMOUNT
+            )
+        );
+        escrow.requestPegOut{value: tiny}(DEST, user);
+
+        assertEq(escrow.totalRequests(), 0);
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## What

Adds an S11.1-mapped Foundry suite for `PegOutEscrow` (permitted transitions, forbidden paths, races R1–R4 / B1–B8, mid-flight fee snapshot) and regtest deploy wiring so FlyoverConfigurations + PegOutEscrow stand up with the Flyover stack.

- Extends [`test/pegout-escrow/PegOutEscrow.t.sol`](test/pegout-escrow/PegOutEscrow.t.sol): rename covered cases to `test_T*`, `test_R*`, `test_B*`; add gap coverage.
- Adds [`DeployFlyoverConfigurations.s.sol`](script/deployment/DeployFlyoverConfigurations.s.sol) and [`DeployPegOutEscrow.s.sol`](script/deployment/DeployPegOutEscrow.s.sol) (S5 proxy + init; provisional values from `FlyoverConfigurationsRegtest`).
- Extends [`DeployFlyover.s.sol`](script/deployment/DeployFlyover.s.sol) so `make deploy-flyover-broadcast` deploys configs + escrow, calls `setPegOutEscrow`, and grants escrow `COLLATERAL_SLASHER`.
- Makefile targets for the standalone scripts; deploy tests updated.

## Why

S11.1 needs a suite a reviewer can diff against the state-machine table. S15/S16 need a real escrow (+ configs) on regtest from the existing one-command S5 flow. Escrow requires configs in `initialize`, so configs must be deployed before escrow (unlike PegIn’s optional `setPegInDependencies`).

## Type of Change

- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Refactor (no intended behavior change)
- [ ] Security hardening
- [x] Tests only
- [x] Build/CI/Tooling
- [ ] Documentation

*(Tests + deploy/tooling; no product change to `refundPegOut` → `onSettlement(FULFILLED)`.)*

## Affected Areas

- [ ] PegIn flow (`registerPegIn`, `callForUser`, quote validation)
- [x] PegOut flow (`depositPegout`, `refundPegOut`, `refundUserPegOut`)
- [ ] Liquidity Provider lifecycle (register/update/status/resign/collateral/withdraw)
- [ ] Pause/operational controls
- [ ] Quote hashing/signature logic
- [ ] Bitcoin tx / PMT / merkle validation
- [x] Deployment or upgrade scripts / Makefile targets
- [ ] CI workflows (`ci`, `fuzz`, `formal`, `slither`, `codeql`)
- [ ] Docs

## Risk & Security Review

- [x] Access control and authorization paths reviewed
- [ ] Reentrancy and external call paths reviewed
- [x] Storage layout / upgrade safety reviewed (if upgradeable code changed)
- [x] Time/block/confirmation assumptions reviewed
- [ ] BTC tx output/index assumptions reviewed (if pegout validation touched)
- [x] No secrets or sensitive values added

*(Deploy only wires existing roles/setters; no escrow storage-layout change. R2 equality / claim-window checks covered in tests.)*

## Test Plan

List what you ran locally and the outcome:

- [ ] `npm run lint:sol`
- [ ] `npm run lint:ts`
- [ ] `npm run compile`
- [ ] `npm test`
- [ ] `npm run test:fuzz` (if logic/state transitions changed)
- [ ] `npm run test:invariant` (if invariant-sensitive logic changed)
- [ ] `npm run test:formal` (if formal-verification-sensitive logic changed)
- [ ] `npm run test:integration` (if integration paths changed)
- [ ] `npm run test:e2e` (if deployment/ownership flows changed)

Additional notes on test coverage, edge cases, and any tests intentionally skipped:

- `forge test --match-path 'test/pegout-escrow/PegOutEscrow.t.sol'` — 34 passed
- `forge test --match-path 'test/deployment/Deploy{Flyover,PegOutEscrow}.t.sol'` — 9 passed
- T4 / R3 late-fulfill asserted via `vm.prank(pegOut); escrow.onSettlement(..., FULFILLED)` — live `refundPegOut` → FULFILLED notify remains an S13 gap (no product wire in this PR)
- B8 remains reserved (PoC still rejects under-min at request; no new state)

## Deployment & Ops Impact

- [ ] No deployment impact
- [x] Requires deployment
- [ ] Requires upgrade
- [x] Env/config changes required (`.env`, network RPCs, verification, etc.)
- [x] Runbook/update instructions added to PR description

**Regtest (one command after libraries are in `addresses.json`):**

```bash
make deploy-libraries-broadcast NETWORK=rskRegtest   # if libs missing
make deploy-flyover-broadcast NETWORK=rskRegtest