### PR TITLE
Feat/fly 2549

### DIFF
--- a/src/PegOutContract.sol
+++ b/src/PegOutContract.sol
@@ -293,12 +293,16 @@ contract PegOutContract is
         uint256 merkleBranchPath,
         bytes32[] calldata merkleBranchHashes
     ) external nonReentrant whenNotHardPaused override {
-        Quotes.PegOutQuote memory quote = _validatePegOutTransaction(quoteHash, btcTx);
+        (Quotes.PegOutQuote memory quote, uint256 paidAmount) = _validatePegOutTransaction(quoteHash, btcTx);
         _validateBtcTxConfirmations(quote, btcTx, btcBlockHeaderHash, merkleBranchPath, merkleBranchHashes);
+
+        uint256 floor = _deliveryFloor(quote, _pegOutRegistry[quoteHash].maxMinerFee);
+        uint256 topUp = paidAmount < floor ? floor - paidAmount : 0;
 
         delete _pegOutQuotes[quoteHash];
         _pegOutRegistry[quoteHash].completed = true;
         emit PegOutRefunded(quoteHash);
+        _notifyEscrowSettlement(quoteHash, IPegOutEscrow.EscrowedPegOutState.FULFILLED);
 
         if (_shouldPenalize(quote, quoteHash, btcBlockHeaderHash)) {
             uint256 collateral = _collateralManagement.getPegOutCollateral(quote.lpRskAddress);
@@ -308,7 +312,14 @@ contract PegOutContract is
             _collateralManagement.slashPegOutCollateral(msg.sender, quote, quoteHash);
         }
 
-        uint256 refundAmount = quote.value + quote.callFee + quote.gasFee;
+        if (topUp > 0) {
+            (bool topSent,) = quote.rskRefundAddress.call{value: topUp}("");
+            if (!topSent) {
+                _increaseBalance(quote.rskRefundAddress, topUp);
+            }
+        }
+
+        uint256 refundAmount = quote.value + quote.callFee + quote.gasFee - topUp;
         (bool sent,) = quote.lpRskAddress.call{value: refundAmount}("");
         if (!sent) {
             _increaseBalance(quote.lpRskAddress, refundAmount);
@@ -364,7 +375,7 @@ contract PegOutContract is
         bytes32 quoteHash,
         bytes calldata btcTx
     ) external view override returns (Quotes.PegOutQuote memory quote) {
-        return _validatePegOutTransaction(quoteHash, btcTx);
+        (quote,) = _validatePegOutTransaction(quoteHash, btcTx);
     }
 
     /// @inheritdoc IPegOut
@@ -543,13 +554,16 @@ contract PegOutContract is
     /// Used by both validatePegout (for unbroadcasted transactions) and refundPegOut (before confirmation check).
     /// The validation expects fixed output positions in btcTx:
     /// output 0 is the payment output and output 1 is the OP_RETURN quote-hash output.
+    /// Amount shortfalls relative to the short-delivery floor are not reverted here; {refundPegOut}
+    /// tops the user up from escrow.
     /// @param quoteHash the hash of the quote being validated
     /// @param btcTx the Bitcoin transaction
     /// @return quote the PegOutQuote associated with the transaction
+    /// @return paidAmount BTC payment output value in wei
     function _validatePegOutTransaction(
         bytes32 quoteHash,
         bytes calldata btcTx
-    ) private view returns (Quotes.PegOutQuote memory quote) {
+    ) private view returns (Quotes.PegOutQuote memory quote, uint256 paidAmount) {
         if (_isQuoteCompleted(quoteHash)) revert QuoteAlreadyCompleted(quoteHash);
 
         quote = _pegOutQuotes[quoteHash];
@@ -557,8 +571,21 @@ contract PegOutContract is
 
         BtcUtils.TxRawOutput[] memory outputs = BtcUtils.getOutputs(btcTx);
         _validateBtcTxNullData(outputs, quoteHash);
-        _validateBtcTxAmount(outputs, quote);
+        paidAmount = outputs[_PAY_TO_ADDRESS_OUTPUT].value * _SAT_TO_WEI_CONVERSION;
         _validateBtcTxDestination(outputs, quote);
+    }
+
+    /// @notice Short-delivery floor: `amount − callFee − maxMinerFee` (walkthrough 10·D / B8).
+    /// @dev Satoshi-floors the result the same way the legacy required amount did for `value`.
+    function _deliveryFloor(
+        Quotes.PegOutQuote memory quote,
+        uint256 maxMinerFee
+    ) private pure returns (uint256 floorAmount) {
+        uint256 deductions = quote.callFee + maxMinerFee;
+        floorAmount = quote.value > deductions ? quote.value - deductions : 0;
+        if (floorAmount > _SAT_TO_WEI_CONVERSION && (floorAmount % _SAT_TO_WEI_CONVERSION) != 0) {
+            floorAmount -= floorAmount % _SAT_TO_WEI_CONVERSION;
+        }
     }
 
     /// @notice This function is used to validate the number of confirmations of the Bitcoin transaction.
@@ -602,21 +629,6 @@ contract PegOutContract is
         if (keccak256(quote.depositAddress) != keccak256(btcTxDestination)) {
             revert InvalidDestination(quote.depositAddress, btcTxDestination);
         }
-    }
-
-    /// @notice This function is used to validate the amount of the Bitcoin transaction
-    /// @param outputs the outputs of the Bitcoin transaction
-    /// @param quote the peg out quote
-    function _validateBtcTxAmount(
-        BtcUtils.TxRawOutput[] memory outputs,
-        Quotes.PegOutQuote memory quote
-    ) private pure {
-        uint256 requiredAmount = quote.value;
-        if (quote.value > _SAT_TO_WEI_CONVERSION && (quote.value % _SAT_TO_WEI_CONVERSION) != 0) {
-            requiredAmount = quote.value - (quote.value % _SAT_TO_WEI_CONVERSION);
-        }
-        uint256 paidAmount = outputs[_PAY_TO_ADDRESS_OUTPUT].value * _SAT_TO_WEI_CONVERSION;
-        if (paidAmount < requiredAmount) revert Flyover.InsufficientAmount(paidAmount, requiredAmount);
     }
 
     /// @notice This function is used to validate the null data of the Bitcoin transaction. The null data

