### PR TITLE
Feat/fly 2551

### DIFF
--- a/script/deployment/DeployFlyover.s.sol
+++ b/script/deployment/DeployFlyover.s.sol
@@ -327,6 +327,7 @@ contract DeployFlyover is Script {
         cm.grantRole(slasher, d.pegInProxy);
         cm.grantRole(slasher, d.pegOutProxy);
         cm.grantRole(slasher, d.pegOutEscrowProxy);
+        cm.setFlyoverDiscovery(d.flyoverDiscoveryProxy);
     }
 
     function _log(FlyoverDeployment memory d) private pure {

--- a/src/CollateralManagement.sol
+++ b/src/CollateralManagement.sol
@@ -4,10 +4,11 @@ pragma solidity 0.8.25;
 import {
     AccessControlDefaultAdminRulesUpgradeable
 } from "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlDefaultAdminRulesUpgradeable.sol";
-import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {EmergencyPause} from "./EmergencyPause/EmergencyPause.sol";
 import {ICollateralManagement} from "./interfaces/ICollateralManagement.sol";
+import {IFlyoverDiscovery} from "./interfaces/IFlyoverDiscovery.sol";
 import {IPauseRegistry} from "./interfaces/IPauseRegistry.sol";
 import {Flyover} from "./libraries/Flyover.sol";
 import {Quotes} from "./libraries/Quotes.sol";
@@ -16,6 +17,7 @@ import {Quotes} from "./libraries/Quotes.sol";
 /// @notice This contract is used to manage the collateral related aspects of the Flyover system.
 /// This involves adding, slashing, resigning and withdrawing collateral.
 /// @author Rootstock Labs
+// solhint-disable-next-line max-states-count
 contract CollateralManagementContract is
     AccessControlDefaultAdminRulesUpgradeable,
     ReentrancyGuard,
@@ -42,6 +44,12 @@ contract CollateralManagementContract is
     mapping(address => uint256) private _resignationBlockNum;
     mapping(address => uint256) private _rewards;
 
+    /// @dev FlyoverDiscovery is the source of truth for the listed provider set.
+    IFlyoverDiscovery private _flyoverDiscovery;
+    /// @dev Block at which peg-out collateral first became positive; used by the grace window.
+    mapping(address => uint256) private _pegOutRegistrationBlock;
+    uint256 private _globalSlashGraceBlocks;
+
     /// @notice Emitted when the minimum collateral is set
     /// @param oldMinCollateral The old minimum collateral
     /// @param newMinCollateral The new minimum collateral
@@ -54,6 +62,17 @@ contract CollateralManagementContract is
     /// @param oldReward The old reward percentage
     /// @param newReward The new reward percentage
     event RewardPercentageSet(uint256 indexed oldReward, uint256 indexed newReward);
+    /// @notice Emitted when the global-slash grace window is set
+    /// @param oldGraceBlocks The previous grace window in blocks
+    /// @param newGraceBlocks The new grace window in blocks
+    event GlobalSlashGraceBlocksSet(uint256 indexed oldGraceBlocks, uint256 indexed newGraceBlocks);
+    /// @notice Emitted when the FlyoverDiscovery address used for the provider set is updated
+    /// @param oldAddress The previous Discovery address
+    /// @param newAddress The new Discovery address
+    event FlyoverDiscoverySet(address indexed oldAddress, address indexed newAddress);
+
+    /// @notice Raised when {globalSlash} is called before FlyoverDiscovery is wired
+    error FlyoverDiscoveryNotSet();
 
     modifier onlyRegisteredForPegIn(address addr) {
         if (!_isRegistered(Flyover.ProviderType.PegIn, addr))
@@ -159,6 +178,24 @@ contract CollateralManagementContract is
         _rewardPercentage = rewardPercentage;
     }
 
+    /// @notice Sets the no-penalty grace window (blocks after peg-out registration) for global slash
+    /// @dev Default is 0 (no LP is in-window until configured).
+    /// @param graceBlocks The new grace window length in blocks
+    // solhint-disable-next-line comprehensive-interface
+    function setGlobalSlashGraceBlocks(uint256 graceBlocks) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        emit GlobalSlashGraceBlocksSet(_globalSlashGraceBlocks, graceBlocks);
+        _globalSlashGraceBlocks = graceBlocks;
+    }
+
+    /// @notice Sets the FlyoverDiscovery used as the provider-set source of truth for {globalSlash}
+    /// @param flyoverDiscovery_ The Discovery contract address
+    // solhint-disable-next-line comprehensive-interface
+    function setFlyoverDiscovery(address flyoverDiscovery_) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (flyoverDiscovery_.code.length == 0) revert Flyover.NoContract(flyoverDiscovery_);
+        emit FlyoverDiscoverySet(address(_flyoverDiscovery), flyoverDiscovery_);
+        _flyoverDiscovery = IFlyoverDiscovery(flyoverDiscovery_);
+    }
+
     /// @inheritdoc ICollateralManagement
     /// @dev Intentionally not paused: slashing must remain available so PegIn/PegOut can enforce penalties
     ///      when they call this during registerPegIn/refundPegOut; a separate pause would cause reverts.
