### PR TITLE
Feat/fly 2548

### DIFF
--- a/src/PegOutContract.sol
+++ b/src/PegOutContract.sol
@@ -32,8 +32,9 @@ contract PegOutContract is
     /// @notice This struct is used to store the information of a peg out
     /// @param completed whether the peg out has been completed or not,
     /// completed means the peg out was paid and refunded (to any party)
-    /// @param depositTimestamp the timestamp of the deposit
-    /// @param depositBlock the block where the deposit was recorded
+    /// @param depositTimestamp Penalty-clock anchor: user deposit time for legacy
+    /// {depositPegOut}, claim time for commit-first {registerClaimedPegOut}
+    /// @param depositBlock Block of the same anchor as {depositTimestamp}
     struct PegOutRecord {
         bool completed;
         uint256 depositTimestamp;
@@ -486,9 +487,9 @@ contract PegOutContract is
         return _pegOutRegistry[quoteHash].completed;
     }
 
-    /// @notice This function is used to check if a liquidity provider should be penalized
-    /// according to the following rules:
-    /// - If the transfer was not made on time, the liquidity provider should be penalized
+    /// @notice Whether the LP should be penalized for late BTC delivery or late refund.
+    /// @dev The transfer deadline is measured from the registry anchor
+    /// (`depositTimestamp` / `depositBlock`: claim time on commit-first, deposit time on legacy).
     /// @param quote the peg out quote
     /// @param quoteHash the hash of the quote
     /// @param blockHash the hash of the block that contains the first confirmation of the peg out transaction
@@ -549,7 +550,6 @@ contract PegOutContract is
 
         quote = _pegOutQuotes[quoteHash];
         if (quote.lbcAddress == address(0)) revert Flyover.QuoteNotFound(quoteHash);
-        if (quote.lpRskAddress != msg.sender) revert Flyover.InvalidSender(quote.lpRskAddress, msg.sender);
 
         BtcUtils.TxRawOutput[] memory outputs = BtcUtils.getOutputs(btcTx);
         _validateBtcTxNullData(outputs, quoteHash);

