### PR TITLE
Feat/fly 2547

### DIFF
--- a/src/PegOutContract.sol
+++ b/src/PegOutContract.sol
@@ -188,6 +188,9 @@ contract PegOutContract is
             revert SignatureValidator.IncorrectSignature(quote.lpRskAddress, eip712Hash, signature);
         }
 
+        // Mirror depositPegOut: same Quotes.PegOutQuote + registry so _validatePegOutTransaction
+        // reads claim-fed records unmodified (keyed by escrow requestHash / OP_RETURN id).
+        _pegOutQuotes[requestHash] = quote;
         _pegOutRegistry[requestHash].depositTimestamp = block.timestamp;
         _pegOutRegistry[requestHash].depositBlock = block.number;
 
@@ -408,7 +411,7 @@ contract PegOutContract is
         }
     }
 
-    /// @notice Escrow CLAIMED quote required for {registerClaimedPegOut}.
+    /// @notice Escrow CLAIMED quote required for {registerClaimedPegOut} (source before mirror into `_pegOutQuotes`).
     function _requireClaimedEscrowQuote(bytes32 requestHash)
         private
         view

--- a/src/interfaces/IPegOut.sol
+++ b/src/interfaces/IPegOut.sol
@@ -136,8 +136,9 @@ interface IPegOut is IPausable, IERC5267 {
     function depositPegOut(Quotes.PegOutQuote calldata quote, bytes calldata signature) external payable;
 
     /// @notice Commit-first path: PegOutEscrow registers a claimed peg-out under the request hash
-    /// @dev Only callable by the wired PegOutEscrow. Quote terms stay on escrow; this contract records
-    /// claim timing / completion and holds the forwarded RBTC.
+    /// @dev Only callable by the wired PegOutEscrow. Loads the escrow-built quote, re-verifies the LP
+    /// signature, stores the same quote-shaped record as {depositPegOut} under requestHash, records
+    /// claim timing, and holds the forwarded RBTC so settlement validation stays on one struct / one path.
     /// @param requestHash Escrow-minted request id
     /// @param signature LP EIP-712 signature over the escrowed quote (with lpRskAddress set)
     function registerClaimedPegOut(bytes32 requestHash, bytes calldata signature) external payable;

--- a/test/pegout-escrow/PegOutEscrow.t.sol
+++ b/test/pegout-escrow/PegOutEscrow.t.sol
@@ -19,6 +19,7 @@ import {FlyoverConfigurationsMock} from "../pegin/FlyoverConfigurationsMock.sol"
 
 /// @title PegOutEscrow S11.1 state machine + claim gates
 /// @dev Test names map to S11.1 transition / race / B-scenario ids where applicable.
+/// TODO: rename tests that embed user-story ids (e.g. S13.1) once those ids are no longer needed for review.
 contract PegOutEscrowTest is Test {
     /// @dev Mirrors impl-only {PegOutEscrow.EscrowPegOutChangePaid} for expectEmit.
     event EscrowPegOutChangePaid(
@@ -440,6 +441,39 @@ contract PegOutEscrowTest is Test {
         assertEq(escrow.getPegOutQuote(requestHash).lpRskAddress, lp);
         assertEq(address(pegOut).balance, pegOutBefore + payout);
         assertEq(address(escrow).balance, escrowBefore - payout);
+    }
+
+    /// @notice Claim-fed quote mirrored into PegOutContract passes today's validatePegout.
+    /// TODO: rename off the S13.1 story id once review no longer needs the ticket tag.
+    function test_S13_1_ClaimFedRecord_PassesValidatePegout() public {
+        bytes memory dest = _btcAddressP2pkh();
+        vm.prank(user);
+        bytes32 requestHash = escrow.requestPegOut{value: DEFAULT_VALUE}(
+            dest,
+            user
+        );
+
+        Quotes.PegOutQuote memory quote = escrow.getPegOutQuote(requestHash);
+        bytes memory signature = _signForLp(lpKey, quote, lp);
+        vm.prank(lp);
+        escrow.claimPegOut(requestHash, signature);
+
+        quote = escrow.getPegOutQuote(requestHash);
+        bytes memory btcTx = _generateBtcTx(quote, requestHash);
+
+        vm.prank(lp);
+        Quotes.PegOutQuote memory returned = pegOut.validatePegout(
+            requestHash,
+            btcTx
+        );
+
+        assertEq(returned.lpRskAddress, lp);
+        assertEq(returned.value, quote.value);
+        assertEq(returned.callFee, quote.callFee);
+        assertEq(
+            keccak256(returned.depositAddress),
+            keccak256(quote.depositAddress)
+        );
     }
 
     function test_R4_B1_SecondClaim_RevertsInvalidState() public {
@@ -952,6 +986,11 @@ contract PegOutEscrowTest is Test {
     // helpers
     // -------------------------------------------------------------------------
 
+    string constant HELPER_SCRIPT_GENERATE_BTC_TX =
+        "script/helpers/generate-btc-tx.ts";
+    string constant HELPER_SCRIPT_GET_BTC_ADDRESS_BYTES =
+        "script/helpers/get-btc-address-bytes.ts";
+
     function _requestDefault() internal returns (bytes32 requestHash) {
         vm.prank(user);
         requestHash = escrow.requestPegOut{value: DEFAULT_VALUE}(DEST, user);
@@ -979,6 +1018,31 @@ contract PegOutEscrowTest is Test {
         bytes32 eip712Hash = pegOut.hashPegOutQuoteEIP712(quote);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, eip712Hash);
         return abi.encodePacked(r, s, v);
+    }
+
+    /// @dev P2PKH address bytes matching generate-btc-tx.ts / LpRefund helpers.
+    function _btcAddressP2pkh() internal returns (bytes memory) {
+        string[] memory inputs = new string[](4);
+        inputs[0] = "npx";
+        inputs[1] = "ts-node";
+        inputs[2] = HELPER_SCRIPT_GET_BTC_ADDRESS_BYTES;
+        inputs[3] = "p2pkh";
+        return vm.ffi(inputs);
+    }
+
+    function _generateBtcTx(
+        Quotes.PegOutQuote memory quote,
+        bytes32 quoteHash
+    ) internal returns (bytes memory) {
+        string[] memory inputs = new string[](7);
+        inputs[0] = "npx";
+        inputs[1] = "ts-node";
+        inputs[2] = HELPER_SCRIPT_GENERATE_BTC_TX;
+        inputs[3] = vm.toString(quoteHash);
+        inputs[4] = vm.toString(quote.depositAddress);
+        inputs[5] = vm.toString(quote.value);
+        inputs[6] = "p2pkh";
+        return vm.ffi(inputs);
     }
 
     /// @dev `state` mapping is at struct offset 4 under the ERC-7201 root.


### PR DESCRIPTION
## What

After claim, `registerClaimedPegOut` mirrors the escrow-built `Quotes.PegOutQuote` into `_pegOutQuotes[requestHash]` (same store as `depositPegOut`), so today’s `_validatePegOutTransaction` accepts claim-fed records with no validation-path changes. Escrow-only access control and LP `SignatureValidator.verify` are unchanged. Public `depositPegOut` stays for the dual path until it is removed in a dedicated PR.

## Why

Claim already forwarded RBTC and registry timing, but never wrote the quote body, so settlement hit `QuoteNotFound`. Without one mirrored record feeding the existing validator, refund/SPV validation cannot run on commit-first peg-outs (drift risk of a second quote/validation path).

## Type of Change

- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Refactor (no intended behavior change)
- [ ] Security hardening
- [ ] Tests only
- [ ] Build/CI/Tooling
- [ ] Documentation

## Affected Areas

- [ ] PegIn flow (`registerPegIn`, `callForUser`, quote validation)
- [x] PegOut flow (`depositPegout`, `refundPegOut`, `refundUserPegOut`)
- [ ] Liquidity Provider lifecycle (register/update/status/resign/collateral/withdraw)
- [ ] Pause/operational controls
- [x] Quote hashing/signature logic
- [x] Bitcoin tx / PMT / merkle validation
- [ ] Deployment or upgrade scripts / Makefile targets
- [ ] CI workflows (`ci`, `fuzz`, `formal`, `slither`, `codeql`)
- [ ] Docs

## Risk & Security Review

- [x] Access control and authorization paths reviewed
- [x] Reentrancy and external call paths reviewed
- [x] Storage layout / upgrade safety reviewed (if upgradeable code changed)
- [x] Time/block/confirmation assumptions reviewed
- [x] BTC tx output/index assumptions reviewed (if pegout validation touched)
- [x] No secrets or sensitive values added

## Test Plan

List what you ran locally and the outcome:

- [ ] `npm run lint:sol`
- [ ] `npm run lint:ts`
- [ ] `npm run compile`
- [x] `npm test` — `forge test --match-path 'test/pegout-escrow/**'` (35 passed, including `test_S13_1_ClaimFedRecord_PassesValidatePegout`); `DeployPegOutEscrow` suite green
- [ ] `npm run test:fuzz` (if logic/state transitions changed)
- [ ] `npm run test:invariant` (if invariant-sensitive logic changed)
- [ ] `npm run test:formal` (if formal-verification-sensitive logic changed)
- [ ] `npm run test:integration` (if integration paths changed)
- [ ] `npm run test:e2e` (if deployment/ownership flows changed)

Additional notes on test coverage, edge cases, and any tests intentionally skipped:

- Acceptance: claim → FFI BTC tx (`OP_RETURN` = `requestHash`) → `validatePegout` returns mirrored quote fields.
- `_validatePegOutTransaction` unmodified; only field *storage* at register time changed.
- Non-escrow `registerClaimedPegOut` still covered by existing deploy tests (`OnlyPegOutEscrow`).
- Out of scope: third-party refund / `FULFILLED` notify, short-delivery floor, regtest e2e `refundPegOut`.
- TODO in escrow suite: rename ticket-tagged test names once review no longer needs them.

## Deployment & Ops Impact

- [x] No deployment impact
- [ ] Requires deployment
- [ ] Requires upgrade
- [ ] Env/config changes required (`.env`, network RPCs, verification, etc.)
- [ ] Runbook/update instructions added to PR description

If deployment/upgrade is needed, include target network(s), simulation command(s), and rollback considerations.

## Related Issues

- Jira: [FLY-2547](https://rsklabs.atlassian.net/browse/FLY-2547)

## Reviewer Notes

- Focus on `registerClaimedPegOut`: after sig verify it now does `_pegOutQuotes[requestHash] = quote` alongside registry writes — keyed by escrow `requestHash` (OP_RETURN id), not `keccak256(encodePegOutQuote)`.
- One struct (`Quotes.PegOutQuote`), one validation path; reconstruction stays in escrow `_buildQuote` only.
- Quote body is intentionally duplicated in storage (escrow + PegOutContract) so settlement internals stay unchanged; not a second builder/validator.
- `depositPegOut` not retired/gated (legacy quote path kept for existing LPS/SDK).