--- a/src/PegOutContract.sol
+++ b/src/PegOutContract.sol
@@ -35,10 +35,13 @@ contract PegOutContract is
     /// @param depositTimestamp Penalty-clock anchor: user deposit time for legacy
     /// {depositPegOut}, claim time for commit-first {registerClaimedPegOut}
     /// @param depositBlock Block of the same anchor as {depositTimestamp}
+    /// @param maxMinerFee Snapshotted short-delivery floor cap (wei) from escrow at claim;
+    /// zero when unset (legacy depositPegOut)
     struct PegOutRecord {
         bool completed;
         uint256 depositTimestamp;
         uint256 depositBlock;
+        uint256 maxMinerFee;
     }
 
     /// @notice The version of the contract
@@ -194,6 +197,7 @@ contract PegOutContract is
         _pegOutQuotes[requestHash] = quote;
         _pegOutRegistry[requestHash].depositTimestamp = block.timestamp;
         _pegOutRegistry[requestHash].depositBlock = block.number;
+        _pegOutRegistry[requestHash].maxMinerFee = _pegOutEscrow.getMaxMinerFee(requestHash);
 
         emit PegOutDeposit(requestHash, quote.lpRskAddress, block.timestamp, msg.value);
     }

--- a/src/PegOutEscrow.sol
+++ b/src/PegOutEscrow.sol
@@ -25,6 +25,14 @@ contract PegOutEscrow is
     ReentrancyGuard,
     IPegOutEscrow
 {
+    /// @notice Per-request escrow record: quote-shaped terms plus snapshotted floor inputs.
+    /// @dev `maxMinerFee` is frozen at {requestPegOut} from FlyoverConfigurations so a later
+    /// config change cannot move this peg-out's short-delivery floor (B8 / 10·D).
+    struct EscrowedPegOut {
+        Quotes.PegOutQuote quote;
+        uint256 maxMinerFee;
+    }
+
     /// @custom:storage-location erc7201:rsk.flyover.PegOutEscrow
     struct PegOutEscrowStorage {
         /// Settlement contract (claim forwards funds here; also supplies dustThreshold).
@@ -33,8 +41,8 @@ contract PegOutEscrow is
         ICollateralManagement collateralManagement;
         /// Active peg-out fee, bounds, deadlines, and confirmation tiers.
         IFlyoverConfigurations configurations;
-        /// Quote-shaped terms snapshotted at request (deleted on cancel / terminal states).
-        mapping(bytes32 => Quotes.PegOutQuote) quotes;
+        /// Request envelope snapshotted at request (deleted on cancel / terminal states).
+        mapping(bytes32 => EscrowedPegOut) requests;
         /// Lifecycle per requestHash (`NONE` if never requested).
         mapping(bytes32 => EscrowedPegOutState) state;
         /// requestHash for each 1-based nonce; LPS rebuild after missed events.
@@ -146,8 +154,10 @@ contract PegOutEscrow is
         $.requestHashByNonce[nonce] = requestHash;
 
         uint256 confirmations = $.configurations.getRequiredPegOutBtcConfirmations(amount);
-        $.quotes[requestHash] =
+        EscrowedPegOut storage request = $.requests[requestHash];
+        request.quote =
             _buildQuote($, cfg, refundAddress, destinationAddress, amount, callFee, nonce, confirmations);
+        request.maxMinerFee = cfg.maxMinerFee;
 
         emit PegOutRequested(requestHash, refundAddress, amount, destinationAddress);
 
@@ -161,7 +171,7 @@ contract PegOutEscrow is
     function cancelPegOut(bytes32 requestHash) external override nonReentrant whenNotSoftPaused {
         PegOutEscrowStorage storage $ = _getStorage();
         _requireRequested($, requestHash);
-        Quotes.PegOutQuote memory q = $.quotes[requestHash];
+        Quotes.PegOutQuote memory q = $.requests[requestHash].quote;
         if (msg.sender != q.rskRefundAddress) {
             revert Flyover.InvalidSender(q.rskRefundAddress, msg.sender);
         }
@@ -182,7 +192,7 @@ contract PegOutEscrow is
         PegOutEscrowStorage storage $ = _getStorage();
         _requireRequested($, requestHash);
 
-        Quotes.PegOutQuote storage q = $.quotes[requestHash];
+        Quotes.PegOutQuote storage q = $.requests[requestHash].quote;
         if (block.timestamp > q.depositDateLimit) {
             revert ClaimWindowClosed(q.depositDateLimit);
         }
@@ -215,7 +225,7 @@ contract PegOutEscrow is
     function refundOnNoClaim(bytes32 requestHash) external override nonReentrant whenNotSoftPaused {
         PegOutEscrowStorage storage $ = _getStorage();
         _requireRequested($, requestHash);
-        Quotes.PegOutQuote memory q = $.quotes[requestHash];
+        Quotes.PegOutQuote memory q = $.requests[requestHash].quote;
         // solhint-disable-next-line gas-strict-inequalities
         if (block.timestamp <= q.depositDateLimit) {
             revert ClaimWindowOpen(q.depositDateLimit);
@@ -261,7 +271,16 @@ contract PegOutEscrow is
         if ($.state[requestHash] == EscrowedPegOutState.NONE) {
             revert Flyover.QuoteNotFound(requestHash);
         }
-        return $.quotes[requestHash];
+        return $.requests[requestHash].quote;
+    }
+
+    /// @inheritdoc IPegOutEscrow
+    function getMaxMinerFee(bytes32 requestHash) external view override returns (uint256) {
+        PegOutEscrowStorage storage $ = _getStorage();
+        if ($.state[requestHash] == EscrowedPegOutState.NONE) {
+            revert Flyover.QuoteNotFound(requestHash);
+        }
+        return $.requests[requestHash].maxMinerFee;
     }
 
     /// @inheritdoc IPegOutEscrow
@@ -290,7 +309,7 @@ contract PegOutEscrow is
         EscrowedPegOutState finalState
     ) private {
         $.state[requestHash] = finalState;
-        delete $.quotes[requestHash];
+        delete $.requests[requestHash];
     }
 
     // slither-disable-next-line arbitrary-send-eth,low-level-calls

--- a/src/interfaces/IPegOutEscrow.sol
+++ b/src/interfaces/IPegOutEscrow.sol
@@ -106,6 +106,10 @@ interface IPegOutEscrow {
     /// settlement source of truth alongside the lean {PegOutRequested} event.
     function getPegOutQuote(bytes32 requestHash) external view returns (Quotes.PegOutQuote memory);
 
+    /// @notice Snapshotted `maxMinerFee` from FlyoverConfigurations at {requestPegOut} time
+    /// @dev Used by PegOutContract for the short-delivery floor (B8). Reverts if state is `NONE`.
+    function getMaxMinerFee(bytes32 requestHash) external view returns (uint256);
+
     /// @notice Number of requests ever minted (monotone nonce high-water mark)
     /// @dev With {requestIdAt}, an LPS can rebuild the pending set after missed events.
     function totalRequests() external view returns (uint256);

--- a/test/fuzz/pegout/BtcTransactionParsing.fuzz.t.sol
+++ b/test/fuzz/pegout/BtcTransactionParsing.fuzz.t.sol
@@ -54,51 +54,45 @@ contract BtcTransactionParsingFuzzTest is PegOutFuzzTestBase {
         );
     }
 
-    /// @notice Fuzz test: BTC transaction with varying amounts
-    /// @dev Tests that refunds fail when BTC tx amount is less than quote value
-    ///      Contract validates in _validateBtcTxAmount and reverts with Flyover.InsufficientAmount
-    function testFuzz_RefundPegOut_ValidatesTransactionAmount(
+    /// @notice Fuzz test: under-floor BTC delivery tops up and still completes
+    /// @dev Floor = value − callFee − maxMinerFee; legacy deposit leaves maxMinerFee = 0.
+    function testFuzz_RefundPegOut_UnderFloor_TopsUpAndCompletes(
         uint128 quoteValue,
         uint128 btcTxAmount
     ) public {
         quoteValue = uint128(bound(quoteValue, 0.001 ether, 10 ether));
         btcTxAmount = uint128(bound(btcTxAmount, 0.0001 ether, 10 ether));
 
-        // The contract compares satoshi-normalized values, so constrain fuzz inputs
-        // against the same normalized amounts to avoid false revert expectations.
         uint64 satAmount = uint64(btcTxAmount / 1e10);
         uint256 paidAmountWei = uint256(satAmount) * 1e10;
-
-        uint256 requiredAmount = quoteValue;
-        if (quoteValue > 1e10 && (quoteValue % 1e10) != 0) {
-            requiredAmount = quoteValue - (quoteValue % 1e10);
-        }
-
-        vm.assume(paidAmountWei < requiredAmount);
 
         Quotes.PegOutQuote memory quote = createAndDepositFuzzQuote(quoteValue);
         bytes32 quoteHash = pegOutContract.hashPegOutQuote(quote);
 
-        // Generate BTC tx with different amount
+        uint256 deductions = quote.callFee; // maxMinerFee unset on legacy deposit
+        uint256 floorAmount = quote.value > deductions
+            ? quote.value - deductions
+            : 0;
+        if (floorAmount > 1e10 && (floorAmount % 1e10) != 0) {
+            floorAmount -= floorAmount % 1e10;
+        }
+
+        vm.assume(paidAmountWei < floorAmount);
+
         bytes memory btcTx = generateBtcTxWithCustomAmount(
             quote,
             quoteHash,
             btcTxAmount
         );
 
-        // Setup bridge
         setupFuzzBridgeMock(quote);
 
-        // expected values follow contract's satoshi conversion/rounding rules
+        uint256 topUp = floorAmount - paidAmountWei;
+        uint256 escrowed = quote.value + quote.callFee + quote.gasFee;
+        uint256 userBefore = quote.rskRefundAddress.balance;
+        uint256 lpBefore = pegOutLp.balance;
 
         vm.prank(pegOutLp);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                Flyover.InsufficientAmount.selector,
-                paidAmountWei,
-                requiredAmount
-            )
-        );
         pegOutContract.refundPegOut(
             quoteHash,
             btcTx,
@@ -106,6 +100,10 @@ contract BtcTransactionParsingFuzzTest is PegOutFuzzTestBase {
             PARTIAL_MERKLE_TREE,
             merkleHashes
         );
+
+        assertTrue(pegOutContract.isQuoteCompleted(quoteHash));
+        assertEq(quote.rskRefundAddress.balance, userBefore + topUp);
+        assertEq(pegOutLp.balance, lpBefore + escrowed - topUp);
     }
 
     /// @notice Fuzz test: BTC transaction amount should succeed when >= quote value

--- a/test/pegout-escrow/PegOutEscrow.t.sol
+++ b/test/pegout-escrow/PegOutEscrow.t.sol
@@ -55,6 +55,7 @@ contract PegOutEscrowTest is Test {
     FlyoverConfigurationsMock internal configurations;
     CollateralManagementMock internal collateral;
     PauseRegistry internal pauseRegistry;
+    BridgeMock internal bridge;
 
     address internal owner;
     address internal user;
@@ -63,6 +64,13 @@ contract PegOutEscrowTest is Test {
     uint256 internal lpKey;
     address internal otherLp;
     uint256 internal otherLpKey;
+
+    bytes32 internal constant BLOCK_HEADER_HASH = bytes32(uint256(1));
+    uint256 internal constant PARTIAL_MERKLE_TREE = 0;
+    bytes32[] internal merkleHashes;
+
+    /// @dev Seed config maxMinerFee (snapshotted per request).
+    uint256 internal constant MAX_MINER_FEE = 0.001 ether;
 
     bytes internal constant DEST =
         hex"0014deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
@@ -77,6 +85,9 @@ contract PegOutEscrowTest is Test {
         vm.deal(other, 100 ether);
         vm.deal(lp, 100 ether);
         vm.deal(otherLp, 100 ether);
+
+        merkleHashes = new bytes32[](1);
+        merkleHashes[0] = bytes32(uint256(1));
 
         PauseRegistry prImpl = new PauseRegistry();
         pauseRegistry = PauseRegistry(
@@ -93,7 +104,7 @@ contract PegOutEscrowTest is Test {
         configurations = new FlyoverConfigurationsMock();
         collateral = new CollateralManagementMock();
 
-        BridgeMock bridge = new BridgeMock();
+        bridge = new BridgeMock();
         PegOutContract pegOutImpl = new PegOutContract();
         pegOut = PegOutContract(
             payable(
@@ -198,6 +209,7 @@ contract PegOutEscrowTest is Test {
         assertEq(q.lbcAddress, address(pegOut));
         assertEq(q.lpRskAddress, address(0));
         assertEq(q.nonce, int64(uint64(nonce)));
+        assertEq(escrow.getMaxMinerFee(requestHash), MAX_MINER_FEE);
         assertEq(q.depositDateLimit, uint32(block.timestamp + CLAIM_WINDOW));
         assertEq(q.transferTime, uint32(CALL_TIME));
         assertEq(
@@ -915,6 +927,8 @@ contract PegOutEscrowTest is Test {
     {
         bytes32 requestHash = _requestDefault();
         Quotes.PegOutQuote memory before = escrow.getPegOutQuote(requestHash);
+        uint256 snapshottedMaxMinerFee = escrow.getMaxMinerFee(requestHash);
+        assertEq(snapshottedMaxMinerFee, MAX_MINER_FEE);
 
         IFlyoverConfigurations.ConfirmationTier[]
             memory tiers = new IFlyoverConfigurations.ConfirmationTier[](1);
@@ -935,7 +949,7 @@ contract PegOutEscrowTest is Test {
                 callTime: CALL_TIME,
                 expireTime: EXPIRE_TIME,
                 expireBlocks: EXPIRE_BLOCKS,
-                maxMinerFee: 0.001 ether
+                maxMinerFee: 0.05 ether
             })
         );
 
@@ -945,6 +959,11 @@ contract PegOutEscrowTest is Test {
         assertEq(afterCfg.value, before.value);
         assertEq(afterCfg.depositDateLimit, before.depositDateLimit);
         assertEq(afterCfg.expireDate, before.expireDate);
+        assertEq(escrow.getMaxMinerFee(requestHash), snapshottedMaxMinerFee);
+        assertEq(
+            configurations.getPegOutConfiguration().maxMinerFee,
+            0.05 ether
+        );
 
         bytes memory signature = _signForLp(lpKey, afterCfg, lp);
         vm.prank(lp);
@@ -955,31 +974,185 @@ contract PegOutEscrowTest is Test {
             escrow.getPegOutQuote(requestHash).penaltyFee,
             before.penaltyFee
         );
+        assertEq(escrow.getMaxMinerFee(requestHash), snapshottedMaxMinerFee);
         assertEq(
             uint256(escrow.getPegOutState(requestHash)),
             uint256(IPegOutEscrow.EscrowedPegOutState.CLAIMED)
         );
     }
 
-    /// @dev B8 is reserved in S11.1; PoC still rejects under-value at validation (no new state).
-    function test_B8_BelowFloor_ReservedPoCGap() public {
-        // Tiny payment cannot clear min after fee split — never leaves NONE (same gate as B7 today).
-        uint256 tiny = FIXED_FEE + 0.001 ether;
-        (uint256 amount, , ) = _expectedSplit(tiny);
-        assertLt(amount, MIN_AMOUNT);
+    /// @dev B8: delivery at the floor settles with no RBTC top-up.
+    function test_B8_AtFloor_NoTopUp() public {
+        (
+            bytes32 requestHash,
+            Quotes.PegOutQuote memory quote,
+            uint256 floor
+        ) = _claimWithP2pkhDest();
+        uint256 escrowed = quote.value + quote.callFee + quote.gasFee;
 
-        vm.prank(user);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IPegOutEscrow.NotServiceable.selector,
-                amount,
-                MIN_AMOUNT,
-                MAX_AMOUNT
-            )
+        bytes memory btcTx = _generateBtcTxWithAmount(
+            quote,
+            requestHash,
+            floor
         );
-        escrow.requestPegOut{value: tiny}(DEST, user);
+        _setupBridgeConfirmations(quote);
 
-        assertEq(escrow.totalRequests(), 0);
+        uint256 userBefore = user.balance;
+        uint256 lpBefore = lp.balance;
+
+        vm.prank(lp);
+        pegOut.refundPegOut(
+            requestHash,
+            btcTx,
+            BLOCK_HEADER_HASH,
+            PARTIAL_MERKLE_TREE,
+            merkleHashes
+        );
+
+        assertEq(user.balance, userBefore, "no top-up at floor");
+        assertEq(lp.balance, lpBefore + escrowed);
+        assertTrue(pegOut.isQuoteCompleted(requestHash));
+        assertEq(
+            uint256(escrow.getPegOutState(requestHash)),
+            uint256(IPegOutEscrow.EscrowedPegOutState.FULFILLED)
+        );
+    }
+
+    /// @dev B8: delivery above the floor settles with no RBTC top-up.
+    function test_B8_AboveFloor_NoTopUp() public {
+        (
+            bytes32 requestHash,
+            Quotes.PegOutQuote memory quote,
+            uint256 floor
+        ) = _claimWithP2pkhDest();
+        uint256 escrowed = quote.value + quote.callFee + quote.gasFee;
+        uint256 paid = floor + Quotes.SAT_TO_WEI_CONVERSION;
+
+        bytes memory btcTx = _generateBtcTxWithAmount(quote, requestHash, paid);
+        _setupBridgeConfirmations(quote);
+
+        uint256 userBefore = user.balance;
+        uint256 lpBefore = lp.balance;
+
+        vm.prank(lp);
+        pegOut.refundPegOut(
+            requestHash,
+            btcTx,
+            BLOCK_HEADER_HASH,
+            PARTIAL_MERKLE_TREE,
+            merkleHashes
+        );
+
+        assertEq(user.balance, userBefore, "no top-up above floor");
+        assertEq(lp.balance, lpBefore + escrowed);
+        assertTrue(pegOut.isQuoteCompleted(requestHash));
+    }
+
+    /// @dev B8: under-floor delivery tops up user and debits LP by the same shortfall.
+    function test_B8_UnderFloor_TopUpAndDebitLp() public {
+        (
+            bytes32 requestHash,
+            Quotes.PegOutQuote memory quote,
+            uint256 floor
+        ) = _claimWithP2pkhDest();
+        uint256 escrowed = quote.value + quote.callFee + quote.gasFee;
+        uint256 paid = floor - Quotes.SAT_TO_WEI_CONVERSION;
+        uint256 topUp = floor - paid;
+
+        bytes memory btcTx = _generateBtcTxWithAmount(quote, requestHash, paid);
+        _setupBridgeConfirmations(quote);
+
+        uint256 userBefore = user.balance;
+        uint256 lpBefore = lp.balance;
+        uint256 pegOutBefore = address(pegOut).balance;
+
+        vm.prank(lp);
+        pegOut.refundPegOut(
+            requestHash,
+            btcTx,
+            BLOCK_HEADER_HASH,
+            PARTIAL_MERKLE_TREE,
+            merkleHashes
+        );
+
+        assertEq(user.balance, userBefore + topUp);
+        assertEq(lp.balance, lpBefore + escrowed - topUp);
+        assertEq(user.balance - userBefore + lp.balance - lpBefore, escrowed);
+        assertEq(address(pegOut).balance, pegOutBefore - escrowed);
+        assertTrue(pegOut.isQuoteCompleted(requestHash));
+        assertEq(
+            uint256(escrow.getPegOutState(requestHash)),
+            uint256(IPegOutEscrow.EscrowedPegOutState.FULFILLED)
+        );
+    }
+
+    /// @dev B8: live maxMinerFee change after request does not move this peg-out's floor.
+    function test_B8_ConfigChangeAfterRequest_FloorUnchanged() public {
+        bytes memory dest = _btcAddressP2pkh();
+        vm.prank(user);
+        bytes32 requestHash = escrow.requestPegOut{value: DEFAULT_VALUE}(
+            dest,
+            user
+        );
+        Quotes.PegOutQuote memory quote = escrow.getPegOutQuote(requestHash);
+        uint256 snapshotted = escrow.getMaxMinerFee(requestHash);
+        uint256 floorBefore = _floor(quote, snapshotted);
+
+        IFlyoverConfigurations.ConfirmationTier[]
+            memory tiers = new IFlyoverConfigurations.ConfirmationTier[](1);
+        tiers[0] = IFlyoverConfigurations.ConfirmationTier({
+            maxAmount: type(uint256).max,
+            confirmations: TIER_CONFIRMATIONS
+        });
+        configurations.setPegOutConfiguration(
+            IFlyoverConfigurations.PegOutConfiguration({
+                fixedFee: FIXED_FEE,
+                percentageFee: PERCENTAGE_FEE,
+                minAmount: MIN_AMOUNT,
+                maxAmount: MAX_AMOUNT,
+                confirmationTiers: tiers,
+                penaltyFee: PENALTY_FEE,
+                claimWindow: CLAIM_WINDOW,
+                claimWindowBlocks: CLAIM_WINDOW_BLOCKS,
+                callTime: CALL_TIME,
+                expireTime: EXPIRE_TIME,
+                expireBlocks: EXPIRE_BLOCKS,
+                maxMinerFee: MAX_MINER_FEE * 20
+            })
+        );
+
+        assertEq(escrow.getMaxMinerFee(requestHash), snapshotted);
+        assertEq(
+            _floor(quote, escrow.getMaxMinerFee(requestHash)),
+            floorBefore
+        );
+
+        bytes memory signature = _signForLp(lpKey, quote, lp);
+        vm.prank(lp);
+        escrow.claimPegOut(requestHash, signature);
+        quote = escrow.getPegOutQuote(requestHash);
+
+        // Pay just under the snapshotted floor (would be above a higher live-config floor).
+        uint256 paid = floorBefore - Quotes.SAT_TO_WEI_CONVERSION;
+        bytes memory btcTx = _generateBtcTxWithAmount(quote, requestHash, paid);
+        _setupBridgeConfirmations(quote);
+
+        uint256 topUp = floorBefore - paid;
+        uint256 userBefore = user.balance;
+        uint256 lpBefore = lp.balance;
+        uint256 escrowed = quote.value + quote.callFee + quote.gasFee;
+
+        vm.prank(lp);
+        pegOut.refundPegOut(
+            requestHash,
+            btcTx,
+            BLOCK_HEADER_HASH,
+            PARTIAL_MERKLE_TREE,
+            merkleHashes
+        );
+
+        assertEq(user.balance, userBefore + topUp);
+        assertEq(lp.balance, lpBefore + escrowed - topUp);
     }
 
     // -------------------------------------------------------------------------
@@ -1002,6 +1175,52 @@ contract PegOutEscrowTest is Test {
         bytes memory signature = _signForLp(lpKey, quote, lp);
         vm.prank(lp);
         escrow.claimPegOut(requestHash, signature);
+    }
+
+    function _claimWithP2pkhDest()
+        internal
+        returns (
+            bytes32 requestHash,
+            Quotes.PegOutQuote memory quote,
+            uint256 floor
+        )
+    {
+        bytes memory dest = _btcAddressP2pkh();
+        vm.prank(user);
+        requestHash = escrow.requestPegOut{value: DEFAULT_VALUE}(dest, user);
+        quote = escrow.getPegOutQuote(requestHash);
+        bytes memory signature = _signForLp(lpKey, quote, lp);
+        vm.prank(lp);
+        escrow.claimPegOut(requestHash, signature);
+        quote = escrow.getPegOutQuote(requestHash);
+        floor = _floor(quote, escrow.getMaxMinerFee(requestHash));
+    }
+
+    function _floor(
+        Quotes.PegOutQuote memory quote,
+        uint256 maxMinerFee
+    ) internal pure returns (uint256 floorAmount) {
+        uint256 deductions = quote.callFee + maxMinerFee;
+        floorAmount = quote.value > deductions ? quote.value - deductions : 0;
+        if (
+            floorAmount > Quotes.SAT_TO_WEI_CONVERSION &&
+            (floorAmount % Quotes.SAT_TO_WEI_CONVERSION) != 0
+        ) {
+            floorAmount -= floorAmount % Quotes.SAT_TO_WEI_CONVERSION;
+        }
+    }
+
+    function _setupBridgeConfirmations(
+        Quotes.PegOutQuote memory quote
+    ) internal {
+        bytes memory header = new bytes(80);
+        uint32 ts = uint32(block.timestamp + 100);
+        header[68] = bytes1(uint8(ts));
+        header[69] = bytes1(uint8(ts >> 8));
+        header[70] = bytes1(uint8(ts >> 16));
+        header[71] = bytes1(uint8(ts >> 24));
+        bridge.setHeaderByHash(BLOCK_HEADER_HASH, header);
+        bridge.setConfirmations(int256(uint256(quote.transferConfirmations)));
     }
 
     function _warpPastFulfillment(Quotes.PegOutQuote memory q) internal {
@@ -1034,13 +1253,21 @@ contract PegOutEscrowTest is Test {
         Quotes.PegOutQuote memory quote,
         bytes32 quoteHash
     ) internal returns (bytes memory) {
+        return _generateBtcTxWithAmount(quote, quoteHash, quote.value);
+    }
+
+    function _generateBtcTxWithAmount(
+        Quotes.PegOutQuote memory quote,
+        bytes32 quoteHash,
+        uint256 amountWei
+    ) internal returns (bytes memory) {
         string[] memory inputs = new string[](7);
         inputs[0] = "npx";
         inputs[1] = "ts-node";
         inputs[2] = HELPER_SCRIPT_GENERATE_BTC_TX;
         inputs[3] = vm.toString(quoteHash);
         inputs[4] = vm.toString(quote.depositAddress);
-        inputs[5] = vm.toString(quote.value);
+        inputs[5] = vm.toString(amountWei);
         inputs[6] = "p2pkh";
         return vm.ffi(inputs);
     }
@@ -1076,7 +1303,7 @@ contract PegOutEscrowTest is Test {
                 callTime: CALL_TIME,
                 expireTime: EXPIRE_TIME,
                 expireBlocks: EXPIRE_BLOCKS,
-                maxMinerFee: 0.001 ether
+                maxMinerFee: MAX_MINER_FEE
             })
         );
     }

--- a/test/pegout/LpRefund.t.sol
+++ b/test/pegout/LpRefund.t.sol
@@ -363,19 +363,19 @@ contract LpRefundTest is PegOutTestBase {
         );
     }
 
-    function test_RefundPegOut_RevertsIfBtcTxDoesNotHaveHighEnoughAmount()
-        public
-    {
+    function test_RefundPegOut_UnderFloor_TopsUpUserAndDebitsLp() public {
         Quotes.PegOutQuote memory quote = createAndDepositQuote();
         bytes32 quoteHash = pegOutContract.hashPegOutQuote(quote);
-        uint256 originalValue = quote.value; // Store original value before modification
+        uint256 escrowed = quote.value + quote.callFee + quote.gasFee;
+        // Legacy path: maxMinerFee unset (0) → floor = value − callFee
+        uint256 floor = quote.value - quote.callFee;
+        uint256 paid = 0.9 ether;
+        uint256 topUp = floor - paid;
 
-        // Generate BTC tx with insufficient amount (0.9 ETH when quote needs 1 ETH)
         Quotes.PegOutQuote memory lowQuote = quote;
-        lowQuote.value = 0.9 ether;
-        bytes memory btcTx = generateBtcTx(lowQuote, quoteHash); // Low amount!
+        lowQuote.value = paid;
+        bytes memory btcTx = generateBtcTx(lowQuote, quoteHash);
 
-        // Setup headers
         bytes memory header = createBtcBlockHeader(
             uint32(block.timestamp + 100)
         );
@@ -384,16 +384,10 @@ contract LpRefundTest is PegOutTestBase {
             int256(uint256(quote.transferConfirmations))
         );
 
-        uint256 lowAmountWei = 0.9 ether;
+        uint256 userBefore = quote.rskRefundAddress.balance;
+        uint256 lpBefore = pegOutLp.balance;
 
         vm.prank(pegOutLp);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                Flyover.InsufficientAmount.selector,
-                lowAmountWei,
-                originalValue
-            )
-        );
         pegOutContract.refundPegOut(
             quoteHash,
             btcTx,
@@ -401,6 +395,10 @@ contract LpRefundTest is PegOutTestBase {
             PARTIAL_MERKLE_TREE,
             merkleHashes
         );
+
+        assertEq(quote.rskRefundAddress.balance, userBefore + topUp);
+        assertEq(pegOutLp.balance, lpBefore + escrowed - topUp);
+        assertTrue(pegOutContract.isQuoteCompleted(quoteHash));
     }
 
     function test_RefundPegOut_RevertsIfBtcTxNotDirectedToUserAddress() public {
@@ -963,29 +961,22 @@ contract LpRefundTest is PegOutTestBase {
         pegOutContract.validatePegout(quoteHash, btcTx);
     }
 
-    function test_ValidatePegout_RevertsIfBtcTxDoesNotHaveHighEnoughAmount()
-        public
-    {
+    function test_ValidatePegout_AcceptsUnderFloorAmount() public {
         Quotes.PegOutQuote memory quote = createAndDepositQuote();
         bytes32 quoteHash = pegOutContract.hashPegOutQuote(quote);
-        uint256 originalValue = quote.value; // Store original value before modification
+        uint256 storedValue = quote.value;
 
-        // Generate BTC tx with insufficient amount (0.9 ETH when quote needs 1 ETH)
+        // Under floor is accepted at validation; refundPegOut performs the top-up.
         Quotes.PegOutQuote memory lowQuote = quote;
         lowQuote.value = 0.9 ether;
-        bytes memory btcTx = generateBtcTx(lowQuote, quoteHash); // Low amount!
-
-        uint256 lowAmountWei = 0.9 ether;
+        bytes memory btcTx = generateBtcTx(lowQuote, quoteHash);
 
         vm.prank(pegOutLp);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                Flyover.InsufficientAmount.selector,
-                lowAmountWei,
-                originalValue
-            )
+        Quotes.PegOutQuote memory returned = pegOutContract.validatePegout(
+            quoteHash,
+            btcTx
         );
-        pegOutContract.validatePegout(quoteHash, btcTx);
+        assertEq(returned.value, storedValue);
     }
 
     function test_ValidatePegout_RevertsIfBtcTxNotDirectedToUserAddress()


### PR DESCRIPTION
## What

Implements short-delivery floor and escrow top-up for commit-first peg-out settlement.

- Replaces the flat `InsufficientAmount` revert on BTC delivery below `quote.value` with floor validation: `floor = amount − callFee − maxMinerFee`.
- At/above floor: settle with no top-up.
- Under floor: top up `rskRefundAddress` with `floor − deliveredAmount` and debit the LP payout by the same amount (flows conserve escrowed total).
- Snapshots admin `maxMinerFee` from `FlyoverConfigurations` at `requestPegOut` on an escrow request envelope (`quote` + `maxMinerFee`), copies it onto `PegOutRecord` at `registerClaimedPegOut`, and uses that value at `refundPegOut` so a later config change cannot move this peg-out’s floor.
- `refundPegOut` notifies escrow `FULFILLED` on successful settlement.

## Why

Ordinary BTC miner-fee variance was stranding peg-outs under the old “must deliver full `quote.value`” rule. A protocol floor plus an on-chain top-up bounds that variance. `maxMinerFee` is frozen at user request so fee/config changes cannot rewrite economics after RBTC is locked.

## Type of Change

- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Refactor (no intended behavior change)
- [ ] Security hardening
- [ ] Tests only
- [ ] Build/CI/Tooling
- [ ] Documentation

## Affected Areas

- [ ] PegIn flow (`registerPegIn`, `callForUser`, quote validation)
- [x] PegOut flow (`depositPegout`, `refundPegOut`, `refundUserPegOut`)
- [ ] Liquidity Provider lifecycle (register/update/status/resign/collateral/withdraw)
- [ ] Pause/operational controls
- [ ] Quote hashing/signature logic
- [x] Bitcoin tx / PMT / merkle validation
- [ ] Deployment or upgrade scripts / Makefile targets
- [ ] CI workflows (`ci`, `fuzz`, `formal`, `slither`, `codeql`)
- [ ] Docs

## Risk & Security Review

- [x] Access control and authorization paths reviewed
- [x] Reentrancy and external call paths reviewed
- [x] Storage layout / upgrade safety reviewed (if upgradeable code changed)
- [x] Time/block/confirmation assumptions reviewed
- [x] BTC tx output/index assumptions reviewed (if pegout validation touched)
- [x] No secrets or sensitive values added

Notes:
- `Quotes.PegOutQuote` intentionally unchanged (cross-lane ABI / hash / signature freeze).
- Escrow ERC-7201 layout: `quotes` mapping replaced by `requests` envelope (`quote` + `maxMinerFee`); unreleased escrow path.
- `PegOutRecord` gains `maxMinerFee`; set only on claim-fed registration.
- Top-up uses the same call + balance-fallback pattern as existing payouts; must not be counted like `gasFee` in `value + callFee + gasFee` accounting.
- Under-floor no longer reverts on amount; `validatePegout` accepts under-floor txs (top-up happens only in `refundPegOut`).

## Test Plan

List what you ran locally and the outcome:

- [ ] `npm run lint:sol`
- [ ] `npm run lint:ts`
- [ ] `npm run compile`
- [ ] `npm test`
- [x] Foundry: `forge test --match-contract PegOutEscrowTest --ffi` (incl. floor/top-up cases)
- [x] Foundry: `forge test --match-contract LpRefundTest --ffi` (under-floor top-up)
- [x] Foundry: amount fuzz (`testFuzz_RefundPegOut_UnderFloor_*`, `AcceptsValidAmount`)
- [ ] `npm run test:fuzz` (if logic/state transitions changed)
- [ ] `npm run test:invariant` (if invariant-sensitive logic changed)
- [ ] `npm run test:formal` (if formal-verification-sensitive logic changed)
- [ ] `npm run test:integration` (if integration paths changed)
- [ ] `npm run test:e2e` (if deployment/ownership flows changed)

Additional notes:
- At floor / above floor (no top-up); under floor (exact top-up + LP debit + conservation); config change after request leaves snapshotted floor unchanged.
- Legacy `depositPegOut` path: `maxMinerFee` unset (0) ⇒ floor = `value − callFee`; under-floor tops up rather than reverting.

## Deployment & Ops Impact

- [ ] No deployment impact
- [x] Requires deployment
- [x] Requires upgrade
- [ ] Env/config changes required (`.env`, network RPCs, verification, etc.)
- [ ] Runbook/update instructions added to PR description

Upgradeable `PegOutEscrow` / `PegOutContract` storage layout changed (`requests` envelope; `PegOutRecord.maxMinerFee`). Treat as fresh deploy / coordinated upgrade for the unreleased commit-first stack; do not assume in-place upgrade of production quote storage without a migration plan.

## Related Issues

- Jira: [FLY-2549](https://rsklabs.atlassian.net/browse/FLY-2549)

## Reviewer Notes

- Focus: `_deliveryFloor` / top-up conservation in `refundPegOut`; request-time snapshot + claim copy; no `PegOutQuote` field for `maxMinerFee`.
- Freeze timing: request-time snapshot (not claim-time from live config) so the floor cannot move after the user locked RBTC.