--- a/src/interfaces/IPegOut.sol
+++ b/src/interfaces/IPegOut.sol
@@ -143,9 +143,10 @@ interface IPegOut is IPausable, IERC5267 {
     /// @param signature LP EIP-712 signature over the escrowed quote (with lpRskAddress set)
     function registerClaimedPegOut(bytes32 requestHash, bytes calldata signature) external payable;
 
-    /// @notice This function is used by the liquidity provider to recover the funds spent on the peg out service plus
-    /// their fee for the service. It proves the inclusion of the transaction paying to the user in the Bitcoin network.
-    /// The LP is expected to have reviewed all quote fields when issuing the quote, as they represent the agreed terms.
+    /// @notice Recovers escrowed RBTC plus the LP fee against an SPV proof of the BTC payment.
+    /// @dev Any caller may submit the proof (e.g. a watchtower). Payout always goes to the
+    /// recorded LP (`quote.lpRskAddress`), never to `msg.sender`. Late fulfillment still
+    /// completes but may slash the LP and credit the caller via the existing punisher reward.
     /// @param quoteHash hash of the quote being refunded
     /// @param btcTx the Bitcoin raw transaction without witness data. It must include
     /// the required outputs in this EXACT order
@@ -190,11 +191,9 @@ interface IPegOut is IPausable, IERC5267 {
     /// @param quoteHash the hash of the quote to check
     function isQuoteCompleted(bytes32 quoteHash) external view returns (bool);
 
-    /// @notice This function validates a Bitcoin transaction for a peg out refund without confirmations.
-    /// It allows liquidity providers to verify a transaction will be accepted before broadcasting to Bitcoin.
-    /// This performs the same validations as refundPegOut except for confirmations.
-    /// The LP is responsible for having reviewed all quote fields when issuing the quote, as they represent
-    /// the agreed terms.
+    /// @notice Validates a Bitcoin transaction for a peg-out refund without checking confirmations.
+    /// @dev Same checks as {refundPegOut} except confirmations. Any caller may preflight
+    /// (including a third party); does not move funds.
     /// @param quoteHash hash of the quote being validated
     /// @param btcTx the bitcoin raw transaction without the witness (does not need to be broadcasted yet)
     /// @return quote the PegOutQuote associated with the validated transaction

--- a/test/pegout/LpRefund.t.sol
+++ b/test/pegout/LpRefund.t.sol
@@ -143,27 +143,50 @@ contract LpRefundTest is PegOutTestBase {
         );
     }
 
-    function test_RefundPegOut_RevertsIfNotCalledByLP() public {
+    function test_RefundPegOut_AllowsThirdPartyCallerAndPaysRecordedLp()
+        public
+    {
         Quotes.PegOutQuote memory quote = createAndDepositQuote();
         bytes32 quoteHash = pegOutContract.hashPegOutQuote(quote);
 
-        bytes memory btcTx = generateBtcTx(quote, quoteHash);
-
-        // fullLp tries to refund pegOutLp's quote
-        vm.prank(fullLp);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                Flyover.InvalidSender.selector,
-                pegOutLp,
-                fullLp
-            )
+        bytes memory header = createBtcBlockHeader(
+            uint32(block.timestamp + 100)
         );
+        bridgeMock.setHeaderByHash(BLOCK_HEADER_HASH, header);
+        bridgeMock.setConfirmations(
+            int256(uint256(quote.transferConfirmations))
+        );
+
+        bytes memory btcTx = generateBtcTx(quote, quoteHash);
+        uint256 refundAmount = getTotalValue(quote);
+        uint256 lpBalanceBefore = pegOutLp.balance;
+        uint256 callerBalanceBefore = fullLp.balance;
+        uint256 callerRewardsBefore = collateralManagement.getRewards(fullLp);
+
+        vm.prank(fullLp);
         pegOutContract.refundPegOut(
             quoteHash,
             btcTx,
             BLOCK_HEADER_HASH,
             PARTIAL_MERKLE_TREE,
             merkleHashes
+        );
+
+        assertTrue(pegOutContract.isQuoteCompleted(quoteHash));
+        assertEq(
+            pegOutLp.balance,
+            lpBalanceBefore + refundAmount,
+            "Recorded LP must receive the payout"
+        );
+        assertEq(
+            fullLp.balance,
+            callerBalanceBefore,
+            "Third-party caller must not receive the RBTC payout"
+        );
+        assertEq(
+            collateralManagement.getRewards(fullLp),
+            callerRewardsBefore,
+            "On-time third-party refund pays no punisher reward"
         );
     }
 
@@ -415,13 +438,12 @@ contract LpRefundTest is PegOutTestBase {
     {
         Quotes.PegOutQuote memory quote = createAndDepositQuote();
         bytes32 quoteHash = pegOutContract.hashPegOutQuote(quote);
+        // Registry depositTimestamp is stamped at deposit (legacy) / claim (commit-first).
+        uint256 depositTimestamp = block.timestamp;
 
-        // Setup header with late timestamp (after transferTime + btcBlockTime)
+        // Setup header with late timestamp (after deposit/claim + transferTime + btcBlockTime)
         uint32 lateTime = uint32(
-            quote.agreementTimestamp +
-                quote.transferTime +
-                TEST_BTC_BLOCK_TIME +
-                500
+            depositTimestamp + quote.transferTime + TEST_BTC_BLOCK_TIME + 500
         );
         bytes memory header = createBtcBlockHeader(lateTime);
         bridgeMock.setHeaderByHash(BLOCK_HEADER_HASH, header);
@@ -435,9 +457,7 @@ contract LpRefundTest is PegOutTestBase {
         uint256 penalty = quote.penaltyFee;
         uint256 reward = (penalty * TEST_REWARD_PERCENTAGE) / 10000;
 
-        // assert to confirm time is late enough
-        assertTrue(quote.expireDate < lateTime);
-        // Refund should succeed but emit penalization
+        // Refund should succeed but emit penalization (LP self-submit keeps self-punisher)
         vm.prank(pegOutLp);
         vm.expectEmit(true, false, false, true);
         emit IPegOut.PegOutRefunded(quoteHash);
@@ -456,6 +476,62 @@ contract LpRefundTest is PegOutTestBase {
             BLOCK_HEADER_HASH,
             PARTIAL_MERKLE_TREE,
             merkleHashes
+        );
+    }
+
+    function test_RefundPegOut_ThirdPartyLateProofPaysLpAndRewardsCaller()
+        public
+    {
+        Quotes.PegOutQuote memory quote = createAndDepositQuote();
+        bytes32 quoteHash = pegOutContract.hashPegOutQuote(quote);
+        uint256 depositTimestamp = block.timestamp;
+
+        uint32 lateTime = uint32(
+            depositTimestamp + quote.transferTime + TEST_BTC_BLOCK_TIME + 500
+        );
+        bytes memory header = createBtcBlockHeader(lateTime);
+        bridgeMock.setHeaderByHash(BLOCK_HEADER_HASH, header);
+        bridgeMock.setConfirmations(
+            int256(uint256(quote.transferConfirmations))
+        );
+
+        bytes memory btcTx = generateBtcTx(quote, quoteHash);
+        uint256 refundAmount = getTotalValue(quote);
+        uint256 penalty = quote.penaltyFee;
+        uint256 reward = (penalty * TEST_REWARD_PERCENTAGE) / 10000;
+        uint256 lpBalanceBefore = pegOutLp.balance;
+        uint256 lpCollateralBefore = collateralManagement.getPegOutCollateral(
+            pegOutLp
+        );
+        uint256 callerRewardsBefore = collateralManagement.getRewards(fullLp);
+
+        vm.prank(fullLp);
+        vm.expectEmit(true, true, true, true);
+        emit ICollateralManagement.Penalized(
+            pegOutLp,
+            fullLp,
+            quoteHash,
+            Flyover.ProviderType.PegOut,
+            penalty,
+            reward
+        );
+        pegOutContract.refundPegOut(
+            quoteHash,
+            btcTx,
+            BLOCK_HEADER_HASH,
+            PARTIAL_MERKLE_TREE,
+            merkleHashes
+        );
+
+        assertTrue(pegOutContract.isQuoteCompleted(quoteHash));
+        assertEq(pegOutLp.balance, lpBalanceBefore + refundAmount);
+        assertEq(
+            collateralManagement.getPegOutCollateral(pegOutLp),
+            lpCollateralBefore - penalty
+        );
+        assertEq(
+            collateralManagement.getRewards(fullLp),
+            callerRewardsBefore + reward
         );
     }
 
@@ -802,22 +878,19 @@ contract LpRefundTest is PegOutTestBase {
         pegOutContract.validatePegout(quoteHash, btcTx);
     }
 
-    function test_ValidatePegout_RevertsIfNotCalledByLP() public {
+    function test_ValidatePegout_AllowsThirdPartyCaller() public {
         Quotes.PegOutQuote memory quote = createAndDepositQuote();
         bytes32 quoteHash = pegOutContract.hashPegOutQuote(quote);
 
         bytes memory btcTx = generateBtcTx(quote, quoteHash);
 
-        // fullLp tries to validate pegOutLp's quote
         vm.prank(fullLp);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                Flyover.InvalidSender.selector,
-                pegOutLp,
-                fullLp
-            )
+        Quotes.PegOutQuote memory returnedQuote = pegOutContract.validatePegout(
+            quoteHash,
+            btcTx
         );
-        pegOutContract.validatePegout(quoteHash, btcTx);
+        assertEq(returnedQuote.lpRskAddress, pegOutLp);
+        assertEq(returnedQuote.value, quote.value);
     }
 
     function test_ValidatePegout_RevertsIfBtcTxNotRelatedToQuote() public {


### PR DESCRIPTION
## What

Open `refundPegOut` and `validatePegout` to any caller so a third party can submit (or preflight) an SPV proof when the LP cannot. RBTC payout still goes only to the recorded LP (`quote.lpRskAddress`). Document that `PegOutRecord.depositTimestamp` / `depositBlock` are the penalty clock (user deposit on the legacy path; claim time on the commit-first path). Slash / punisher rewards are unchanged.

## Why

If the responsible LP pays BTC but cannot submit the RSK proof, funds stay locked and a late user refund can slash the LP while the user keeps the BTC. Allowing third-party submission unblocks that path (and future watchtower use) without changing who receives the escrowed RBTC.

## Type of Change

- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Refactor (no intended behavior change)
- [ ] Security hardening
- [ ] Tests only
- [ ] Build/CI/Tooling
- [ ] Documentation

## Affected Areas

- [ ] PegIn flow (`registerPegIn`, `callForUser`, quote validation)
- [x] PegOut flow (`depositPegout`, `refundPegOut`, `refundUserPegOut`)
- [ ] Liquidity Provider lifecycle (register/update/status/resign/collateral/withdraw)
- [ ] Pause/operational controls
- [ ] Quote hashing/signature logic
- [x] Bitcoin tx / PMT / merkle validation
- [ ] Deployment or upgrade scripts / Makefile targets
- [ ] CI workflows (`ci`, `fuzz`, `formal`, `slither`, `codeql`)
- [ ] Docs

## Risk & Security Review

- [x] Access control and authorization paths reviewed
- [x] Reentrancy and external call paths reviewed
- [x] Storage layout / upgrade safety reviewed (if upgradeable code changed)
- [x] Time/block/confirmation assumptions reviewed
- [x] BTC tx output/index assumptions reviewed (if pegout validation touched)
- [x] No secrets or sensitive values added

## Test Plan

List what you ran locally and the outcome:

- [ ] `npm run lint:sol`
- [ ] `npm run lint:ts`
- [ ] `npm run compile`
- [ ] `npm test`
- [ ] `npm run test:fuzz` (if logic/state transitions changed)
- [ ] `npm run test:invariant` (if invariant-sensitive logic changed)
- [ ] `npm run test:formal` (if formal-verification-sensitive logic changed)
- [ ] `npm run test:integration` (if integration paths changed)
- [ ] `npm run test:e2e` (if deployment/ownership flows changed)

Additional notes on test coverage, edge cases, and any tests intentionally skipped:

- `forge test --match-contract LpRefundTest` — passed (28), including:
  - third-party on-time refund pays recorded LP only (no punisher reward)
  - third-party late proof pays LP and credits punisher reward to caller
  - LP self-submit on-time / late unchanged (including self-punisher when late)
  - third-party `validatePegout` preflight succeeds
- Full `make test` still fails two pre-existing differential suites (`addresses.json` missing `.rskMainnet.LiquidityBridgeContract.address`); unrelated to this change. Prefer `make test-unit` / targeted peg-out tests for this PR.

## Deployment & Ops Impact

- [ ] No deployment impact
- [ ] Requires deployment
- [x] Requires upgrade
- [ ] Env/config changes required (`.env`, network RPCs, verification, etc.)
- [ ] Runbook/update instructions added to PR description

Upgradeable `PegOutContract` behavior change (caller check removed). No storage layout change.

## Related Issues

- Jira: [FLY-2548](https://rsklabs.atlassian.net/browse/FLY-2548)

## Reviewer Notes

- Payout path unchanged: still `quote.lpRskAddress`, never `msg.sender`.
- As legacy `depositPegout` flow will be removed, no need to change that `slashTime` parameters, which is already by default implemented inside `registerClaimedPegout`
- Reward/slash mechanism unchanged: only late/penalizable refunds credit the caller via existing `slashPegOutCollateral`.
- **Deferred:** dedicated caller reward for on-time (non-penalizable) third-party refunds — honest submitters are unpaid until a follow-up.
- **Out of this PR:** short-delivery floor / top-up, escrow `FULFILLED` notify from `refundPegOut`, watchtower implementation.
- Shared helper `_validatePegOutTransaction` drives both `refundPegOut` and `validatePegout`, so both are open to third parties.