@@ -212,10 +249,17 @@ contract CollateralManagementContract is
     }
 
     /// @inheritdoc ICollateralManagement
-    /// @dev Stub until proportional global slash is implemented. Callers
-    ///      (e.g. PegOutEscrow.refundOnNoClaim) must not block user refunds on this reverting.
-    function globalSlash(uint256) external onlyRole(COLLATERAL_SLASHER) override {
-        revert GlobalSlashNotImplemented();
+    /// @dev Intentionally not paused: slashing must remain available so PegOutEscrow can
+    ///      enforce penalties from refundOnNoClaim. Provider set is FlyoverDiscovery.getProviders.
+    function globalSlash(uint256 total) external onlyRole(COLLATERAL_SLASHER) override {
+        if (total == 0) revert GlobalSlashZeroAmount();
+        if (address(_flyoverDiscovery) == address(0)) revert FlyoverDiscoveryNotSet();
+
+        (address[] memory lps, uint256[] memory amounts, uint256 sum, uint256 n) =
+            _eligiblePegOutProviders();
+        if (sum == 0) revert GlobalSlashNoEligibleProviders();
+
+        _distributeGlobalSlash(total, lps, amounts, sum, n);
     }
 
     /// @inheritdoc ICollateralManagement
@@ -272,6 +316,29 @@ contract CollateralManagementContract is
     /// @inheritdoc ICollateralManagement
     function getResignDelayInBlocks() external view override returns (uint256) {
         return _resignDelayInBlocks;
+    }
+
+    /// @notice Gets the no-penalty grace window used by {globalSlash}
+    /// @return The grace window length in blocks
+    // solhint-disable-next-line comprehensive-interface
+    function getGlobalSlashGraceBlocks() external view returns (uint256) {
+        return _globalSlashGraceBlocks;
+    }
+
+    /// @notice Gets the block at which an account's peg-out collateral first became positive
+    /// @dev Zero means no recorded registration (pre-upgrade / never registered for peg-out).
+    /// @param addr The liquidity provider address
+    /// @return The registration block, or 0 if unset
+    // solhint-disable-next-line comprehensive-interface
+    function getPegOutRegistrationBlock(address addr) external view returns (uint256) {
+        return _pegOutRegistrationBlock[addr];
+    }
+
+    /// @notice Gets the FlyoverDiscovery used as the provider-set source of truth
+    /// @return The Discovery contract address (zero if unset)
+    // solhint-disable-next-line comprehensive-interface
+    function getFlyoverDiscovery() external view returns (address) {
+        return address(_flyoverDiscovery);
     }
 
     /// @inheritdoc ICollateralManagement
@@ -357,12 +424,82 @@ contract CollateralManagementContract is
 
     /// @notice Adds peg out collateral to an account
     /// @dev Is very important for this function to remain private as the public function
-    /// is the one protected by the role checks
+    /// is the one protected by the role checks. Records the registration block on first
+    /// peg-out collateral for the global-slash grace window.
     /// @param addr The address of the account
     /// @param amount The amount of peg out collateral to add
     function _addPegOutCollateralTo(address addr, uint256 amount) private {
+        if (_pegOutCollateral[addr] == 0 && amount > 0) {
+            _pegOutRegistrationBlock[addr] = block.number;
+        }
         _pegOutCollateral[addr] += amount;
         emit ICollateralManagement.PegOutCollateralAdded(addr, amount);
+    }
+
+    /// @notice Takes `min(total, sum)` from eligible LPs proportional to peg-out collateral.
+    /// @dev Last LP receives the remainder, capped at their collateral, so rounding dust stays in the split.
+    /// @param total Requested slash amount
+    /// @param lps Eligible provider addresses
+    /// @param amounts Peg-out collateral of each eligible provider
+    /// @param sum Total peg-out collateral of eligible providers
+    /// @param n Number of eligible providers
+    function _distributeGlobalSlash(
+        uint256 total,
+        address[] memory lps,
+        uint256[] memory amounts,
+        uint256 sum,
+        uint256 n
+    ) private {
+        uint256 toTake = Math.min(total, sum);
+        uint256 distributed;
+        for (uint256 i; i < n; ++i) {
+            uint256 share = (i == n - 1)
+                ? Math.min(toTake - distributed, amounts[i])
+                : (toTake * amounts[i]) / sum;
+            if (share == 0) continue;
+            _pegOutCollateral[lps[i]] -= share;
+            distributed += share;
+            emit GlobalSlashShare(lps[i], share);
+        }
+        _penalties += distributed;
+        emit GlobalSlashExecuted(total, distributed);
+    }
+
+    /// @notice Listed PegOut/Both LPs outside the grace window, with their peg-out collateral.
+    /// @dev Arrays are sized to `getProviders().length`; only the first `n` entries are populated.
+    /// @return lps Eligible provider addresses
+    /// @return amounts Peg-out collateral of each eligible provider
+    /// @return sum Total peg-out collateral of eligible providers
+    /// @return n Number of eligible providers
+    function _eligiblePegOutProviders()
+        private
+        view
+        returns (address[] memory lps, uint256[] memory amounts, uint256 sum, uint256 n)
+    {
+        Flyover.LiquidityProvider[] memory providers = _flyoverDiscovery.getProviders();
+        uint256 length = providers.length;
+        lps = new address[](length);
+        amounts = new uint256[](length);
+
+        for (uint256 i; i < length; ++i) {
+            if (providers[i].providerType == Flyover.ProviderType.PegIn) continue;
+            address lp = providers[i].providerAddress;
+            if (_isInGlobalSlashGraceWindow(lp)) continue;
+            lps[n] = lp;
+            amounts[n] = _pegOutCollateral[lp];
+            sum += amounts[n];
+            ++n;
+        }
+    }
+
+    /// @notice Whether an LP is still inside the global-slash grace window
+    /// @dev `regBlock == 0` (never recorded) is eligible, not in grace.
+    /// @param addr The liquidity provider address
+    /// @return True if the LP must be skipped by {globalSlash}
+    function _isInGlobalSlashGraceWindow(address addr) private view returns (bool) {
+        uint256 regBlock = _pegOutRegistrationBlock[addr];
+        if (regBlock == 0) return false;
+        return block.number < regBlock + _globalSlashGraceBlocks;
     }
 
     /// @notice Checks if an account is registered

--- a/src/interfaces/ICollateralManagement.sol
+++ b/src/interfaces/ICollateralManagement.sol
@@ -55,6 +55,17 @@ interface ICollateralManagement is IPausable {
         uint256 reward
     );
 
+    /// @notice Emitted when a proportional global slash completes
+    /// @dev Destination of slashed funds is protocol {getPenalties}; no punisher reward.
+    /// @param requested The `total` argument passed by the caller
+    /// @param distributed The amount actually taken from eligible peg-out collateral
+    event GlobalSlashExecuted(uint256 indexed requested, uint256 indexed distributed);
+
+    /// @notice Emitted for each eligible LP whose peg-out collateral was reduced by a global slash
+    /// @param liquidityProvider The LP that was slashed
+    /// @param amount The peg-out collateral taken from this LP
+    event GlobalSlashShare(address indexed liquidityProvider, uint256 indexed amount);
+
     /// @notice Emitted when a liquidity provider has already resigned
     /// @param from The address of the liquidity provider
     error AlreadyResigned(address from);
@@ -87,8 +98,11 @@ interface ICollateralManagement is IPausable {
     /// @param minCollateral The minimum collateral that was invalid
     error MinCollateralTooLow(uint256 minCollateral);
 
-    /// @notice Raised when {globalSlash} is called before it is implemented
-    error GlobalSlashNotImplemented();
+    /// @notice Raised when {globalSlash} is called with a zero aggregate amount
+    error GlobalSlashZeroAmount();
+
+    /// @notice Raised when {globalSlash} finds no eligible peg-out LPs past the grace window
+    error GlobalSlashNoEligibleProviders();
 
     /// @notice Adds peg in collateral to an account
     /// @param addr The address of the account
@@ -142,13 +156,15 @@ interface ICollateralManagement is IPausable {
         bytes32 quoteHash
     ) external;
 
-    /// @notice Slashes `total` proportionally across registered LPs past the grace window.
-    /// @dev Used when a serviceable request goes unclaimed (peg-in unclaimed settle;
-    /// peg-out {IPegOutEscrow-refundOnNoClaim}). Requires the COLLATERAL_SLASHER role.
-    /// Drains peg-in collateral first, then peg-out. Part of `total` may be paid as a
-    /// punisher reward using the same split as individual slashes. Until the proportional
-    /// slash is implemented, callers may see {GlobalSlashNotImplemented}.
-    /// @param total Aggregate penalty amount to distribute across eligible LPs
+    /// @notice Slashes `total` proportionally across registered peg-out LPs past the
+    /// grace window.
+    /// @dev Requires the COLLATERAL_SLASHER role. The provider set is
+    /// {IFlyoverDiscovery-getProviders}. Only PegOut / Both types are slashed. Peg-in
+    /// collateral and peg-in-only LPs are untouched. LPs still inside the post-registration
+    /// grace window are skipped. 100% of the taken amount is credited to protocol
+    /// {getPenalties}; there is no punisher reward. Callers that must not block a user
+    /// refund should wrap this in try/catch.
+    /// @param total Aggregate penalty amount to distribute across eligible peg-out LPs
     function globalSlash(uint256 total) external;
 
     /// @notice Withdraws rewards from the contract. Sends to the caller. Use withdrawRewards(address payable to)

--- a/src/test-contracts/CollateralManagementMock.sol
+++ b/src/test-contracts/CollateralManagementMock.sol
@@ -15,6 +15,9 @@ contract CollateralManagementMock is ICollateralManagement {
     uint256 public globalSlashCalls;
     uint256 public lastGlobalSlashTotal;
 
+    /// @dev Stub revert used by PegOutEscrow tests that expect GlobalSlashSkipped.
+    error GlobalSlashStubReverts();
+
     function setGlobalSlashReverts(bool reverts_) external {
         globalSlashReverts = reverts_;
     }
@@ -45,9 +48,9 @@ contract CollateralManagementMock is ICollateralManagement {
 
     function globalSlash(uint256 total) external {
         if (globalSlashReverts) {
-            revert GlobalSlashNotImplemented();
+            revert GlobalSlashStubReverts();
         }
-        globalSlashCalls += 1;
+        ++globalSlashCalls;
         lastGlobalSlashTotal = total;
     }
 

--- a/test/collateral/Configuration.t.sol
+++ b/test/collateral/Configuration.t.sol
@@ -83,6 +83,13 @@ contract ConfigurationTest is CollateralTestBase {
             0,
             "Penalties should be 0"
         );
+
+        // Check global-slash grace window default
+        assertEq(
+            collateralManagement.getGlobalSlashGraceBlocks(),
+            0,
+            "GlobalSlashGraceBlocks should default to 0"
+        );
     }
 
     function test_Initialize_AllowsInitializeOnlyOnce() public {

--- a/test/collateral/Slashing.t.sol
+++ b/test/collateral/Slashing.t.sol
@@ -3,18 +3,28 @@ pragma solidity 0.8.25;
 
 import {CollateralTestBase} from "./CollateralTestBase.sol";
 import {CollateralManagementContract} from "../../src/CollateralManagement.sol";
+import {FlyoverDiscovery} from "../../src/FlyoverDiscovery.sol";
 import {ICollateralManagement} from "../../src/interfaces/ICollateralManagement.sol";
 import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
 import {Flyover} from "../../src/libraries/Flyover.sol";
 import {Quotes} from "../../src/libraries/Quotes.sol";
 import {WalletMock} from "../../src/test-contracts/WalletMock.sol";
 import {P2PKH_ZERO_ADDRESS_TESTNET} from "../constants/btc.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {StdStorage, stdStorage} from "forge-std/StdStorage.sol";
 
 contract SlashingTest is CollateralTestBase {
+    using stdStorage for StdStorage;
+
+    FlyoverDiscovery public discovery;
+
     address public punisher;
     address public liquidityProvider;
     address public user;
     address public notSlasher;
+    address public lpA;
+    address public lpB;
+    address public pegInOnly;
 
     bytes32 public quoteHash;
 
@@ -24,10 +34,14 @@ contract SlashingTest is CollateralTestBase {
     uint256 constant GAS_FEE = 100;
     uint256 constant GAS_LIMIT = 21000;
     uint256 constant QUOTE_VALUE = 1 ether;
+    uint256 constant COLLATERAL_A = 10 ether;
+    uint256 constant COLLATERAL_B = 20 ether;
+    uint256 constant SLASH_TOTAL = 3 ether;
 
     function setUp() public {
         deployCollateralManagement();
         setupRoles();
+        _deployAndWireDiscovery();
         setupTestAccounts();
         setupCollateral();
 
@@ -41,12 +55,18 @@ contract SlashingTest is CollateralTestBase {
         liquidityProvider = makeAddr("liquidityProvider");
         user = makeAddr("user");
         notSlasher = makeAddr("notSlasher");
+        lpA = makeAddr("lpA");
+        lpB = makeAddr("lpB");
+        pegInOnly = makeAddr("pegInOnly");
 
         // Fund accounts
         vm.deal(punisher, 100 ether);
         vm.deal(liquidityProvider, 100 ether);
         vm.deal(user, 100 ether);
         vm.deal(notSlasher, 100 ether);
+        vm.deal(lpA, 100 ether);
+        vm.deal(lpB, 100 ether);
+        vm.deal(pegInOnly, 100 ether);
     }
 
     function createPegInQuote()
@@ -486,5 +506,387 @@ contract SlashingTest is CollateralTestBase {
             bytes("")
         );
         walletMock.execute(address(collateralManagement), 0, withdrawData);
+    }
+
+    // ============ globalSlash function tests ============
+
+    function _deployAndWireDiscovery() internal {
+        FlyoverDiscovery impl = new FlyoverDiscovery();
+        ERC1967Proxy proxy = new ERC1967Proxy(
+            address(impl),
+            abi.encodeCall(
+                FlyoverDiscovery.initialize,
+                (
+                    owner,
+                    TEST_DEFAULT_ADMIN_DELAY,
+                    address(collateralManagement),
+                    pauseRegistry
+                )
+            )
+        );
+        discovery = FlyoverDiscovery(address(proxy));
+
+        vm.startPrank(owner);
+        collateralManagement.grantRole(
+            collateralManagement.COLLATERAL_ADDER(),
+            address(discovery)
+        );
+        collateralManagement.setFlyoverDiscovery(address(discovery));
+        vm.stopPrank();
+    }
+
+    function _approvePegOut(address lp, uint256 amount) internal {
+        vm.prank(lp, lp);
+        discovery.register{value: amount}(
+            "LP",
+            "http://localhost/api",
+            true,
+            Flyover.ProviderType.PegOut
+        );
+        vm.prank(owner);
+        discovery.approveRegistration(lp);
+    }
+
+    function _approvePegIn(address lp, uint256 amount) internal {
+        vm.prank(lp, lp);
+        discovery.register{value: amount}(
+            "LP",
+            "http://localhost/api",
+            true,
+            Flyover.ProviderType.PegIn
+        );
+        vm.prank(owner);
+        discovery.approveRegistration(lp);
+    }
+
+    function _topUpPegOut(address lp, uint256 amount) internal {
+        vm.prank(adder);
+        collateralManagement.addPegOutCollateralTo{value: amount}(lp);
+    }
+
+    function test_T3_GlobalSlash_ProportionalToPegOutCollateral() public {
+        _approvePegOut(lpA, COLLATERAL_A);
+        _approvePegOut(lpB, COLLATERAL_B);
+        vm.prank(adder);
+        collateralManagement.addPegInCollateralTo{value: BASE_COLLATERAL}(lpA);
+
+        uint256 pegInBefore = collateralManagement.getPegInCollateral(lpA);
+
+        vm.prank(slasher);
+        collateralManagement.globalSlash(SLASH_TOTAL);
+
+        assertEq(
+            collateralManagement.getPegOutCollateral(lpA),
+            COLLATERAL_A - 1 ether,
+            "lpA should lose 1/3 of slash"
+        );
+        assertEq(
+            collateralManagement.getPegOutCollateral(lpB),
+            COLLATERAL_B - 2 ether,
+            "lpB should lose 2/3 of slash"
+        );
+        assertEq(
+            collateralManagement.getPegInCollateral(lpA),
+            pegInBefore,
+            "peg-in collateral must be untouched"
+        );
+    }
+
+    function test_T3_GlobalSlash_SkipsGraceWindow() public {
+        uint256 grace = 100;
+        vm.prank(owner);
+        collateralManagement.setGlobalSlashGraceBlocks(grace);
+
+        _approvePegOut(lpA, COLLATERAL_A);
+        uint256 regA = collateralManagement.getPegOutRegistrationBlock(lpA);
+
+        vm.roll(regA + grace);
+        _approvePegOut(lpB, COLLATERAL_B);
+
+        assertFalse(
+            block.number <
+                collateralManagement.getPegOutRegistrationBlock(lpA) + grace
+        );
+        assertTrue(
+            block.number <
+                collateralManagement.getPegOutRegistrationBlock(lpB) + grace
+        );
+
+        vm.prank(slasher);
+        collateralManagement.globalSlash(SLASH_TOTAL);
+
+        assertEq(
+            collateralManagement.getPegOutCollateral(lpA),
+            COLLATERAL_A - SLASH_TOTAL,
+            "out-of-window LP pays the full slash"
+        );
+        assertEq(
+            collateralManagement.getPegOutCollateral(lpB),
+            COLLATERAL_B,
+            "in-window LP must be skipped"
+        );
+    }
+
+    function test_T3_GlobalSlash_SkipsResigned() public {
+        _approvePegOut(lpA, COLLATERAL_A);
+        _approvePegOut(lpB, COLLATERAL_B);
+
+        vm.prank(lpB);
+        collateralManagement.resign();
+
+        vm.prank(slasher);
+        collateralManagement.globalSlash(SLASH_TOTAL);
+
+        assertEq(
+            collateralManagement.getPegOutCollateral(lpA),
+            COLLATERAL_A - SLASH_TOTAL
+        );
+        assertEq(
+            collateralManagement.getPegOutCollateral(lpB),
+            COLLATERAL_B,
+            "resigned LP must be skipped"
+        );
+    }
+
+    function test_T3_GlobalSlash_SkipsPegInOnly() public {
+        _approvePegIn(pegInOnly, BASE_COLLATERAL);
+        _approvePegOut(lpA, COLLATERAL_A);
+
+        uint256 pegInBefore = collateralManagement.getPegInCollateral(
+            pegInOnly
+        );
+
+        vm.prank(slasher);
+        collateralManagement.globalSlash(SLASH_TOTAL);
+
+        assertEq(
+            collateralManagement.getPegInCollateral(pegInOnly),
+            pegInBefore
+        );
+        assertEq(
+            collateralManagement.getPegOutCollateral(lpA),
+            COLLATERAL_A - SLASH_TOTAL
+        );
+    }
+
+    function test_T3_GlobalSlash_UsesDiscoveryNotCollateralOnly() public {
+        // Collateral without Discovery approval must not be slashed.
+        vm.prank(adder);
+        collateralManagement.addPegOutCollateralTo{value: COLLATERAL_A}(lpA);
+
+        vm.prank(slasher);
+        vm.expectRevert(
+            ICollateralManagement.GlobalSlashNoEligibleProviders.selector
+        );
+        collateralManagement.globalSlash(SLASH_TOTAL);
+
+        assertEq(collateralManagement.getPegOutCollateral(lpA), COLLATERAL_A);
+    }
+
+    function test_T3_GlobalSlash_GrandfatheredZeroRegBlockIsEligible() public {
+        uint256 grace = 1_000;
+        vm.prank(owner);
+        collateralManagement.setGlobalSlashGraceBlocks(grace);
+
+        _approvePegOut(lpA, COLLATERAL_A);
+        stdstore
+            .target(address(collateralManagement))
+            .sig("getPegOutRegistrationBlock(address)")
+            .with_key(lpA)
+            .checked_write(uint256(0));
+        assertEq(collateralManagement.getPegOutRegistrationBlock(lpA), 0);
+
+        vm.prank(slasher);
+        collateralManagement.globalSlash(SLASH_TOTAL);
+
+        assertEq(
+            collateralManagement.getPegOutCollateral(lpA),
+            COLLATERAL_A - SLASH_TOTAL,
+            "zero registration block must not grant infinite grace"
+        );
+    }
+
+    function test_T3_GlobalSlash_DestinationIsPenalties() public {
+        _approvePegOut(lpA, COLLATERAL_A);
+        uint256 balanceBefore = address(collateralManagement).balance;
+        uint256 penaltiesBefore = collateralManagement.getPenalties();
+        uint256 rewardsSlashBefore = collateralManagement.getRewards(slasher);
+        uint256 rewardsLpBefore = collateralManagement.getRewards(lpA);
+
+        vm.expectEmit(true, true, false, true, address(collateralManagement));
+        emit ICollateralManagement.GlobalSlashShare(lpA, SLASH_TOTAL);
+        vm.expectEmit(true, true, false, true, address(collateralManagement));
+        emit ICollateralManagement.GlobalSlashExecuted(
+            SLASH_TOTAL,
+            SLASH_TOTAL
+        );
+
+        vm.prank(slasher);
+        collateralManagement.globalSlash(SLASH_TOTAL);
+
+        assertEq(
+            collateralManagement.getPenalties(),
+            penaltiesBefore + SLASH_TOTAL,
+            "100% of taken collateral goes to protocol penalties"
+        );
+        assertEq(collateralManagement.getRewards(slasher), rewardsSlashBefore);
+        assertEq(collateralManagement.getRewards(lpA), rewardsLpBefore);
+        assertEq(
+            address(collateralManagement).balance,
+            balanceBefore,
+            "RBTC must stay in CollateralManagement"
+        );
+    }
+
+    function test_T3_GlobalSlash_UnauthorizedReverts() public {
+        _approvePegOut(lpA, COLLATERAL_A);
+        bytes32 slasherRole = collateralManagement.COLLATERAL_SLASHER();
+
+        vm.prank(notSlasher);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                notSlasher,
+                slasherRole
+            )
+        );
+        collateralManagement.globalSlash(SLASH_TOTAL);
+    }
+
+    function test_T3_GlobalSlash_NoEligibleReverts() public {
+        vm.prank(slasher);
+        vm.expectRevert(
+            ICollateralManagement.GlobalSlashNoEligibleProviders.selector
+        );
+        collateralManagement.globalSlash(SLASH_TOTAL);
+
+        uint256 grace = 100;
+        vm.prank(owner);
+        collateralManagement.setGlobalSlashGraceBlocks(grace);
+        _approvePegOut(lpA, COLLATERAL_A);
+
+        vm.prank(slasher);
+        vm.expectRevert(
+            ICollateralManagement.GlobalSlashNoEligibleProviders.selector
+        );
+        collateralManagement.globalSlash(SLASH_TOTAL);
+    }
+
+    function test_T3_GlobalSlash_DiscoveryNotSetReverts() public {
+        // Fresh CM without Discovery wiring.
+        CollateralManagementContract bareImpl = new CollateralManagementContract();
+        ERC1967Proxy bareProxy = new ERC1967Proxy(
+            address(bareImpl),
+            abi.encodeCall(
+                CollateralManagementContract.initialize,
+                (
+                    owner,
+                    TEST_DEFAULT_ADMIN_DELAY,
+                    TEST_MIN_COLLATERAL,
+                    TEST_RESIGN_DELAY_BLOCKS,
+                    TEST_REWARD_PERCENTAGE,
+                    pauseRegistry
+                )
+            )
+        );
+        CollateralManagementContract bare = CollateralManagementContract(
+            payable(address(bareProxy))
+        );
+        vm.startPrank(owner);
+        bare.grantRole(bare.COLLATERAL_SLASHER(), slasher);
+        vm.stopPrank();
+
+        vm.prank(slasher);
+        vm.expectRevert(
+            CollateralManagementContract.FlyoverDiscoveryNotSet.selector
+        );
+        bare.globalSlash(SLASH_TOTAL);
+    }
+
+    function test_T3_GlobalSlash_ZeroAmountReverts() public {
+        _approvePegOut(lpA, COLLATERAL_A);
+        vm.prank(slasher);
+        vm.expectRevert(ICollateralManagement.GlobalSlashZeroAmount.selector);
+        collateralManagement.globalSlash(0);
+    }
+
+    function test_T3_GlobalSlash_CapsAtEligibleSum() public {
+        _approvePegOut(lpA, 1 ether);
+        _approvePegOut(lpB, 2 ether);
+
+        vm.prank(slasher);
+        collateralManagement.globalSlash(100 ether);
+
+        assertEq(collateralManagement.getPegOutCollateral(lpA), 0);
+        assertEq(collateralManagement.getPegOutCollateral(lpB), 0);
+        assertEq(collateralManagement.getPenalties(), 3 ether);
+    }
+
+    function test_SetGlobalSlashGraceBlocks_OnlyAdmin() public {
+        assertEq(collateralManagement.getGlobalSlashGraceBlocks(), 0);
+
+        vm.prank(owner);
+        vm.expectEmit(true, true, false, true, address(collateralManagement));
+        emit CollateralManagementContract.GlobalSlashGraceBlocksSet(0, 50);
+        collateralManagement.setGlobalSlashGraceBlocks(50);
+        assertEq(collateralManagement.getGlobalSlashGraceBlocks(), 50);
+
+        bytes32 adminRole = collateralManagement.DEFAULT_ADMIN_ROLE();
+        vm.prank(notSlasher);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                notSlasher,
+                adminRole
+            )
+        );
+        collateralManagement.setGlobalSlashGraceBlocks(10);
+    }
+
+    function test_T3_GlobalSlash_TopUpDoesNotResetGraceWindow() public {
+        uint256 grace = 100;
+        vm.prank(owner);
+        collateralManagement.setGlobalSlashGraceBlocks(grace);
+
+        _approvePegOut(lpA, COLLATERAL_A);
+        uint256 regBlock = collateralManagement.getPegOutRegistrationBlock(lpA);
+
+        vm.roll(block.number + 10);
+        _topUpPegOut(lpA, 1 ether);
+
+        assertEq(
+            collateralManagement.getPegOutRegistrationBlock(lpA),
+            regBlock,
+            "top-up must not refresh registration block"
+        );
+    }
+
+    function test_T3_GlobalSlash_WithdrawThenReAddResetsGraceWindow() public {
+        uint256 grace = 100;
+        vm.prank(owner);
+        collateralManagement.setGlobalSlashGraceBlocks(grace);
+
+        _approvePegOut(lpA, COLLATERAL_A);
+        uint256 firstReg = collateralManagement.getPegOutRegistrationBlock(lpA);
+
+        vm.prank(lpA);
+        collateralManagement.resign();
+        vm.roll(block.number + TEST_RESIGN_DELAY_BLOCKS);
+        vm.prank(lpA);
+        collateralManagement.withdrawCollateral();
+
+        assertEq(collateralManagement.getPegOutCollateral(lpA), 0);
+
+        vm.roll(block.number + 5);
+        _topUpPegOut(lpA, COLLATERAL_A);
+
+        uint256 secondReg = collateralManagement.getPegOutRegistrationBlock(
+            lpA
+        );
+        assertTrue(
+            secondReg > firstReg,
+            "re-add must start a new grace window"
+        );
+        assertEq(secondReg, block.number);
     }
 }

--- a/test/deployment/DeployFlyover.t.sol
+++ b/test/deployment/DeployFlyover.t.sol
@@ -334,6 +334,7 @@ contract DeployFlyoverTest is Test {
             collateralSlasherRole,
             address(pegOutContract)
         );
+        collateralManagement.setFlyoverDiscovery(address(discovery));
         // Escrow slash role is granted inside _deployPegOutEscrow.
 
         // Verify FlyoverDiscovery has COLLATERAL_ADDER


### PR DESCRIPTION
## What

Implements **global slash + post-registration grace window** in `CollateralManagement`.

- **`globalSlash(uint256 total)`** — takes `min(total, eligibleSum)` from listed PegOut/Both LPs, proportional to peg-out collateral; credits 100% to protocol `_penalties` (no punisher reward).
- **Provider set** — `FlyoverDiscovery.getProviders()` (listed, active, not resigned, sufficient collateral). Peg-in-only LPs and peg-in collateral are untouched.
- **Grace window** — admin-configurable `_globalSlashGraceBlocks` (default `0`). LPs are skipped while `block.number < registrationBlock + grace`. Registration block is set on first 0→positive peg-out deposit; top-ups do not refresh it.
- **Wiring** — `setFlyoverDiscovery` / `getFlyoverDiscovery`; deploy script calls `cm.setFlyoverDiscovery(d.flyoverDiscoveryProxy)`.
- **Tests** — global-slash and grace-window cases added to `test/collateral/Slashing.t.sol`.

`PegOutEscrow.refundOnNoClaim` already calls `globalSlash(q.penaltyFee)` inside `try/catch`; this PR implements the CM side only.

## Why

When a serviceable peg-out stays unclaimed past the claim deadline, there is no responsible LP to slash individually. The network should share the penalty proportionally so unserved requests are costly and honest LPs are not the only ones paying for collective failure.

The grace window protects freshly registered LPs during bootstrap so setup collateral is not immediately exposed to a global slash.

## Type of Change

- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Refactor (no intended behavior change)
- [ ] Security hardening
- [ ] Tests only
- [ ] Build/CI/Tooling
- [ ] Documentation

## Affected Areas

- [ ] PegIn flow (`registerPegIn`, `callForUser`, quote validation)
- [ ] PegOut flow (`depositPegout`, `refundPegOut`, `refundUserPegOut`)
- [x] Liquidity Provider lifecycle (register/update/status/resign/collateral/withdraw)
- [ ] Pause/operational controls
- [ ] Quote hashing/signature logic
- [ ] Bitcoin tx / PMT / merkle validation
- [x] Deployment or upgrade scripts / Makefile targets
- [ ] CI workflows (`ci`, `fuzz`, `formal`, `slither`, `codeql`)
- [ ] Docs

## Risk & Security Review

- [x] Access control and authorization paths reviewed — `globalSlash` is `COLLATERAL_SLASHER` only; Discovery/grace setters are `DEFAULT_ADMIN_ROLE`.
- [x] Reentrancy and external call paths reviewed — no external calls in slash path; state updates before events.
- [x] Storage layout / upgrade safety reviewed (if upgradeable code changed) — three new storage slots appended (`_flyoverDiscovery`, `_pegOutRegistrationBlock`, `_globalSlashGraceBlocks`); `initialize` ABI unchanged.
- [x] Time/block/confirmation assumptions reviewed — grace window is block-based; `regBlock == 0` is eligible (grandfathered).
- [ ] BTC tx output/index assumptions reviewed (if pegout validation touched)
- [x] No secrets or sensitive values added

**Behavioral notes for reviewers**

| Path | Who is slashed |
| --- | --- |
| `refundOnNoClaim` (unclaimed past deadline) | All eligible peg-out LPs, proportional; grace-window LPs skipped |
| User cancel while `REQUESTED` | Nobody (escrow does not call `globalSlash`) |
| Claimed, fulfillment timeout | Not in this PR (individual slash) |

- Slash amount is **not** computed in CM: caller passes `total` (escrow uses `quote.penaltyFee` from config).
- `globalSlash` is intentionally **not paused** (same as individual slash paths).
- Revert on no eligible LPs is expected; escrow `try/catch` must not block user refund.
- Unbounded loop over `getProviders()` — acceptable for expected LP count; gas scales with listed providers.

## Test Plan

List what you ran locally and the outcome:

- [x] `npm run lint:sol` — clean on touched CM/interface/mock files
- [ ] `npm run lint:ts`
- [x] `npm run compile` / `forge build`
- [x] `npm test` — `test/collateral/Slashing.t.sol` (23 tests, including global-slash cases)
- [ ] `npm run test:fuzz` (if logic/state transitions changed)
- [ ] `npm run test:invariant` (if invariant-sensitive logic changed)
- [ ] `npm run test:formal` (if formal-verification-sensitive logic changed)
- [ ] `npm run test:integration` (if integration paths changed)
- [x] `npm run test:e2e` (if deployment/ownership flows changed) — `test/deployment/DeployFlyover.t.sol` wiring assertion

**Coverage highlights**

- Proportional split across two LPs; cap at eligible sum
- Grace window skip vs out-of-window LP
- Resigned LP skipped (via Discovery listing)
- Peg-in-only LP / peg-in collateral untouched
- Collateral without Discovery listing not slashed
- Grandfathered `regBlock == 0` still eligible under grace config
- 100% → `_penalties`, no punisher rewards, RBTC stays in CM
- Unauthorized caller, zero amount, Discovery unset, no eligible LPs
- Top-up does not reset grace; withdraw + re-add does
- `setGlobalSlashGraceBlocks` admin gating; default grace `0`

**Not in this PR**

- Individual slash on claimed fulfillment timeout
- Calibrating `penaltyFee` amount or grace window length

## Deployment & Ops Impact

- [ ] No deployment impact
- [x] Requires deployment
- [x] Requires upgrade (existing CM proxies need upgrade + post-upgrade admin steps)
- [ ] Env/config changes required (`.env`, network RPCs, verification, etc.)
- [ ] Runbook/update instructions added to PR description

**Post-deploy / post-upgrade admin**

1. `cm.setFlyoverDiscovery(flyoverDiscoveryProxy)` — wired in `DeployFlyover.s.sol` for fresh deploys; required for upgraded CM instances.
2. Optionally `cm.setGlobalSlashGraceBlocks(N)` when bootstrap window is chosen (default `0` = no grace until set).

Fresh deploys: Discovery is granted `COLLATERAL_ADDER` so registration deposits collateral through Discovery.

## [Jira Ticket](https://rsklabs.atlassian.net/browse/FLY-2551?atlOrigin=eyJpIjoiYmZmNWZiODA1OWUyNDliMTgxODYyMTRlNmVlNTEwMGQiLCJwIjoiaiJ9)

## Reviewer Notes

Focus areas:

1. **`_eligiblePegOutProviders` / `_distributeGlobalSlash`** — two-pass collect + proportional distribute; last LP gets remainder capped at collateral.
2. **Discovery as source of truth** — no local LP enumerable set; relies on `getProviders()` filters (resigned / insufficient collateral already excluded).
3. **Grace clock** — `_pegOutRegistrationBlock` on first peg-out deposit only; not cleared on slash or withdraw (re-add after full withdraw starts new window).
4. **Storage** — contract now has 11 state declarations; `max-states-count` disabled same as `PegInContract`.

**Intentionally unchanged:** `initialize` ABI, `IFlyoverDiscovery` API, `PegOutEscrow`, `penaltyFee` calibration.
